### PR TITLE
Redesign admin dashboard with full student record management

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,10 +1,11 @@
 """
 Views for user authentication and profile management.
 """
-from rest_framework import status, generics, permissions
+from rest_framework import status, generics, permissions, filters
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
 from rest_framework_simplejwt.views import TokenObtainPairView
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -26,6 +27,19 @@ from core.views import TenantAwareViewSet, TenantAwareReadOnlyViewSet
 
 
 User = get_user_model()
+
+
+class StudentRecordsPagination(PageNumberPagination):
+    """
+    Pagination for the tenant admin student-records view.
+
+    Defaults to a high page size so admins can search/filter/export across
+    the whole institution, while still allowing an explicit ?page_size=
+    override (capped) for clients that want true pagination.
+    """
+    page_size = 100
+    page_size_query_param = 'page_size'
+    max_page_size = 5000
 
 
 class CustomTokenObtainPairView(TokenObtainPairView):
@@ -183,10 +197,38 @@ class TenantStudentViewSet(TenantAwareViewSet):
     queryset = StudentProfile.objects.all()
     serializer_class = StudentProfileSerializer
     permission_classes = [permissions.IsAuthenticated, IsTenantAdmin]
+    pagination_class = StudentRecordsPagination
+    filter_backends = [filters.SearchFilter, filters.OrderingFilter]
+    search_fields = [
+        'user__email', 'user__first_name', 'user__last_name', 'user__phone',
+        'school', 'coaching', 'city', 'state',
+    ]
+    ordering_fields = [
+        'user__first_name', 'user__email', 'total_xp', 'current_level',
+        'total_questions_attempted', 'created_at',
+    ]
+    ordering = ['user__first_name']
 
     def get_queryset(self):
         tenant = self.request.tenant
-        return StudentProfile.objects.filter(user__tenant=tenant).select_related('user', 'primary_exam')
+        qs = StudentProfile.objects.filter(user__tenant=tenant).select_related('user', 'primary_exam')
+
+        # Optional explicit filters (used by the admin dashboard).
+        role = self.request.query_params.get('role')
+        if role:
+            qs = qs.filter(user__role=role)
+
+        status_param = self.request.query_params.get('status')
+        if status_param == 'active':
+            qs = qs.filter(user__is_suspended=False)
+        elif status_param == 'suspended':
+            qs = qs.filter(user__is_suspended=True)
+
+        primary_exam = self.request.query_params.get('primary_exam')
+        if primary_exam:
+            qs = qs.filter(primary_exam_id=primary_exam)
+
+        return qs
 
     @action(detail=True, methods=['post'])
     def reset_progress(self, request, pk=None):

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -1,8 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion, AnimatePresence } from 'framer-motion'
+import toast from 'react-hot-toast'
 import { analyticsService } from '../services/analyticsService'
 import { tenantAdminService } from '../services/tenantAdminService'
+import { examService } from '../services/examService'
 import {
     Users,
     GraduationCap,
@@ -15,10 +17,8 @@ import {
     ShieldOff,
     RotateCcw,
     UserCog,
-    ChevronRight,
     Award,
     X,
-    Calendar,
     MapPin,
     School,
     BookOpen,
@@ -27,35 +27,312 @@ import {
     ChevronDown,
     Book,
     Layers,
-    FileText,
     Clock,
     XCircle,
-    Check
+    Check,
+    Pencil,
+    Save,
+    Loader2,
+    Download,
+    SlidersHorizontal,
+    RefreshCw,
+    Mail,
+    Phone,
+    Filter,
 } from 'lucide-react'
 
+/* ---------------------------------------------------------------------------
+ * Choice constants — kept in sync with backend users/models.py
+ * ------------------------------------------------------------------------- */
+const GRADE_OPTIONS = [
+    { value: '', label: '—' },
+    { value: '6', label: 'Class 6' },
+    { value: '7', label: 'Class 7' },
+    { value: '8', label: 'Class 8' },
+    { value: '9', label: 'Class 9' },
+    { value: '10', label: 'Class 10' },
+    { value: '11', label: 'Class 11' },
+    { value: '12', label: 'Class 12' },
+    { value: 'graduate', label: 'Graduate' },
+    { value: 'other', label: 'Other' },
+]
+
+const BOARD_OPTIONS = [
+    { value: '', label: '—' },
+    { value: 'cbse', label: 'CBSE' },
+    { value: 'icse', label: 'ICSE' },
+    { value: 'state', label: 'State Board' },
+    { value: 'ib', label: 'IB' },
+    { value: 'igcse', label: 'IGCSE' },
+    { value: 'other', label: 'Other' },
+]
+
+const MEDIUM_OPTIONS = [
+    { value: 'english', label: 'English' },
+    { value: 'hindi', label: 'Hindi' },
+    { value: 'bilingual', label: 'Bilingual' },
+    { value: 'other', label: 'Other' },
+]
+
+const STUDY_TIME_OPTIONS = [
+    { value: 'morning', label: 'Morning (6AM-12PM)' },
+    { value: 'afternoon', label: 'Afternoon (12PM-6PM)' },
+    { value: 'evening', label: 'Evening (6PM-10PM)' },
+    { value: 'night', label: 'Night (10PM-6AM)' },
+]
+
+const ROLE_OPTIONS = [
+    { value: 'student', label: 'Student' },
+    { value: 'instructor', label: 'Instructor' },
+    { value: 'admin', label: 'Admin' },
+]
+
+const roleBadgeClass = (role) =>
+    role === 'admin'
+        ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+        : role === 'instructor'
+            ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+            : 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-300'
+
+/* ---------------------------------------------------------------------------
+ * StatCard
+ * ------------------------------------------------------------------------- */
 const StatCard = ({ title, value, icon: Icon, color, description }) => (
     <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="card p-6"
+        className="card p-5 sm:p-6"
     >
-        <div className="flex items-start justify-between">
-            <div>
-                <p className="text-sm font-medium text-surface-500 mb-1">{title}</p>
-                <h3 className="text-3xl font-bold text-surface-900 dark:text-white">{value}</h3>
-                {description && (
-                    <p className="mt-2 text-sm text-surface-500">{description}</p>
-                )}
+        <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+                <p className="text-sm font-medium text-surface-500 mb-1 truncate">{title}</p>
+                <h3 className="text-2xl sm:text-3xl font-bold text-surface-900 dark:text-white">{value}</h3>
+                {description && <p className="mt-2 text-xs sm:text-sm text-surface-500">{description}</p>}
             </div>
-            <div className={`p-3 rounded-xl ${color}`}>
+            <div className={`p-3 rounded-xl shrink-0 ${color}`}>
                 <Icon className="w-6 h-6 text-white" />
             </div>
         </div>
     </motion.div>
 )
 
-const StudentDetailModal = ({ student, onClose }) => {
-    if (!student) return null;
+/* ---------------------------------------------------------------------------
+ * Reusable form field helpers (used by the edit modal)
+ * ------------------------------------------------------------------------- */
+const Field = ({ label, children, hint }) => (
+    <div className="space-y-1.5">
+        <label className="block text-[11px] font-bold uppercase tracking-wider text-surface-400">{label}</label>
+        {children}
+        {hint && <p className="text-[10px] text-surface-400">{hint}</p>}
+    </div>
+)
+
+const TextInput = (props) => <input {...props} className={`input ${props.className || ''}`} />
+const SelectInput = ({ options, ...props }) => (
+    <select {...props} className={`input ${props.className || ''}`}>
+        {options.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+    </select>
+)
+
+/* ---------------------------------------------------------------------------
+ * StudentEditModal — edit ANY metadata of a student
+ * ------------------------------------------------------------------------- */
+const StudentEditModal = ({ student, exams, onClose }) => {
+    const queryClient = useQueryClient()
+
+    const [form, setForm] = useState(() => ({
+        // user
+        first_name: student.user.first_name || '',
+        last_name: student.user.last_name || '',
+        phone: student.user.phone || '',
+        role: student.user.role || 'student',
+        // profile — personal
+        date_of_birth: student.date_of_birth || '',
+        bio: student.bio || '',
+        instagram_handle: student.instagram_handle || '',
+        parent_phone: student.parent_phone || '',
+        // profile — academic
+        grade: student.grade || '',
+        school: student.school || '',
+        coaching: student.coaching || '',
+        board: student.board || '',
+        medium: student.medium || 'english',
+        target_year: student.target_year || '',
+        primary_exam: student.primary_exam || '',
+        // profile — location & prefs
+        city: student.city || '',
+        state: student.state || '',
+        daily_study_goal_minutes: student.daily_study_goal_minutes ?? 60,
+        preferred_study_time: student.preferred_study_time || 'evening',
+    }))
+
+    const set = (key) => (e) => setForm((f) => ({ ...f, [key]: e.target.value }))
+
+    const mutation = useMutation({
+        mutationFn: (payload) => tenantAdminService.updateStudent(student.id, payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            toast.success('Student record updated')
+            onClose()
+        },
+        onError: (err) => {
+            const data = err?.response?.data
+            const msg = typeof data === 'string'
+                ? data
+                : data
+                    ? Object.entries(data).map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`).join(' • ')
+                    : 'Failed to update record'
+            toast.error(msg)
+        },
+    })
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        const payload = {
+            user: {
+                first_name: form.first_name.trim(),
+                last_name: form.last_name.trim(),
+                phone: form.phone.trim(),
+                role: form.role,
+            },
+            date_of_birth: form.date_of_birth || null,
+            bio: form.bio,
+            instagram_handle: form.instagram_handle.replace('@', ''),
+            parent_phone: form.parent_phone,
+            grade: form.grade,
+            school: form.school,
+            coaching: form.coaching,
+            board: form.board,
+            medium: form.medium,
+            target_year: form.target_year === '' ? null : Number(form.target_year),
+            primary_exam: form.primary_exam || null,
+            city: form.city,
+            state: form.state,
+            daily_study_goal_minutes: Number(form.daily_study_goal_minutes) || 0,
+            preferred_study_time: form.preferred_study_time,
+        }
+        mutation.mutate(payload)
+    }
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60 backdrop-blur-sm">
+            <motion.form
+                onSubmit={handleSubmit}
+                initial={{ opacity: 0, scale: 0.95, y: 20 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                className="bg-white dark:bg-surface-800 rounded-3xl w-full max-w-4xl max-h-[92vh] overflow-hidden shadow-2xl border border-surface-100 dark:border-surface-700 flex flex-col"
+            >
+                {/* Header */}
+                <div className="p-5 sm:p-6 border-b dark:border-surface-700 flex items-center justify-between bg-surface-50/50 dark:bg-surface-900/20">
+                    <div className="flex items-center gap-3 min-w-0">
+                        <div className="w-11 h-11 rounded-2xl bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 text-lg font-black shrink-0">
+                            {student.user.full_name.charAt(0) || '?'}
+                        </div>
+                        <div className="min-w-0">
+                            <h2 className="text-lg font-bold text-surface-900 dark:text-white truncate">Edit Student Record</h2>
+                            <p className="text-xs text-surface-500 truncate">{student.user.email}</p>
+                        </div>
+                    </div>
+                    <button type="button" onClick={onClose} className="p-2 hover:bg-surface-100 dark:hover:bg-surface-700 rounded-xl transition-colors shrink-0">
+                        <X className="w-5 h-5 text-surface-500" />
+                    </button>
+                </div>
+
+                {/* Body */}
+                <div className="flex-1 overflow-y-auto p-5 sm:p-8 space-y-8">
+                    {/* Personal */}
+                    <section className="space-y-4">
+                        <h3 className="text-xs font-black uppercase tracking-widest text-primary-600 dark:text-primary-400 flex items-center gap-2">
+                            <Users className="w-4 h-4" /> Personal Information
+                        </h3>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <Field label="First Name"><TextInput value={form.first_name} onChange={set('first_name')} placeholder="First name" /></Field>
+                            <Field label="Last Name"><TextInput value={form.last_name} onChange={set('last_name')} placeholder="Last name" /></Field>
+                            <Field label="Email (read-only)"><TextInput value={student.user.email} disabled className="opacity-60 cursor-not-allowed" /></Field>
+                            <Field label="Phone"><TextInput value={form.phone} onChange={set('phone')} placeholder="Phone number" /></Field>
+                            <Field label="Date of Birth"><TextInput type="date" value={form.date_of_birth || ''} onChange={set('date_of_birth')} /></Field>
+                            <Field label="Parent Contact"><TextInput value={form.parent_phone} onChange={set('parent_phone')} placeholder="Parent phone" /></Field>
+                            <Field label="Instagram Handle"><TextInput value={form.instagram_handle} onChange={set('instagram_handle')} placeholder="username" /></Field>
+                            <Field label="Role" hint="Controls platform permissions">
+                                <SelectInput options={ROLE_OPTIONS} value={form.role} onChange={set('role')} />
+                            </Field>
+                            <div className="sm:col-span-2">
+                                <Field label="Bio">
+                                    <textarea
+                                        value={form.bio}
+                                        onChange={set('bio')}
+                                        rows={3}
+                                        maxLength={500}
+                                        placeholder="Short bio…"
+                                        className="input resize-none"
+                                    />
+                                </Field>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* Academic */}
+                    <section className="space-y-4">
+                        <h3 className="text-xs font-black uppercase tracking-widest text-primary-600 dark:text-primary-400 flex items-center gap-2">
+                            <School className="w-4 h-4" /> Academic Details
+                        </h3>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <Field label="Primary Exam">
+                                <SelectInput
+                                    options={[{ value: '', label: '—' }, ...exams.map((ex) => ({ value: ex.id, label: ex.name }))]}
+                                    value={form.primary_exam}
+                                    onChange={set('primary_exam')}
+                                />
+                            </Field>
+                            <Field label="Target Year"><TextInput type="number" value={form.target_year} onChange={set('target_year')} placeholder="e.g. 2026" /></Field>
+                            <Field label="Grade / Class"><SelectInput options={GRADE_OPTIONS} value={form.grade} onChange={set('grade')} /></Field>
+                            <Field label="Board / University"><SelectInput options={BOARD_OPTIONS} value={form.board} onChange={set('board')} /></Field>
+                            <Field label="School / Institute"><TextInput value={form.school} onChange={set('school')} placeholder="School name" /></Field>
+                            <Field label="Coaching Center"><TextInput value={form.coaching} onChange={set('coaching')} placeholder="Coaching name" /></Field>
+                            <Field label="Study Medium"><SelectInput options={MEDIUM_OPTIONS} value={form.medium} onChange={set('medium')} /></Field>
+                        </div>
+                    </section>
+
+                    {/* Location & Preferences */}
+                    <section className="space-y-4">
+                        <h3 className="text-xs font-black uppercase tracking-widest text-primary-600 dark:text-primary-400 flex items-center gap-2">
+                            <MapPin className="w-4 h-4" /> Location & Preferences
+                        </h3>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <Field label="City"><TextInput value={form.city} onChange={set('city')} placeholder="City" /></Field>
+                            <Field label="State"><TextInput value={form.state} onChange={set('state')} placeholder="State" /></Field>
+                            <Field label="Daily Study Goal (minutes)"><TextInput type="number" min="0" value={form.daily_study_goal_minutes} onChange={set('daily_study_goal_minutes')} /></Field>
+                            <Field label="Preferred Study Time"><SelectInput options={STUDY_TIME_OPTIONS} value={form.preferred_study_time} onChange={set('preferred_study_time')} /></Field>
+                        </div>
+                    </section>
+                </div>
+
+                {/* Footer */}
+                <div className="p-4 sm:p-5 bg-surface-50 dark:bg-surface-900/20 border-t dark:border-surface-700 flex items-center justify-end gap-3">
+                    <button type="button" onClick={onClose} className="px-5 py-2.5 rounded-xl font-bold text-sm text-surface-600 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-700 transition-colors">
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={mutation.isPending}
+                        className="px-6 py-2.5 bg-primary-600 text-white rounded-xl font-bold text-sm hover:bg-primary-700 transition-colors flex items-center gap-2 disabled:opacity-60"
+                    >
+                        {mutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                        Save Changes
+                    </button>
+                </div>
+            </motion.form>
+        </div>
+    )
+}
+
+/* ---------------------------------------------------------------------------
+ * StudentDetailModal — read-only full profile
+ * ------------------------------------------------------------------------- */
+const StudentDetailModal = ({ student, onClose, onEdit }) => {
+    if (!student) return null
 
     const sections = [
         {
@@ -65,22 +342,22 @@ const StudentDetailModal = ({ student, onClose }) => {
                 { label: 'Full Name', value: student.user.full_name },
                 { label: 'Email', value: student.user.email },
                 { label: 'Phone', value: student.user.phone || 'Not provided' },
-                { label: 'Date of Birth', value: student.date_of_birth || 'Not provided', icon: Calendar },
+                { label: 'Date of Birth', value: student.date_of_birth || 'Not provided' },
                 { label: 'Bio', value: student.bio || 'No bio available', fullWidth: true },
-            ]
+            ],
         },
         {
             title: 'Academic Details',
             icon: School,
             fields: [
-                { label: 'Primary Exam', value: student.primary_exam_name, icon: BookOpen },
+                { label: 'Primary Exam', value: student.primary_exam_name || 'Not set' },
                 { label: 'Target Year', value: student.target_year || 'Not set' },
                 { label: 'Grade/Level', value: student.grade || 'Not provided' },
                 { label: 'School/Institute', value: student.school || 'Not provided' },
                 { label: 'Coaching Center', value: student.coaching || 'Not provided' },
                 { label: 'Board/University', value: student.board || 'Not provided' },
                 { label: 'Study Medium', value: student.medium || 'Not provided' },
-            ]
+            ],
         },
         {
             title: 'Location & Preferences',
@@ -92,7 +369,7 @@ const StudentDetailModal = ({ student, onClose }) => {
                 { label: 'Preferred Study Time', value: student.preferred_study_time, className: 'capitalize' },
                 { label: 'Instagram', value: student.instagram_handle ? `@${student.instagram_handle}` : 'Not provided' },
                 { label: 'Parent Contact', value: student.parent_phone || 'Not provided' },
-            ]
+            ],
         },
         {
             title: 'Performance Statistics',
@@ -104,42 +381,37 @@ const StudentDetailModal = ({ student, onClose }) => {
                 { label: 'Questions Attempted', value: student.total_questions_attempted },
                 { label: 'Correct Answers', value: student.total_correct_answers },
                 { label: 'Total Study Time', value: `${student.total_study_time_minutes} minutes` },
-            ]
-        }
-    ];
+            ],
+        },
+    ]
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-surface-900/60 backdrop-blur-sm">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60 backdrop-blur-sm">
             <motion.div
                 initial={{ opacity: 0, scale: 0.95, y: 20 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 className="bg-white dark:bg-surface-800 rounded-3xl w-full max-w-4xl max-h-[90vh] overflow-hidden shadow-2xl border border-surface-100 dark:border-surface-700 flex flex-col"
             >
-                {/* Header */}
-                <div className="p-6 border-b dark:border-surface-700 flex items-center justify-between bg-surface-50/50 dark:bg-surface-900/20">
-                    <div className="flex items-center gap-4">
-                        <div className="w-12 h-12 rounded-2xl bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 text-xl font-black">
-                            {student.user.full_name.charAt(0)}
+                <div className="p-5 sm:p-6 border-b dark:border-surface-700 flex items-center justify-between bg-surface-50/50 dark:bg-surface-900/20">
+                    <div className="flex items-center gap-3 min-w-0">
+                        <div className="w-11 h-11 rounded-2xl bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 text-lg font-black shrink-0">
+                            {student.user.full_name.charAt(0) || '?'}
                         </div>
-                        <div>
-                            <h2 className="text-xl font-bold text-surface-900 dark:text-white">{student.user.full_name}</h2>
-                            <p className="text-sm text-surface-500">{student.user.email}</p>
+                        <div className="min-w-0">
+                            <h2 className="text-lg sm:text-xl font-bold text-surface-900 dark:text-white truncate">{student.user.full_name}</h2>
+                            <p className="text-xs sm:text-sm text-surface-500 truncate">{student.user.email}</p>
                         </div>
                     </div>
-                    <button
-                        onClick={onClose}
-                        className="p-2 hover:bg-surface-100 dark:hover:bg-surface-700 rounded-xl transition-colors"
-                    >
-                        <X className="w-6 h-6 text-surface-500" />
+                    <button onClick={onClose} className="p-2 hover:bg-surface-100 dark:hover:bg-surface-700 rounded-xl transition-colors shrink-0">
+                        <X className="w-5 h-5 text-surface-500" />
                     </button>
                 </div>
 
-                {/* Content */}
-                <div className="flex-1 overflow-y-auto p-8 space-y-10">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+                <div className="flex-1 overflow-y-auto p-5 sm:p-8 space-y-8 sm:space-y-10">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 sm:gap-10">
                         {sections.map((section, idx) => (
                             <div key={idx} className="space-y-4">
-                                <h3 className="text-sm font-black uppercase tracking-widest text-primary-600 dark:text-primary-400 flex items-center gap-2">
+                                <h3 className="text-xs font-black uppercase tracking-widest text-primary-600 dark:text-primary-400 flex items-center gap-2">
                                     <section.icon className="w-4 h-4" />
                                     {section.title}
                                 </h3>
@@ -147,9 +419,7 @@ const StudentDetailModal = ({ student, onClose }) => {
                                     {section.fields.map((field, fIdx) => (
                                         <div key={fIdx} className={`${field.fullWidth ? 'col-span-2' : ''} space-y-1`}>
                                             <p className="text-[10px] font-bold text-surface-400 uppercase tracking-wider">{field.label}</p>
-                                            <p className={`text-sm text-surface-700 dark:text-surface-200 ${field.className || ''}`}>
-                                                {field.value}
-                                            </p>
+                                            <p className={`text-sm text-surface-700 dark:text-surface-200 break-words ${field.className || ''}`}>{field.value}</p>
                                         </div>
                                     ))}
                                 </div>
@@ -158,13 +428,12 @@ const StudentDetailModal = ({ student, onClose }) => {
                     </div>
                 </div>
 
-                {/* Footer */}
-                <div className="p-6 bg-surface-50 dark:bg-surface-900/20 border-t dark:border-surface-700 flex justify-end">
-                    <button
-                        onClick={onClose}
-                        className="px-6 py-2.5 bg-surface-900 dark:bg-white text-white dark:text-surface-900 rounded-xl font-bold text-sm hover:opacity-90 transition-opacity"
-                    >
-                        Close Profile
+                <div className="p-4 sm:p-5 bg-surface-50 dark:bg-surface-900/20 border-t dark:border-surface-700 flex justify-end gap-3">
+                    <button onClick={onClose} className="px-5 py-2.5 rounded-xl font-bold text-sm text-surface-600 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-700 transition-colors">
+                        Close
+                    </button>
+                    <button onClick={() => onEdit(student)} className="px-6 py-2.5 bg-primary-600 text-white rounded-xl font-bold text-sm hover:bg-primary-700 transition-colors flex items-center gap-2">
+                        <Pencil className="w-4 h-4" /> Edit Record
                     </button>
                 </div>
             </motion.div>
@@ -172,187 +441,275 @@ const StudentDetailModal = ({ student, onClose }) => {
     )
 }
 
+/* ---------------------------------------------------------------------------
+ * Row action buttons shared between desktop table & mobile cards
+ * ------------------------------------------------------------------------- */
+const RowActions = ({ student, onView, onEdit, onReset }) => (
+    <div className="flex items-center gap-1">
+        <button onClick={() => onEdit(student)} className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all" title="Edit record">
+            <Pencil className="w-4 h-4" />
+        </button>
+        <button onClick={() => onView(student)} className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all" title="View full profile">
+            <ExternalLink className="w-4 h-4" />
+        </button>
+        <button onClick={() => onReset(student)} className="p-2 text-surface-400 hover:text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg transition-all" title="Reset progress">
+            <RotateCcw className="w-4 h-4" />
+        </button>
+    </div>
+)
+
+/* ---------------------------------------------------------------------------
+ * StudentManagement — search, filters, export, edit
+ * ------------------------------------------------------------------------- */
 const StudentManagement = () => {
     const queryClient = useQueryClient()
     const [searchTerm, setSearchTerm] = useState('')
     const [filterRole, setFilterRole] = useState('all')
+    const [filterStatus, setFilterStatus] = useState('all')
+    const [filterExam, setFilterExam] = useState('all')
+    const [sortBy, setSortBy] = useState('name')
     const [selectedStudent, setSelectedStudent] = useState(null)
+    const [editingStudent, setEditingStudent] = useState(null)
 
     const { data: students, isLoading } = useQuery({
         queryKey: ['tenantStudents'],
-        queryFn: () => tenantAdminService.getStudents()
+        queryFn: () => tenantAdminService.getStudents(),
     })
+
+    const { data: examsData } = useQuery({
+        queryKey: ['adminExamOptions'],
+        queryFn: () => examService.getAvailableExamsForEnrollment(),
+    })
+    const exams = Array.isArray(examsData) ? examsData : (examsData?.results || examsData?.exams || [])
 
     const resetMutation = useMutation({
         mutationFn: (id) => tenantAdminService.resetStudentProgress(id),
         onSuccess: () => {
-            queryClient.invalidateQueries(['tenantStudents'])
-            alert('Student progress has been reset successfully.')
-        }
+            queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            toast.success('Student progress reset')
+        },
+        onError: () => toast.error('Failed to reset progress'),
     })
 
     const statusMutation = useMutation({
         mutationFn: (id) => tenantAdminService.toggleStudentStatus(id),
         onSuccess: () => {
-            queryClient.invalidateQueries(['tenantStudents'])
-        }
-    })
-
-    const roleMutation = useMutation({
-        mutationFn: ({ id, role }) => tenantAdminService.updateStudent(id, { user: { role } }),
-        onSuccess: () => {
-            queryClient.invalidateQueries(['tenantStudents'])
-            alert('User role updated successfully.')
-        }
+            queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            toast.success('Account status updated')
+        },
+        onError: (err) => toast.error(err?.response?.data?.error || 'Failed to update status'),
     })
 
     const studentList = Array.isArray(students) ? students : (students?.results || [])
 
-    const filteredStudents = studentList.filter(student => {
-        const matchesSearch = student.user.full_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-            student.user.email.toLowerCase().includes(searchTerm.toLowerCase())
-        const matchesRole = filterRole === 'all' || student.user.role === filterRole
-        return matchesSearch && matchesRole
-    })
+    const filteredStudents = useMemo(() => {
+        const term = searchTerm.trim().toLowerCase()
+        const result = studentList.filter((s) => {
+            const matchesSearch =
+                !term ||
+                s.user.full_name.toLowerCase().includes(term) ||
+                s.user.email.toLowerCase().includes(term) ||
+                (s.user.phone || '').toLowerCase().includes(term)
+            const matchesRole = filterRole === 'all' || s.user.role === filterRole
+            const matchesStatus =
+                filterStatus === 'all' ||
+                (filterStatus === 'active' && !s.user.is_suspended) ||
+                (filterStatus === 'suspended' && s.user.is_suspended)
+            const matchesExam = filterExam === 'all' || String(s.primary_exam) === String(filterExam)
+            return matchesSearch && matchesRole && matchesStatus && matchesExam
+        })
 
-    if (isLoading) return <div className="py-12 text-center text-surface-500">Loading students...</div>
+        const sorted = [...result].sort((a, b) => {
+            switch (sortBy) {
+                case 'xp':
+                    return (b.total_xp || 0) - (a.total_xp || 0)
+                case 'accuracy':
+                    return (b.overall_accuracy || 0) - (a.overall_accuracy || 0)
+                case 'level':
+                    return (b.current_level || 0) - (a.current_level || 0)
+                case 'email':
+                    return a.user.email.localeCompare(b.user.email)
+                default:
+                    return a.user.full_name.localeCompare(b.user.full_name)
+            }
+        })
+        return sorted
+    }, [studentList, searchTerm, filterRole, filterStatus, filterExam, sortBy])
+
+    const handleReset = (student) => {
+        if (window.confirm(`Reset ALL progress for ${student.user.full_name}? This cannot be undone.`)) {
+            resetMutation.mutate(student.id)
+        }
+    }
+
+    const exportCsv = () => {
+        if (filteredStudents.length === 0) {
+            toast.error('No records to export')
+            return
+        }
+        const headers = [
+            'Full Name', 'Email', 'Phone', 'Role', 'Status', 'Primary Exam', 'Target Year',
+            'Grade', 'School', 'Coaching', 'Board', 'Medium', 'City', 'State',
+            'Level', 'Total XP', 'Accuracy %', 'Questions Attempted', 'Correct Answers', 'Study Minutes',
+        ]
+        const escape = (v) => `"${String(v ?? '').replace(/"/g, '""')}"`
+        const rows = filteredStudents.map((s) => [
+            s.user.full_name, s.user.email, s.user.phone, s.user.role,
+            s.user.is_suspended ? 'Suspended' : 'Active',
+            s.primary_exam_name, s.target_year, s.grade, s.school, s.coaching, s.board, s.medium,
+            s.city, s.state, s.current_level, s.total_xp, s.overall_accuracy,
+            s.total_questions_attempted, s.total_correct_answers, s.total_study_time_minutes,
+        ].map(escape).join(','))
+        const csv = [headers.map(escape).join(','), ...rows].join('\n')
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+        const url = URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `student-records-${new Date().toISOString().slice(0, 10)}.csv`
+        link.click()
+        URL.revokeObjectURL(url)
+        toast.success(`Exported ${filteredStudents.length} records`)
+    }
+
+    const resetFilters = () => {
+        setSearchTerm(''); setFilterRole('all'); setFilterStatus('all'); setFilterExam('all'); setSortBy('name')
+    }
+
+    const hasActiveFilters = searchTerm || filterRole !== 'all' || filterStatus !== 'all' || filterExam !== 'all' || sortBy !== 'name'
+
+    if (isLoading) return <div className="py-12 text-center text-surface-500">Loading students…</div>
 
     return (
-        <div className="space-y-6">
-            <div className="flex flex-col md:flex-row gap-4 items-center justify-between">
-                <div className="relative w-full md:w-96">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-400" />
-                    <input
-                        type="text"
-                        placeholder="Search by name or email..."
-                        className="input pl-10 w-full"
-                        value={searchTerm}
-                        onChange={(e) => setSearchTerm(e.target.value)}
-                    />
+        <div className="space-y-5">
+            {/* Toolbar */}
+            <div className="card p-4 sm:p-5 space-y-4">
+                <div className="flex flex-col lg:flex-row gap-3 lg:items-center">
+                    <div className="relative flex-1">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-400" />
+                        <input
+                            type="text"
+                            placeholder="Search by name, email or phone…"
+                            className="input pl-10 w-full"
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                        />
+                        {searchTerm && (
+                            <button onClick={() => setSearchTerm('')} className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-400 hover:text-surface-600">
+                                <X className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
+                    <button onClick={exportCsv} className="btn-secondary justify-center whitespace-nowrap">
+                        <Download className="w-4 h-4" /> Export CSV
+                    </button>
                 </div>
-                <select
-                    className="input w-full md:w-48"
-                    value={filterRole}
-                    onChange={(e) => setFilterRole(e.target.value)}
-                >
-                    <option value="all">All Roles</option>
-                    <option value="student">Student</option>
-                    <option value="instructor">Instructor</option>
-                    <option value="admin">Admin</option>
-                </select>
+
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-bold uppercase tracking-wider text-surface-400 flex items-center gap-1"><UserCog className="w-3 h-3" /> Role</label>
+                        <select className="input py-2.5" value={filterRole} onChange={(e) => setFilterRole(e.target.value)}>
+                            <option value="all">All Roles</option>
+                            <option value="student">Student</option>
+                            <option value="instructor">Instructor</option>
+                            <option value="admin">Admin</option>
+                        </select>
+                    </div>
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-bold uppercase tracking-wider text-surface-400 flex items-center gap-1"><Shield className="w-3 h-3" /> Status</label>
+                        <select className="input py-2.5" value={filterStatus} onChange={(e) => setFilterStatus(e.target.value)}>
+                            <option value="all">All Status</option>
+                            <option value="active">Active</option>
+                            <option value="suspended">Suspended</option>
+                        </select>
+                    </div>
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-bold uppercase tracking-wider text-surface-400 flex items-center gap-1"><BookOpen className="w-3 h-3" /> Exam</label>
+                        <select className="input py-2.5" value={filterExam} onChange={(e) => setFilterExam(e.target.value)}>
+                            <option value="all">All Exams</option>
+                            {exams.map((ex) => <option key={ex.id} value={ex.id}>{ex.name}</option>)}
+                        </select>
+                    </div>
+                    <div className="space-y-1">
+                        <label className="text-[10px] font-bold uppercase tracking-wider text-surface-400 flex items-center gap-1"><SlidersHorizontal className="w-3 h-3" /> Sort By</label>
+                        <select className="input py-2.5" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+                            <option value="name">Name (A-Z)</option>
+                            <option value="email">Email (A-Z)</option>
+                            <option value="xp">XP (High-Low)</option>
+                            <option value="accuracy">Accuracy (High-Low)</option>
+                            <option value="level">Level (High-Low)</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div className="flex items-center justify-between text-xs text-surface-500">
+                    <span className="flex items-center gap-1.5">
+                        <Filter className="w-3.5 h-3.5" />
+                        Showing <span className="font-bold text-surface-700 dark:text-surface-200">{filteredStudents.length}</span> of {studentList.length} students
+                    </span>
+                    {hasActiveFilters && (
+                        <button onClick={resetFilters} className="font-semibold text-primary-600 hover:underline">Clear filters</button>
+                    )}
+                </div>
             </div>
 
-            <div className="card overflow-hidden">
+            {/* Desktop table */}
+            <div className="card overflow-hidden hidden md:block">
                 <div className="overflow-x-auto">
                     <table className="w-full text-left">
                         <thead className="bg-surface-50 dark:bg-surface-800/50 text-xs font-semibold text-surface-500 uppercase">
                             <tr>
-                                <th className="px-6 py-4">User</th>
+                                <th className="px-6 py-4">Student</th>
+                                <th className="px-6 py-4">Exam</th>
                                 <th className="px-6 py-4">Status</th>
-                                <th className="px-6 py-4">Stats</th>
-                                <th className="px-6 py-4">Actions</th>
+                                <th className="px-6 py-4">Performance</th>
+                                <th className="px-6 py-4 text-right">Actions</th>
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-surface-100 dark:divide-surface-800">
-                            {filteredStudents?.map((student) => (
+                            {filteredStudents.map((student) => (
                                 <tr key={student.id} className="hover:bg-surface-50/50 dark:hover:bg-surface-800/30 transition-colors">
                                     <td className="px-6 py-4">
                                         <div className="flex items-center gap-3">
-                                            <div className="w-10 h-10 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 font-bold">
-                                                {student.user.full_name.charAt(0)}
+                                            <div className="w-10 h-10 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 font-bold shrink-0">
+                                                {student.user.full_name.charAt(0) || '?'}
                                             </div>
-                                            <div>
-                                                <div className="font-medium text-surface-900 dark:text-white">{student.user.full_name}</div>
-                                                <div className="text-xs text-surface-500">{student.user.email}</div>
-                                                <div className="mt-1">
-                                                    <span className={`px-2 py-0.5 rounded-full text-[10px] uppercase font-bold ${student.user.role === 'admin' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400' :
-                                                        student.user.role === 'instructor' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400' :
-                                                            'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400'
-                                                        }`}>
-                                                        {student.user.role}
-                                                    </span>
-                                                </div>
+                                            <div className="min-w-0">
+                                                <div className="font-medium text-surface-900 dark:text-white truncate">{student.user.full_name}</div>
+                                                <div className="text-xs text-surface-500 truncate">{student.user.email}</div>
+                                                <span className={`inline-block mt-1 px-2 py-0.5 rounded-full text-[10px] uppercase font-bold ${roleBadgeClass(student.user.role)}`}>
+                                                    {student.user.role}
+                                                </span>
                                             </div>
                                         </div>
+                                    </td>
+                                    <td className="px-6 py-4 text-sm text-surface-600 dark:text-surface-300">
+                                        {student.primary_exam_name || <span className="text-surface-400">—</span>}
                                     </td>
                                     <td className="px-6 py-4">
                                         <button
                                             onClick={() => statusMutation.mutate(student.id)}
                                             className={`flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-lg border transition-all ${!student.user.is_suspended
                                                 ? 'bg-emerald-50 border-emerald-100 text-emerald-700 dark:bg-emerald-900/20 dark:border-emerald-800 dark:text-emerald-400'
-                                                : 'bg-rose-50 border-rose-100 text-rose-700 dark:bg-rose-900/20 dark:border-rose-800 dark:text-rose-400 hover:bg-rose-100'
-                                                }`}
+                                                : 'bg-rose-50 border-rose-100 text-rose-700 dark:bg-rose-900/20 dark:border-rose-800 dark:text-rose-400 hover:bg-rose-100'}`}
                                         >
-                                            {!student.user.is_suspended ? (
-                                                <><Shield className="w-3.5 h-3.5" /> Active</>
-                                            ) : (
-                                                <><ShieldOff className="w-3.5 h-3.5" /> Suspended</>
-                                            )}
+                                            {!student.user.is_suspended ? <><Shield className="w-3.5 h-3.5" /> Active</> : <><ShieldOff className="w-3.5 h-3.5" /> Suspended</>}
                                         </button>
                                     </td>
-                                    <td className="px-6 py-4 text-xs space-y-1">
-                                        <div className="flex justify-between">
-                                            <span className="text-surface-500">XP:</span>
-                                            <span className="font-semibold text-surface-900 dark:text-white">{student.total_xp}</span>
-                                        </div>
-                                        <div className="flex justify-between">
-                                            <span className="text-surface-500">Accuracy:</span>
-                                            <span className="font-semibold text-surface-900 dark:text-white">{student.overall_accuracy}%</span>
-                                        </div>
+                                    <td className="px-6 py-4 text-xs space-y-1 whitespace-nowrap">
+                                        <div className="flex justify-between gap-4"><span className="text-surface-500">Lvl</span><span className="font-semibold text-surface-900 dark:text-white">{student.current_level}</span></div>
+                                        <div className="flex justify-between gap-4"><span className="text-surface-500">XP</span><span className="font-semibold text-surface-900 dark:text-white">{student.total_xp}</span></div>
+                                        <div className="flex justify-between gap-4"><span className="text-surface-500">Acc</span><span className="font-semibold text-surface-900 dark:text-white">{student.overall_accuracy}%</span></div>
                                     </td>
                                     <td className="px-6 py-4">
-                                        <div className="flex items-center gap-2">
-                                            <button
-                                                onClick={() => {
-                                                    if (window.confirm(`Are you sure you want to reset all progress for ${student.user.full_name}? This action cannot be undone.`)) {
-                                                        resetMutation.mutate(student.id)
-                                                    }
-                                                }}
-                                                className="p-2 text-surface-400 hover:text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg transition-all tooltip"
-                                                title="Reset Progress"
-                                            >
-                                                <RotateCcw className="w-4 h-4" />
-                                            </button>
-
-                                            <button
-                                                onClick={() => setSelectedStudent(student)}
-                                                className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all tooltip"
-                                                title="View Full Profile"
-                                            >
-                                                <ExternalLink className="w-4 h-4" />
-                                            </button>
-
-                                            <div className="relative group/role">
-                                                <button className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all">
-                                                    <UserCog className="w-4 h-4" />
-                                                </button>
-                                                <div className="absolute right-0 bottom-full mb-2 hidden group-hover/role:block bg-white dark:bg-surface-800 border dark:border-surface-700 rounded-xl shadow-xl p-2 z-50 min-w-[120px]">
-                                                    {['student', 'instructor', 'admin'].map(r => (
-                                                        student.user.role !== r && (
-                                                            <button
-                                                                key={r}
-                                                                onClick={() => {
-                                                                    if (window.confirm(`Change ${student.user.full_name}'s role to ${r}?`)) {
-                                                                        roleMutation.mutate({ id: student.id, role: r })
-                                                                    }
-                                                                }}
-                                                                className="w-full text-left px-3 py-1.5 text-xs rounded-lg hover:bg-surface-50 dark:hover:bg-surface-700 capitalize"
-                                                            >
-                                                                Make {r}
-                                                            </button>
-                                                        )
-                                                    ))}
-                                                </div>
-                                            </div>
+                                        <div className="flex justify-end">
+                                            <RowActions student={student} onView={setSelectedStudent} onEdit={setEditingStudent} onReset={handleReset} />
                                         </div>
                                     </td>
                                 </tr>
                             ))}
-                            {filteredStudents?.length === 0 && (
+                            {filteredStudents.length === 0 && (
                                 <tr>
-                                    <td colSpan="4" className="px-6 py-12 text-center text-surface-500 italic">
-                                        No students found matching your search.
-                                    </td>
+                                    <td colSpan="5" className="px-6 py-12 text-center text-surface-500 italic">No students match your filters.</td>
                                 </tr>
                             )}
                         </tbody>
@@ -360,11 +717,57 @@ const StudentManagement = () => {
                 </div>
             </div>
 
+            {/* Mobile cards */}
+            <div className="md:hidden space-y-3">
+                {filteredStudents.map((student) => (
+                    <div key={student.id} className="card p-4 space-y-3">
+                        <div className="flex items-start gap-3">
+                            <div className="w-11 h-11 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center text-primary-600 font-bold shrink-0">
+                                {student.user.full_name.charAt(0) || '?'}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                                <div className="font-semibold text-surface-900 dark:text-white truncate">{student.user.full_name}</div>
+                                <div className="text-xs text-surface-500 flex items-center gap-1 truncate"><Mail className="w-3 h-3 shrink-0" /> {student.user.email}</div>
+                                {student.user.phone && <div className="text-xs text-surface-500 flex items-center gap-1"><Phone className="w-3 h-3" /> {student.user.phone}</div>}
+                            </div>
+                            <span className={`px-2 py-0.5 rounded-full text-[10px] uppercase font-bold shrink-0 ${roleBadgeClass(student.user.role)}`}>{student.user.role}</span>
+                        </div>
+                        <div className="grid grid-cols-3 gap-2 text-center text-xs bg-surface-50 dark:bg-surface-800/50 rounded-xl p-2.5">
+                            <div><div className="font-bold text-surface-900 dark:text-white">{student.current_level}</div><div className="text-surface-400">Level</div></div>
+                            <div><div className="font-bold text-surface-900 dark:text-white">{student.total_xp}</div><div className="text-surface-400">XP</div></div>
+                            <div><div className="font-bold text-surface-900 dark:text-white">{student.overall_accuracy}%</div><div className="text-surface-400">Accuracy</div></div>
+                        </div>
+                        <div className="flex items-center justify-between">
+                            <button
+                                onClick={() => statusMutation.mutate(student.id)}
+                                className={`flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 rounded-lg border ${!student.user.is_suspended
+                                    ? 'bg-emerald-50 border-emerald-100 text-emerald-700 dark:bg-emerald-900/20 dark:border-emerald-800 dark:text-emerald-400'
+                                    : 'bg-rose-50 border-rose-100 text-rose-700 dark:bg-rose-900/20 dark:border-rose-800 dark:text-rose-400'}`}
+                            >
+                                {!student.user.is_suspended ? <><Shield className="w-3.5 h-3.5" /> Active</> : <><ShieldOff className="w-3.5 h-3.5" /> Suspended</>}
+                            </button>
+                            <RowActions student={student} onView={setSelectedStudent} onEdit={setEditingStudent} onReset={handleReset} />
+                        </div>
+                    </div>
+                ))}
+                {filteredStudents.length === 0 && (
+                    <div className="card p-10 text-center text-surface-500 italic">No students match your filters.</div>
+                )}
+            </div>
+
             <AnimatePresence>
                 {selectedStudent && (
                     <StudentDetailModal
                         student={selectedStudent}
                         onClose={() => setSelectedStudent(null)}
+                        onEdit={(s) => { setSelectedStudent(null); setEditingStudent(s) }}
+                    />
+                )}
+                {editingStudent && (
+                    <StudentEditModal
+                        student={editingStudent}
+                        exams={exams}
+                        onClose={() => setEditingStudent(null)}
                     />
                 )}
             </AnimatePresence>
@@ -372,47 +775,41 @@ const StudentManagement = () => {
     )
 }
 
+/* ---------------------------------------------------------------------------
+ * PerformanceReports
+ * ------------------------------------------------------------------------- */
 const PerformanceReports = () => {
     const { data: subjectStats, isLoading: loadingStats } = useQuery({
         queryKey: ['tenantSubjectStats'],
-        queryFn: () => analyticsService.getTenantSubjectStats()
+        queryFn: () => analyticsService.getTenantSubjectStats(),
     })
 
     const { data: leaderboard, isLoading: loadingLeaderboard } = useQuery({
         queryKey: ['tenantLeaderboard'],
-        queryFn: () => analyticsService.getTenantLeaderboard(5)
+        queryFn: () => analyticsService.getTenantLeaderboard(5),
     })
 
-    if (loadingStats || loadingLeaderboard) return <div className="py-12 text-center text-surface-500">Generating reports...</div>
+    if (loadingStats || loadingLeaderboard) return <div className="py-12 text-center text-surface-500">Generating reports…</div>
 
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
             <div className="lg:col-span-2 space-y-6">
-                <div className="card p-6">
+                <div className="card p-5 sm:p-6">
                     <h3 className="text-lg font-bold mb-6 flex items-center gap-2">
-                        <BarChart3 className="w-5 h-5 text-primary-500" />
-                        Subject-wise Accuracy
+                        <BarChart3 className="w-5 h-5 text-primary-500" /> Subject-wise Accuracy
                     </h3>
                     <div className="space-y-6">
                         {subjectStats?.map((item) => (
                             <div key={item.subject} className="group">
                                 <div className="flex justify-between items-end mb-2">
                                     <div>
-                                        <span className="text-sm font-semibold text-surface-700 dark:text-surface-300 group-hover:text-primary-500 transition-colors">
-                                            {item.subject}
-                                        </span>
-                                        <span className="text-[10px] text-surface-500 ml-2">
-                                            ({item.student_count} students)
-                                        </span>
+                                        <span className="text-sm font-semibold text-surface-700 dark:text-surface-300 group-hover:text-primary-500 transition-colors">{item.subject}</span>
+                                        <span className="text-[10px] text-surface-500 ml-2">({item.student_count} students)</span>
                                     </div>
                                     <span className="text-sm font-bold text-primary-600 dark:text-primary-400">{item.accuracy}%</span>
                                 </div>
                                 <div className="h-3 bg-surface-100 dark:bg-surface-800 rounded-full overflow-hidden">
-                                    <motion.div
-                                        initial={{ width: 0 }}
-                                        animate={{ width: `${item.accuracy}%` }}
-                                        className="h-full bg-gradient-to-r from-primary-500 to-primary-400"
-                                    />
+                                    <motion.div initial={{ width: 0 }} animate={{ width: `${item.accuracy}%` }} className="h-full bg-gradient-to-r from-primary-500 to-primary-400" />
                                 </div>
                                 <div className="mt-1 flex justify-between text-[10px] text-surface-400">
                                     <span>Avg. Study Time: {item.avg_study_minutes}m</span>
@@ -420,59 +817,46 @@ const PerformanceReports = () => {
                             </div>
                         ))}
                         {(!subjectStats || subjectStats.length === 0) && (
-                            <div className="text-center py-12 text-surface-500 italic font-medium">
-                                No subject data available yet.
-                            </div>
+                            <div className="text-center py-12 text-surface-500 italic font-medium">No subject data available yet.</div>
                         )}
                     </div>
                 </div>
             </div>
 
             <div className="space-y-6">
-                <div className="card p-6 bg-gradient-to-br from-surface-50 to-white dark:from-surface-900 dark:to-surface-800 border-primary-500/10">
+                <div className="card p-5 sm:p-6 bg-gradient-to-br from-surface-50 to-white dark:from-surface-900 dark:to-surface-800 border-primary-500/10">
                     <h3 className="text-lg font-bold mb-6 flex items-center gap-2">
-                        <Award className="w-5 h-5 text-amber-500" />
-                        Institutional Top 5
+                        <Award className="w-5 h-5 text-amber-500" /> Institutional Top 5
                     </h3>
                     <div className="space-y-4">
                         {leaderboard?.map((student, index) => (
-                            <div
-                                key={student.id}
-                                className="flex items-center gap-4 p-3 rounded-xl bg-white dark:bg-surface-800/50 shadow-sm border border-surface-100 dark:border-surface-700"
-                            >
-                                <div className={`w-8 h-8 rounded-lg flex items-center justify-center font-bold text-sm ${index === 0 ? 'bg-amber-100 text-amber-600' :
-                                    index === 1 ? 'bg-slate-100 text-slate-600' :
-                                        index === 2 ? 'bg-orange-100 text-orange-600' :
-                                            'bg-surface-100 text-surface-500'
-                                    }`}>
+                            <div key={student.id} className="flex items-center gap-4 p-3 rounded-xl bg-white dark:bg-surface-800/50 shadow-sm border border-surface-100 dark:border-surface-700">
+                                <div className={`w-8 h-8 rounded-lg flex items-center justify-center font-bold text-sm ${index === 0 ? 'bg-amber-100 text-amber-600' : index === 1 ? 'bg-slate-100 text-slate-600' : index === 2 ? 'bg-orange-100 text-orange-600' : 'bg-surface-100 text-surface-500'}`}>
                                     {index + 1}
                                 </div>
                                 <div className="flex-1 min-w-0">
-                                    <div className="font-bold text-sm truncate dark:text-white">
-                                        {student.name}
-                                    </div>
-                                    <div className="text-[10px] text-surface-500 flex items-center gap-1">
-                                        Level {student.level} • {student.accuracy}% Accuracy
-                                    </div>
+                                    <div className="font-bold text-sm truncate dark:text-white">{student.name}</div>
+                                    <div className="text-[10px] text-surface-500">Level {student.level} • {student.accuracy}% Accuracy</div>
                                 </div>
                                 <div className="text-right">
-                                    <div className="text-xs font-black text-primary-600 dark:text-primary-400">
-                                        {student.xp.toLocaleString()}
-                                    </div>
+                                    <div className="text-xs font-black text-primary-600 dark:text-primary-400">{student.xp.toLocaleString()}</div>
                                     <div className="text-[8px] uppercase tracking-wider text-surface-400 font-bold">XP</div>
                                 </div>
                             </div>
                         ))}
+                        {(!leaderboard || leaderboard.length === 0) && (
+                            <p className="text-center text-surface-500 py-8 italic text-sm">No leaderboard data yet.</p>
+                        )}
                     </div>
-                    <button className="w-full mt-6 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 text-xs font-bold text-surface-600 dark:text-surface-400 hover:bg-surface-50 dark:hover:bg-surface-700 transition-all flex items-center justify-center gap-2">
-                        View Full Leaderboard <ChevronRight className="w-3 h-3" />
-                    </button>
                 </div>
             </div>
         </div>
     )
 }
 
+/* ---------------------------------------------------------------------------
+ * ContentManagement
+ * ------------------------------------------------------------------------- */
 const ContentManagement = () => {
     const { data: explorer, isLoading } = useQuery({
         queryKey: ['contentExplorer'],
@@ -486,27 +870,21 @@ const ContentManagement = () => {
 
     return (
         <div className="space-y-6">
-            <div className="flex items-center justify-between mb-2">
-                <div>
-                    <h2 className="text-xl font-bold text-surface-900 dark:text-white">Institutional Content Library</h2>
-                    <p className="text-sm text-surface-500">Explore exams, subjects, and chapters available to your students</p>
-                </div>
+            <div>
+                <h2 className="text-xl font-bold text-surface-900 dark:text-white">Institutional Content Library</h2>
+                <p className="text-sm text-surface-500">Explore exams, subjects, and chapters available to your students</p>
             </div>
 
             <div className="space-y-4">
                 {explorer?.map((exam) => (
                     <div key={exam.id} className="bg-white dark:bg-surface-800 rounded-3xl border border-surface-100 dark:border-surface-700 overflow-hidden shadow-sm">
-                        {/* Exam Header */}
-                        <button
-                            onClick={() => setExpandedExam(expandedExam === exam.id ? null : exam.id)}
-                            className="w-full p-6 flex items-center justify-between hover:bg-surface-50/50 dark:hover:bg-surface-900/10 transition-colors"
-                        >
-                            <div className="flex items-center gap-4">
-                                <div className="w-12 h-12 rounded-2xl bg-surface-100 dark:bg-surface-900/30 flex items-center justify-center">
+                        <button onClick={() => setExpandedExam(expandedExam === exam.id ? null : exam.id)} className="w-full p-5 sm:p-6 flex items-center justify-between hover:bg-surface-50/50 dark:hover:bg-surface-900/10 transition-colors">
+                            <div className="flex items-center gap-4 min-w-0">
+                                <div className="w-12 h-12 rounded-2xl bg-surface-100 dark:bg-surface-900/30 flex items-center justify-center shrink-0">
                                     <Library className="w-6 h-6 text-primary-500" />
                                 </div>
-                                <div className="text-left">
-                                    <h3 className="font-bold text-lg text-surface-900 dark:text-white">{exam.name}</h3>
+                                <div className="text-left min-w-0">
+                                    <h3 className="font-bold text-base sm:text-lg text-surface-900 dark:text-white truncate">{exam.name}</h3>
                                     <div className="flex items-center gap-3 mt-1">
                                         <span className="text-xs font-bold text-surface-400 uppercase tracking-widest">{exam.exam_type}</span>
                                         <div className="w-1 h-1 rounded-full bg-surface-300"></div>
@@ -514,33 +892,28 @@ const ContentManagement = () => {
                                     </div>
                                 </div>
                             </div>
-                            <ChevronDown className={`w-5 h-5 text-surface-400 transition-transform ${expandedExam === exam.id ? 'rotate-180' : ''}`} />
+                            <ChevronDown className={`w-5 h-5 text-surface-400 transition-transform shrink-0 ${expandedExam === exam.id ? 'rotate-180' : ''}`} />
                         </button>
 
                         <AnimatePresence>
                             {expandedExam === exam.id && (
-                                <motion.div
-                                    initial={{ opacity: 0, height: 0 }}
-                                    animate={{ opacity: 1, height: 'auto' }}
-                                    exit={{ opacity: 0, height: 0 }}
-                                    className="overflow-hidden border-t dark:border-surface-700"
-                                >
-                                    <div className="p-6 space-y-4">
-                                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                                <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden border-t dark:border-surface-700">
+                                    <div className="p-5 sm:p-6 space-y-4">
+                                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
                                             <div className="p-4 bg-surface-50 dark:bg-surface-900/30 rounded-2xl">
                                                 <p className="text-[10px] font-bold text-surface-400 uppercase tracking-wider mb-1">Duration</p>
                                                 <p className="font-bold text-surface-700 dark:text-surface-200">{exam.duration_minutes} Minutes</p>
                                             </div>
                                             <div className="p-4 bg-surface-50 dark:bg-surface-900/30 rounded-2xl">
                                                 <p className="text-[10px] font-bold text-surface-400 uppercase tracking-wider mb-1">Marking Scheme</p>
-                                                <p className="font-bold text-surface-700 dark:text-surface-200">+{exam.total_marks} Total / No Neg</p>
+                                                <p className="font-bold text-surface-700 dark:text-surface-200">+{exam.total_marks} Total</p>
                                             </div>
                                             <div className="p-4 bg-surface-50 dark:bg-surface-900/30 rounded-2xl">
                                                 <p className="text-[10px] font-bold text-surface-400 uppercase tracking-wider mb-1">Testing Resources</p>
-                                                <p className="font-bold text-surface-700 dark:text-surface-200">{exam.mock_tests_count} Mock Tests / {exam.quizzes_count} Quizzes</p>
+                                                <p className="font-bold text-surface-700 dark:text-surface-200">{exam.mock_tests_count} Mocks / {exam.quizzes_count} Quizzes</p>
                                             </div>
                                             <div className="p-4 bg-surface-50 dark:bg-surface-900/30 rounded-2xl">
-                                                <p className="text-[10px] font-bold text-surface-400 uppercase tracking-wider mb-1">Global Database</p>
+                                                <p className="text-[10px] font-bold text-surface-400 uppercase tracking-wider mb-1">Question Bank</p>
                                                 <p className="font-bold text-surface-700 dark:text-surface-200">{exam.total_questions?.toLocaleString()}+ Questions</p>
                                             </div>
                                         </div>
@@ -549,48 +922,33 @@ const ContentManagement = () => {
                                             <h4 className="text-xs font-black text-surface-400 uppercase tracking-widest px-2">Subjects & Chapters</h4>
                                             {exam.subjects?.map((subject) => (
                                                 <div key={subject.id} className="border dark:border-surface-700 rounded-2xl overflow-hidden bg-surface-50/30 dark:bg-surface-900/10">
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation()
-                                                            setExpandedSubject(expandedSubject === subject.id ? null : subject.id)
-                                                        }}
-                                                        className="w-full p-4 flex items-center justify-between hover:bg-surface-100/50 dark:hover:bg-surface-700/30 transition-colors"
-                                                    >
-                                                        <div className="flex items-center gap-3">
-                                                            <div className="w-8 h-8 rounded-lg bg-white dark:bg-surface-800 flex items-center justify-center border border-surface-100 dark:border-surface-700">
+                                                    <button onClick={(e) => { e.stopPropagation(); setExpandedSubject(expandedSubject === subject.id ? null : subject.id) }} className="w-full p-4 flex items-center justify-between hover:bg-surface-100/50 dark:hover:bg-surface-700/30 transition-colors">
+                                                        <div className="flex items-center gap-3 min-w-0">
+                                                            <div className="w-8 h-8 rounded-lg bg-white dark:bg-surface-800 flex items-center justify-center border border-surface-100 dark:border-surface-700 shrink-0">
                                                                 <Book className="w-4 h-4 text-primary-600" />
                                                             </div>
-                                                            <div className="text-left">
-                                                                <p className="font-bold text-surface-800 dark:text-surface-200">{subject.name}</p>
+                                                            <div className="text-left min-w-0">
+                                                                <p className="font-bold text-surface-800 dark:text-surface-200 truncate">{subject.name}</p>
                                                                 <p className="text-[10px] text-surface-500">{subject.weightage}% weightage • {subject.total_topics} Topics</p>
                                                             </div>
                                                         </div>
-                                                        <ChevronDown className={`w-4 h-4 text-surface-400 transition-transform ${expandedSubject === subject.id ? 'rotate-180' : ''}`} />
+                                                        <ChevronDown className={`w-4 h-4 text-surface-400 transition-transform shrink-0 ${expandedSubject === subject.id ? 'rotate-180' : ''}`} />
                                                     </button>
 
                                                     <AnimatePresence>
                                                         {expandedSubject === subject.id && (
-                                                            <motion.div
-                                                                initial={{ opacity: 0, height: 0 }}
-                                                                animate={{ opacity: 1, height: 'auto' }}
-                                                                exit={{ opacity: 0, height: 0 }}
-                                                                className="overflow-hidden bg-white dark:bg-surface-800"
-                                                            >
+                                                            <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: 'auto' }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden bg-white dark:bg-surface-800">
                                                                 <div className="p-4 pt-0 divide-y dark:divide-surface-700/50">
                                                                     {subject.chapters?.map((chapter) => (
                                                                         <div key={chapter.id} className="py-3 flex items-center justify-between group">
-                                                                            <div className="flex items-center gap-3">
-                                                                                <Layers className="w-3.5 h-3.5 text-surface-400 group-hover:text-primary-500 transition-colors" />
-                                                                                <div>
-                                                                                    <p className="text-sm font-medium text-surface-700 dark:text-surface-300">{chapter.name}</p>
+                                                                            <div className="flex items-center gap-3 min-w-0">
+                                                                                <Layers className="w-3.5 h-3.5 text-surface-400 group-hover:text-primary-500 transition-colors shrink-0" />
+                                                                                <div className="min-w-0">
+                                                                                    <p className="text-sm font-medium text-surface-700 dark:text-surface-300 truncate">{chapter.name}</p>
                                                                                     <p className="text-[10px] text-surface-500 italic">{chapter.grade ? `Grade ${chapter.grade}` : 'Resource'} • {chapter.estimated_hours}h estimated</p>
                                                                                 </div>
                                                                             </div>
-                                                                            <div className="flex items-center gap-2">
-                                                                                <span className="text-[10px] bg-surface-100 dark:bg-surface-900 border dark:border-surface-700 px-2 py-0.5 rounded-full text-surface-500">
-                                                                                    {chapter.topics_count} Topics
-                                                                                </span>
-                                                                            </div>
+                                                                            <span className="text-[10px] bg-surface-100 dark:bg-surface-900 border dark:border-surface-700 px-2 py-0.5 rounded-full text-surface-500 shrink-0">{chapter.topics_count} Topics</span>
                                                                         </div>
                                                                     ))}
                                                                     {subject.chapters?.length === 0 && (
@@ -609,11 +967,17 @@ const ContentManagement = () => {
                         </AnimatePresence>
                     </div>
                 ))}
+                {(!explorer || explorer.length === 0) && (
+                    <div className="card p-10 text-center text-surface-500 italic">No content library available yet.</div>
+                )}
             </div>
         </div>
     )
 }
 
+/* ---------------------------------------------------------------------------
+ * EnrollmentRequests
+ * ------------------------------------------------------------------------- */
 const EnrollmentRequests = () => {
     const queryClient = useQueryClient()
     const [filter, setFilter] = useState('pending')
@@ -629,14 +993,14 @@ const EnrollmentRequests = () => {
 
     const approve = async (id) => {
         setBusyId(id)
-        try { await tenantAdminService.approveEnrollment(id); refresh() }
-        catch { /* ignore */ } finally { setBusyId(null) }
+        try { await tenantAdminService.approveEnrollment(id); refresh(); toast.success('Enrollment approved') }
+        catch { toast.error('Failed to approve') } finally { setBusyId(null) }
     }
     const reject = async (id) => {
         const reason = window.prompt('Reason for rejection (optional):', '') ?? ''
         setBusyId(id)
-        try { await tenantAdminService.rejectEnrollment(id, reason); refresh() }
-        catch { /* ignore */ } finally { setBusyId(null) }
+        try { await tenantAdminService.rejectEnrollment(id, reason); refresh(); toast.success('Enrollment rejected') }
+        catch { toast.error('Failed to reject') } finally { setBusyId(null) }
     }
 
     const badge = {
@@ -651,10 +1015,9 @@ const EnrollmentRequests = () => {
                 <h2 className="text-xl font-bold flex items-center gap-2">
                     <GraduationCap className="w-5 h-5 text-primary-500" /> Enrollment Requests
                 </h2>
-                <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-lg">
+                <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-lg overflow-x-auto">
                     {['pending', 'approved', 'rejected', 'all'].map((f) => (
-                        <button key={f} onClick={() => setFilter(f)}
-                            className={`px-4 py-1.5 rounded-md text-sm font-semibold capitalize transition-all ${filter === f ? 'bg-white dark:bg-surface-700 text-primary-600 shadow-sm' : 'text-surface-500'}`}>
+                        <button key={f} onClick={() => setFilter(f)} className={`px-4 py-1.5 rounded-md text-sm font-semibold capitalize transition-all whitespace-nowrap ${filter === f ? 'bg-white dark:bg-surface-700 text-primary-600 shadow-sm' : 'text-surface-500'}`}>
                             {f}
                         </button>
                     ))}
@@ -670,63 +1033,161 @@ const EnrollmentRequests = () => {
                 </div>
             ) : (
                 <div className="card overflow-hidden">
-                    <table className="w-full text-left">
-                        <thead className="bg-surface-50 dark:bg-surface-800 text-xs uppercase text-surface-500">
-                            <tr>
-                                <th className="px-4 py-3">Student</th>
-                                <th className="px-4 py-3">Exam</th>
-                                <th className="px-4 py-3">Status</th>
-                                <th className="px-4 py-3 text-right">Action</th>
-                            </tr>
-                        </thead>
-                        <tbody className="divide-y divide-surface-100 dark:divide-surface-700">
-                            {list.map((r) => (
-                                <tr key={r.id}>
-                                    <td className="px-4 py-3">
-                                        <p className="font-medium">{r.student_name || '—'}</p>
-                                        <p className="text-xs text-surface-500">{r.student_email}</p>
-                                    </td>
-                                    <td className="px-4 py-3">{r.exam_name} <span className="text-xs text-surface-400">{r.exam_code}</span></td>
-                                    <td className="px-4 py-3">
-                                        <span className={`px-2.5 py-1 rounded-full text-xs font-semibold capitalize ${badge[r.status]}`}>{r.status}</span>
-                                    </td>
-                                    <td className="px-4 py-3">
-                                        {r.status === 'pending' ? (
-                                            <div className="flex items-center justify-end gap-2">
-                                                <button onClick={() => approve(r.id)} disabled={busyId === r.id}
-                                                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 disabled:opacity-50">
-                                                    <Check size={14} /> Approve
-                                                </button>
-                                                <button onClick={() => reject(r.id)} disabled={busyId === r.id}
-                                                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-500 text-white text-sm font-semibold hover:bg-red-600 disabled:opacity-50">
-                                                    <XCircle size={14} /> Reject
-                                                </button>
-                                            </div>
-                                        ) : r.status === 'rejected' ? (
-                                            <button onClick={() => approve(r.id)} disabled={busyId === r.id}
-                                                className="text-sm text-green-600 hover:underline">Approve anyway</button>
-                                        ) : (
-                                            <span className="text-sm text-surface-400">—</span>
-                                        )}
-                                    </td>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-left">
+                            <thead className="bg-surface-50 dark:bg-surface-800 text-xs uppercase text-surface-500">
+                                <tr>
+                                    <th className="px-4 py-3">Student</th>
+                                    <th className="px-4 py-3">Exam</th>
+                                    <th className="px-4 py-3">Status</th>
+                                    <th className="px-4 py-3 text-right">Action</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody className="divide-y divide-surface-100 dark:divide-surface-700">
+                                {list.map((r) => (
+                                    <tr key={r.id}>
+                                        <td className="px-4 py-3">
+                                            <p className="font-medium">{r.student_name || '—'}</p>
+                                            <p className="text-xs text-surface-500">{r.student_email}</p>
+                                        </td>
+                                        <td className="px-4 py-3 whitespace-nowrap">{r.exam_name} <span className="text-xs text-surface-400">{r.exam_code}</span></td>
+                                        <td className="px-4 py-3">
+                                            <span className={`px-2.5 py-1 rounded-full text-xs font-semibold capitalize ${badge[r.status]}`}>{r.status}</span>
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            {r.status === 'pending' ? (
+                                                <div className="flex items-center justify-end gap-2">
+                                                    <button onClick={() => approve(r.id)} disabled={busyId === r.id} className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 disabled:opacity-50">
+                                                        <Check size={14} /> Approve
+                                                    </button>
+                                                    <button onClick={() => reject(r.id)} disabled={busyId === r.id} className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-red-500 text-white text-sm font-semibold hover:bg-red-600 disabled:opacity-50">
+                                                        <XCircle size={14} /> Reject
+                                                    </button>
+                                                </div>
+                                            ) : r.status === 'rejected' ? (
+                                                <div className="text-right">
+                                                    <button onClick={() => approve(r.id)} disabled={busyId === r.id} className="text-sm text-green-600 hover:underline">Approve anyway</button>
+                                                </div>
+                                            ) : (
+                                                <div className="text-right"><span className="text-sm text-surface-400">—</span></div>
+                                            )}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             )}
         </div>
     )
 }
 
+/* ---------------------------------------------------------------------------
+ * Overview
+ * ------------------------------------------------------------------------- */
+const Overview = ({ stats }) => (
+    <div className="space-y-6 sm:space-y-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
+            <StatCard title="Total Students" value={stats?.total_students || 0} icon={Users} color="bg-blue-500" description="Registered locally" />
+            <StatCard title="Active Today" value={stats?.active_today || 0} icon={Zap} color="bg-amber-500" description="Student engagement" />
+            <StatCard title="Avg. Accuracy" value={`${stats?.avg_accuracy || 0}%`} icon={CheckCircle2} color="bg-emerald-500" description="Target score performance" />
+            <StatCard title="Total XP Distributed" value={stats?.total_xp?.toLocaleString() || 0} icon={TrendingUp} color="bg-purple-500" description="Collective progress" />
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8">
+            <div className="card p-5 sm:p-6">
+                <h3 className="text-lg font-bold mb-6">Student Level Distribution</h3>
+                <div className="space-y-4">
+                    {Object.entries(stats?.level_distribution || {}).map(([level, count]) => {
+                        const percentage = stats?.total_students > 0 ? (count / stats.total_students) * 100 : 0
+                        return (
+                            <div key={level} className="space-y-2">
+                                <div className="flex justify-between text-sm">
+                                    <span className="font-medium text-surface-700 dark:text-surface-300">Level {level}</span>
+                                    <span className="text-surface-500">{count} students ({Math.round(percentage)}%)</span>
+                                </div>
+                                <div className="h-2 bg-surface-100 dark:bg-surface-800 rounded-full overflow-hidden">
+                                    <motion.div initial={{ width: 0 }} animate={{ width: `${percentage}%` }} className="h-full bg-primary-500" />
+                                </div>
+                            </div>
+                        )
+                    })}
+                    {Object.keys(stats?.level_distribution || {}).length === 0 && (
+                        <p className="text-center text-surface-500 py-8 italic">No institutional participation data yet.</p>
+                    )}
+                </div>
+            </div>
+
+            <div className="card p-5 sm:p-6">
+                <h3 className="text-lg font-bold mb-6 flex items-center justify-between">
+                    <span>30-Day Student Activity</span>
+                    <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-surface-400 font-bold">
+                        <div className="w-2 h-2 rounded-full bg-primary-500"></div> Active Users
+                    </div>
+                </h3>
+                <div className="relative h-56 sm:h-64">
+                    <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
+                        {[...Array(5)].map((_, i) => <div key={i} className="w-full border-t border-surface-100 dark:border-surface-800/50 h-0"></div>)}
+                    </div>
+                    <div className="relative h-full flex items-end gap-1 px-2">
+                        {(() => {
+                            const trend = stats?.activity_trend || []
+                            const maxUsers = Math.max(...trend.map((i) => i.active_users), 1)
+                            return trend.map((item) => {
+                                const height = (item.active_users / maxUsers) * 100
+                                return (
+                                    <div key={item.date} className="group relative flex-1 h-full flex flex-col justify-end items-center">
+                                        <div className="absolute inset-x-0 bottom-0 top-0 bg-primary-500/5 opacity-0 group-hover:opacity-100 transition-opacity rounded-t-lg"></div>
+                                        <motion.div initial={{ height: 0 }} animate={{ height: `${height}%` }} className="w-1.5 md:w-2.5 bg-gradient-to-t from-primary-600 to-primary-400 rounded-full relative z-10 shadow-sm" />
+                                        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-4 hidden group-hover:block z-50">
+                                            <div className="bg-surface-900 dark:bg-surface-800 text-white p-2 rounded-xl shadow-2xl border border-surface-700/50 whitespace-nowrap">
+                                                <div className="text-[8px] uppercase tracking-tighter text-surface-400 font-black mb-0.5">{item.date}</div>
+                                                <div className="text-sm font-black flex items-center gap-1.5"><div className="w-1.5 h-1.5 rounded-full bg-primary-400"></div>{item.active_users} Users</div>
+                                            </div>
+                                            <div className="w-2 h-2 bg-surface-900 dark:bg-surface-800 rotate-45 absolute -bottom-1 left-1/2 -translate-x-1/2 border-r border-b border-surface-700/50"></div>
+                                        </div>
+                                    </div>
+                                )
+                            })
+                        })()}
+                        {(!stats?.activity_trend || stats.activity_trend.length === 0) && (
+                            <div className="absolute inset-0 flex items-center justify-center text-surface-500 italic text-sm">No activity trend data recorded.</div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+)
+
+/* ---------------------------------------------------------------------------
+ * AdminDashboard (root)
+ * ------------------------------------------------------------------------- */
+const TABS = [
+    { id: 'overview', label: 'Overview', icon: TrendingUp },
+    { id: 'students', label: 'Student Records', icon: Users },
+    { id: 'enrollments', label: 'Enrollments', icon: GraduationCap },
+    { id: 'performance', label: 'Reports', icon: BarChart3 },
+    { id: 'content', label: 'Content', icon: Library },
+]
+
 const AdminDashboard = () => {
     const [activeTab, setActiveTab] = useState('overview')
+    const queryClient = useQueryClient()
 
-    const { data: stats, isLoading, error } = useQuery({
+    const { data: stats, isLoading, error, isFetching } = useQuery({
         queryKey: ['tenantAdminStats'],
         queryFn: () => analyticsService.getTenantAdminStats(),
-        refreshInterval: 60000,
+        refetchInterval: 60000,
     })
+
+    useEffect(() => { window.scrollTo(0, 0) }, [activeTab])
+
+    const refreshAll = () => {
+        queryClient.invalidateQueries()
+        toast.success('Dashboard refreshed')
+    }
 
     if (isLoading) {
         return (
@@ -738,193 +1199,53 @@ const AdminDashboard = () => {
 
     if (error) {
         return (
-            <div className="alert alert-error">
-                Failed to load admin statistics. Please ensure you have administrator privileges.
+            <div className="max-w-2xl mx-auto card p-8 text-center space-y-3">
+                <ShieldOff className="w-10 h-10 mx-auto text-rose-500" />
+                <h2 className="text-lg font-bold text-surface-900 dark:text-white">Unable to load dashboard</h2>
+                <p className="text-surface-500 text-sm">Failed to load admin statistics. Please ensure you have administrator privileges.</p>
             </div>
         )
     }
 
     return (
-        <div className="space-y-8">
-            {/* Header Section */}
-            <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-                <div>
-                    <h1 className="text-3xl font-bold text-surface-900 dark:text-white">Admin Dashboard</h1>
-                    <p className="text-surface-500 mt-1">Manage your institution and track student performance</p>
-                </div>
-
-                <div className="flex items-center gap-3">
-                    <div className="p-1 px-3 py-1.5 rounded-full bg-primary-50 dark:bg-primary-900/30 border border-primary-100 dark:border-primary-800 text-xs font-medium text-primary-600 dark:text-primary-400">
-                        Institutional Admin
+        <div className="space-y-6 sm:space-y-8 max-w-7xl mx-auto">
+            {/* Header */}
+            <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary-600 via-primary-600 to-primary-700 p-6 sm:p-8 text-white shadow-lg shadow-primary-500/20">
+                <div className="absolute -right-10 -top-10 w-48 h-48 bg-white/10 rounded-full blur-2xl" />
+                <div className="absolute -right-4 bottom-0 w-32 h-32 bg-white/5 rounded-full blur-xl" />
+                <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                    <div>
+                        <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/15 text-xs font-semibold mb-3">
+                            <Shield className="w-3.5 h-3.5" /> Institutional Admin
+                        </div>
+                        <h1 className="text-2xl sm:text-3xl font-bold">Admin Dashboard</h1>
+                        <p className="text-white/80 mt-1 text-sm sm:text-base">Manage student records and track institutional performance</p>
                     </div>
+                    <button onClick={refreshAll} className="self-start sm:self-auto inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
+                        <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} /> Refresh
+                    </button>
                 </div>
             </div>
 
             {/* Tabs */}
-            <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-xl w-fit">
-                {[
-                    { id: 'overview', label: 'Overview', icon: TrendingUp },
-                    { id: 'students', label: 'User Management', icon: Users },
-                    { id: 'enrollments', label: 'Enrollment Requests', icon: GraduationCap },
-                    { id: 'performance', label: 'Performance Reports', icon: BarChart3 },
-                    { id: 'content', label: 'Content Explorer', icon: Library },
-                ].map((tab) => (
-                    <button
-                        key={tab.id}
-                        onClick={() => setActiveTab(tab.id)}
-                        className={`px-6 py-2 rounded-lg text-sm font-bold transition-all flex items-center gap-2 ${activeTab === tab.id
-                            ? 'bg-white dark:bg-surface-700 text-primary-600 dark:text-primary-400 shadow-sm'
-                            : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'
-                            }`}
-                    >
-                        <tab.icon className="w-4 h-4" />
-                        {tab.label}
-                    </button>
-                ))}
+            <div className="overflow-x-auto -mx-1 px-1">
+                <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-xl w-max min-w-full sm:w-fit sm:min-w-0">
+                    {TABS.map((tab) => (
+                        <button
+                            key={tab.id}
+                            onClick={() => setActiveTab(tab.id)}
+                            className={`px-4 sm:px-6 py-2 rounded-lg text-sm font-bold transition-all flex items-center gap-2 whitespace-nowrap ${activeTab === tab.id ? 'bg-white dark:bg-surface-700 text-primary-600 dark:text-primary-400 shadow-sm' : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'}`}
+                        >
+                            <tab.icon className="w-4 h-4" />
+                            {tab.label}
+                        </button>
+                    ))}
+                </div>
             </div>
 
             <AnimatePresence mode="wait">
-                <motion.div
-                    key={activeTab}
-                    initial={{ opacity: 0, x: 10 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: -10 }}
-                    transition={{ duration: 0.2 }}
-                >
-                    {activeTab === 'overview' && (
-                        <div className="space-y-8">
-                            {/* Main Stats */}
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                                <StatCard
-                                    title="Total Students"
-                                    value={stats?.total_students || 0}
-                                    icon={Users}
-                                    color="bg-blue-500"
-                                    description="Registered locally"
-                                />
-                                <StatCard
-                                    title="Active Today"
-                                    value={stats?.active_today || 0}
-                                    icon={Zap}
-                                    color="bg-amber-500"
-                                    description="Student engagement"
-                                />
-                                <StatCard
-                                    title="Avg. Accuracy"
-                                    value={`${stats?.avg_accuracy || 0}%`}
-                                    icon={CheckCircle2}
-                                    color="bg-emerald-500"
-                                    description="Target score performance"
-                                />
-                                <StatCard
-                                    title="Total XP Distributed"
-                                    value={stats?.total_xp?.toLocaleString() || 0}
-                                    icon={TrendingUp}
-                                    color="bg-purple-500"
-                                    description="Collective progress"
-                                />
-                            </div>
-
-                            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                                {/* Level Distribution */}
-                                <div className="card p-6">
-                                    <h3 className="text-lg font-bold mb-6">Student Level Distribution</h3>
-                                    <div className="space-y-4">
-                                        {Object.entries(stats?.level_distribution || {}).map(([level, count]) => {
-                                            const percentage = stats?.total_students > 0
-                                                ? (count / stats.total_students) * 100
-                                                : 0
-
-                                            return (
-                                                <div key={level} className="space-y-2">
-                                                    <div className="flex justify-between text-sm">
-                                                        <span className="font-medium text-surface-700 dark:text-surface-300">Level {level}</span>
-                                                        <span className="text-surface-500">{count} students ({Math.round(percentage)}%)</span>
-                                                    </div>
-                                                    <div className="h-2 bg-surface-100 dark:bg-surface-800 rounded-full overflow-hidden">
-                                                        <motion.div
-                                                            initial={{ width: 0 }}
-                                                            animate={{ width: `${percentage}%` }}
-                                                            className="h-full bg-primary-500"
-                                                        />
-                                                    </div>
-                                                </div>
-                                            )
-                                        })}
-                                        {Object.keys(stats?.level_distribution || {}).length === 0 && (
-                                            <p className="text-center text-surface-500 py-8 italic">No institutional participation data yet.</p>
-                                        )}
-                                    </div>
-                                </div>
-
-                                {/* Performance Trend */}
-                                <div className="card p-6">
-                                    <h3 className="text-lg font-bold mb-6 flex items-center justify-between">
-                                        <span>30-Day Student Activity</span>
-                                        <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-surface-400 font-bold">
-                                            <div className="w-2 h-2 rounded-full bg-primary-500"></div>
-                                            Active Users
-                                        </div>
-                                    </h3>
-
-                                    <div className="relative h-64">
-                                        {/* Background Grid Lines */}
-                                        <div className="absolute inset-0 flex flex-col justify-between pointer-events-none">
-                                            {[...Array(5)].map((_, i) => (
-                                                <div key={i} className="w-full border-t border-surface-100 dark:border-surface-800/50 h-0"></div>
-                                            ))}
-                                        </div>
-
-                                        <div className="relative h-full flex items-end gap-1 px-2">
-                                            {(() => {
-                                                const trend = stats?.activity_trend || []
-                                                const maxUsers = Math.max(...trend.map(i => i.active_users), 1)
-
-                                                return trend.map((item) => {
-                                                    const height = (item.active_users / maxUsers) * 100
-                                                    return (
-                                                        <div
-                                                            key={item.date}
-                                                            className="group relative flex-1 h-full flex flex-col justify-end items-center"
-                                                        >
-                                                            {/* Ghost Bar (Background) */}
-                                                            <div className="absolute inset-x-0 bottom-0 top-0 bg-primary-500/5 opacity-0 group-hover:opacity-100 transition-opacity rounded-t-lg"></div>
-
-                                                            {/* Actual Data Bar */}
-                                                            <motion.div
-                                                                initial={{ height: 0 }}
-                                                                animate={{ height: `${height}%` }}
-                                                                className="w-1.5 md:w-2.5 bg-gradient-to-t from-primary-600 to-primary-400 rounded-full relative z-10 shadow-sm"
-                                                            />
-
-                                                            {/* Tooltip */}
-                                                            <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-4 hidden group-hover:block z-50">
-                                                                <div className="bg-surface-900 dark:bg-surface-800 text-white p-2 rounded-xl shadow-2xl border border-surface-700/50 whitespace-nowrap">
-                                                                    <div className="text-[8px] uppercase tracking-tighter text-surface-400 font-black mb-0.5">{item.date}</div>
-                                                                    <div className="text-sm font-black flex items-center gap-1.5">
-                                                                        <div className="w-1.5 h-1.5 rounded-full bg-primary-400"></div>
-                                                                        {item.active_users} Users
-                                                                    </div>
-                                                                </div>
-                                                                <div className="w-2 h-2 bg-surface-900 dark:bg-surface-800 rotate-45 absolute -bottom-1 left-1/2 -translate-x-1/2 border-r border-b border-surface-700/50"></div>
-                                                            </div>
-                                                        </div>
-                                                    )
-                                                })
-                                            })()}
-
-                                            {(!stats?.activity_trend || stats.activity_trend.length === 0) && (
-                                                <div className="absolute inset-0 flex items-center justify-center text-surface-500 italic text-sm">
-                                                    No activity trend data recorded.
-                                                </div>
-                                            )}
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    )}
-
+                <motion.div key={activeTab} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.2 }}>
+                    {activeTab === 'overview' && <Overview stats={stats} />}
                     {activeTab === 'students' && <StudentManagement />}
                     {activeTab === 'enrollments' && <EnrollmentRequests />}
                     {activeTab === 'performance' && <PerformanceReports />}

--- a/frontend/exam-frontend/src/services/tenantAdminService.js
+++ b/frontend/exam-frontend/src/services/tenantAdminService.js
@@ -3,7 +3,11 @@ import api from './api'
 export const tenantAdminService = {
     // Student Management
     getStudents: async (params = {}) => {
-        const response = await api.get('/auth/tenant-students/', { params })
+        // Pull the full institution roster (high page_size) so search, filters
+        // and CSV export operate over every student, not just the first page.
+        const response = await api.get('/auth/tenant-students/', {
+            params: { page_size: 5000, ...params },
+        })
         return response.data
     },
 


### PR DESCRIPTION
## Why

The admin dashboard is meant to let institutions manage and keep records of their students, but it was limited: admins could only toggle status, reset progress, and change role. They could not edit a student's actual metadata, and there was no real way to look up or export records. This redesign turns the Student Records tab into a functional record-management tool and gives the whole dashboard a professional, responsive feel.

## What changed

**Full student metadata editing**
- New `StudentEditModal` lets admins edit any field on a student: name, phone, role, date of birth, bio, Instagram, parent contact, grade, school, coaching, board, medium, target year, primary exam, city, state, daily study goal, and preferred study time.
- Wired to the existing `PATCH /auth/tenant-students/{id}/` endpoint (nested user + profile update). Dropdown options are kept in sync with the backend model choices, so no backend serializer changes were needed for editing.

**Search, filters, and record export**
- Search by name, email, or phone with a clear button.
- Filters for role, account status (active/suspended), and primary exam, plus sorting by name, email, XP, accuracy, or level.
- CSV export of the currently filtered records for institutional record-keeping, with a live "Showing X of Y students" count and a clear-filters action.

**Records work across the whole roster (the important backend fix)**
- The dashboard does search/filter/export client-side, but DRF's global `PAGE_SIZE=20` meant `getStudents()` only ever returned the first 20 students, so records past page 1 were invisible. Global `SearchFilter` was enabled but the viewset declared no `search_fields`, so server-side search did not work either.
- Added `StudentRecordsPagination` (default page size 100, `?page_size=` override up to 5000) on `TenantStudentViewSet`.
- Enabled `SearchFilter` (email, name, phone, school, coaching, city, state) and `OrderingFilter`, plus explicit `role`, `status`, and `primary_exam` query filters.
- The frontend now requests the full roster so client-side search/filter/export cover every student.

**Professional, responsive UX**
- Gradient header with an Institutional Admin badge and a Refresh control.
- Desktop table plus a dedicated mobile card layout; tabs scroll horizontally on small screens; responsive grids throughout.
- Replaced blocking `alert()` calls with react-hot-toast notifications (already mounted app-wide). Destructive actions still confirm first.

## Notes for reviewers

- No database migration is required; the backend changes are view-layer config only.
- Verified with `manage.py check` in a fresh virtualenv (search/ordering/pagination wiring valid) and a clean frontend `npm run build`.