### PR TITLE
Add Exam Content Builder with full admin CRUD

### DIFF
--- a/backend/content/admin_serializers.py
+++ b/backend/content/admin_serializers.py
@@ -1,0 +1,68 @@
+"""
+Writable serializer for admin content management in the Content Builder.
+"""
+from django.utils.text import slugify
+from rest_framework import serializers
+
+from .models import Content
+from exams.models import Exam
+
+
+class AdminContentSerializer(serializers.ModelSerializer):
+    """Full CRUD serializer for Content with automatic slug handling."""
+    topic_name = serializers.CharField(source='topic.name', read_only=True)
+    subject_name = serializers.CharField(source='subject.name', read_only=True)
+    exams = serializers.PrimaryKeyRelatedField(
+        queryset=Exam.objects.all(), many=True, required=False
+    )
+
+    class Meta:
+        model = Content
+        fields = [
+            'id', 'title', 'slug', 'description', 'content_type',
+            'topic', 'topic_name', 'subject', 'subject_name', 'exams',
+            'content_html', 'video_url', 'video_duration_minutes',
+            'difficulty', 'status', 'is_free', 'is_premium',
+            'estimated_time_minutes', 'order', 'author_name',
+            'views_count', 'likes_count', 'bookmarks_count',
+            'created_at', 'updated_at',
+        ]
+        read_only_fields = [
+            'id', 'slug', 'views_count', 'likes_count', 'bookmarks_count',
+            'created_at', 'updated_at',
+        ]
+
+    def _unique_slug(self, title, instance=None):
+        base = slugify(title) or 'content'
+        slug = base
+        i = 1
+        qs = Content.objects.all()
+        if instance is not None:
+            qs = qs.exclude(pk=instance.pk)
+        while qs.filter(slug=slug).exists():
+            i += 1
+            slug = f"{base}-{i}"
+        return slug
+
+    def _default_exams(self, validated_data):
+        """If no exams supplied, inherit from the subject's exam."""
+        subject = validated_data.get('subject')
+        if subject and getattr(subject, 'exam_id', None):
+            return [subject.exam]
+        return []
+
+    def create(self, validated_data):
+        exams = validated_data.pop('exams', None)
+        validated_data['slug'] = self._unique_slug(validated_data.get('title', ''))
+        content = super().create(validated_data)
+        content.exams.set(exams if exams else self._default_exams(validated_data))
+        return content
+
+    def update(self, instance, validated_data):
+        exams = validated_data.pop('exams', None)
+        if 'title' in validated_data and validated_data['title'] != instance.title:
+            validated_data['slug'] = self._unique_slug(validated_data['title'], instance)
+        content = super().update(instance, validated_data)
+        if exams is not None:
+            content.exams.set(exams)
+        return content

--- a/backend/content/admin_views.py
+++ b/backend/content/admin_views.py
@@ -1,0 +1,21 @@
+"""
+Admin CRUD view for Content in the Content Builder.
+Tenant-admin only, scoped via the subject's exam tenant.
+"""
+from rest_framework import filters
+from django_filters.rest_framework import DjangoFilterBackend
+
+from exams.admin_views import TenantAdminModelViewSet
+from .models import Content
+from .admin_serializers import AdminContentSerializer
+
+
+class AdminContentViewSet(TenantAdminModelViewSet):
+    queryset = Content.objects.select_related('topic', 'subject').all()
+    serializer_class = AdminContentSerializer
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    filterset_fields = ['topic', 'subject', 'content_type', 'difficulty', 'status', 'is_free']
+    search_fields = ['title', 'description']
+    ordering_fields = ['order', 'created_at', 'views_count', 'title']
+    ordering = ['order', '-created_at']
+    tenant_lookup = 'subject__exam__tenant'

--- a/backend/content/urls.py
+++ b/backend/content/urls.py
@@ -7,6 +7,10 @@ from .views import (
     ContentViewSet, ContentProgressViewSet,
     StudyPlanViewSet, StudyPlanItemViewSet
 )
+from .admin_views import AdminContentViewSet
+
+admin_router = DefaultRouter()
+admin_router.register(r'contents', AdminContentViewSet, basename='admin-content')
 
 router = DefaultRouter()
 router.register(r'', ContentViewSet, basename='content')
@@ -15,6 +19,7 @@ router.register(r'study-plans', StudyPlanViewSet, basename='study-plan')
 router.register(r'study-plan-items', StudyPlanItemViewSet, basename='study-plan-item')
 
 urlpatterns = [
+    path('admin/', include(admin_router.urls)),
     path('', include(router.urls)),
 ]
 

--- a/backend/exams/admin_serializers.py
+++ b/backend/exams/admin_serializers.py
@@ -1,0 +1,107 @@
+"""
+Writable serializers for the admin Exam Content Builder.
+
+These power full CRUD over the content hierarchy:
+Exam -> Subject -> Chapter -> Topic -> Content.
+"""
+from rest_framework import serializers
+from .models import Exam, Subject, Topic, Chapter, ChapterTopic
+
+
+class AdminExamSerializer(serializers.ModelSerializer):
+    """Writable serializer for Exam in the content builder."""
+    subjects_count = serializers.IntegerField(source='subjects.count', read_only=True)
+
+    class Meta:
+        model = Exam
+        fields = [
+            'id', 'name', 'code', 'description', 'exam_type',
+            'color', 'status', 'is_featured',
+            'duration_minutes', 'total_marks', 'negative_marking',
+            'negative_marking_ratio', 'total_students', 'total_questions',
+            'subjects_count', 'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'total_students', 'total_questions', 'created_at', 'updated_at']
+
+
+class AdminSubjectSerializer(serializers.ModelSerializer):
+    """Writable serializer for Subject."""
+    exam_name = serializers.CharField(source='exam.name', read_only=True)
+    topics_count = serializers.IntegerField(source='topics.count', read_only=True)
+    chapters_count = serializers.IntegerField(source='chapters.count', read_only=True)
+
+    class Meta:
+        model = Subject
+        fields = [
+            'id', 'name', 'code', 'description', 'icon', 'color',
+            'exam', 'exam_name', 'weightage', 'order',
+            'topics_count', 'chapters_count', 'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class AdminChapterSerializer(serializers.ModelSerializer):
+    """Writable serializer for Chapter."""
+    subject_name = serializers.CharField(source='subject.name', read_only=True)
+    topics_count = serializers.IntegerField(source='topics.count', read_only=True)
+
+    class Meta:
+        model = Chapter
+        fields = [
+            'id', 'name', 'code', 'description', 'subject', 'subject_name',
+            'grade', 'book_reference', 'estimated_hours', 'order',
+            'topics_count', 'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class AdminTopicSerializer(serializers.ModelSerializer):
+    """Writable serializer for Topic.
+
+    Supports an optional ``chapter`` write field so admins can create a topic
+    directly inside a chapter (a ChapterTopic link is created/maintained).
+    """
+    subject_name = serializers.CharField(source='subject.name', read_only=True)
+    content_count = serializers.IntegerField(source='contents.count', read_only=True)
+    chapter = serializers.PrimaryKeyRelatedField(
+        queryset=Chapter.objects.all(), required=False, allow_null=True, write_only=True
+    )
+    chapter_ids = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Topic
+        fields = [
+            'id', 'name', 'code', 'description', 'subject', 'subject_name',
+            'parent_topic', 'difficulty', 'importance', 'estimated_study_hours',
+            'order', 'total_questions', 'content_count', 'chapter', 'chapter_ids',
+            'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'total_questions', 'created_at', 'updated_at']
+
+    def get_chapter_ids(self, obj):
+        return [str(ct.chapter_id) for ct in obj.chapter_topics.all()]
+
+    def _link_chapter(self, topic, chapter):
+        if not chapter:
+            return
+        last = ChapterTopic.objects.filter(chapter=chapter).order_by('-order').first()
+        ChapterTopic.objects.get_or_create(
+            chapter=chapter,
+            topic=topic,
+            defaults={
+                'order': (last.order + 1) if last else 0,
+                'tenant': getattr(topic, 'tenant', None),
+            },
+        )
+
+    def create(self, validated_data):
+        chapter = validated_data.pop('chapter', None)
+        topic = super().create(validated_data)
+        self._link_chapter(topic, chapter)
+        return topic
+
+    def update(self, instance, validated_data):
+        chapter = validated_data.pop('chapter', None)
+        topic = super().update(instance, validated_data)
+        self._link_chapter(topic, chapter)
+        return topic

--- a/backend/exams/admin_views.py
+++ b/backend/exams/admin_views.py
@@ -1,0 +1,111 @@
+"""
+Admin CRUD views for the Exam Content Builder.
+
+All endpoints are restricted to tenant admins and scoped to the current tenant
+via the Exam relationship (child rows may have a null ``tenant`` in legacy data,
+so we always scope through ``exam``).
+"""
+from rest_framework import viewsets, filters, status
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
+from django_filters.rest_framework import DjangoFilterBackend
+
+from core.permissions import IsTenantAdmin
+from .models import Exam, Subject, Topic, Chapter, ChapterTopic
+from .admin_serializers import (
+    AdminExamSerializer, AdminSubjectSerializer,
+    AdminChapterSerializer, AdminTopicSerializer,
+)
+
+
+class BuilderPagination(PageNumberPagination):
+    """Larger pages for the content builder; client may override via page_size."""
+    page_size = 200
+    page_size_query_param = 'page_size'
+    max_page_size = 2000
+
+
+class TenantAdminModelViewSet(viewsets.ModelViewSet):
+    """Base CRUD viewset: tenant-admin only, tenant-scoped, searchable."""
+    permission_classes = [IsTenantAdmin]
+    pagination_class = BuilderPagination
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['name', 'code']
+    ordering_fields = ['order', 'name', 'created_at']
+    ordering = ['order', 'name']
+
+    # Lookup path from the model to the owning Exam's tenant.
+    tenant_lookup = 'tenant'
+
+    def _tenant(self):
+        return getattr(self.request, 'tenant', None)
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        tenant = self._tenant()
+        if not tenant:
+            return qs.none()
+        return qs.filter(**{self.tenant_lookup: tenant})
+
+    def perform_create(self, serializer):
+        serializer.save(tenant=self._tenant())
+
+    @action(detail=False, methods=['post'])
+    def reorder(self, request):
+        """Persist a new ordering. Body: {"order": [id1, id2, ...]}."""
+        ids = request.data.get('order', [])
+        qs = self.get_queryset()
+        lookup = {str(obj.id): obj for obj in qs.filter(id__in=ids)}
+        updated = []
+        for index, obj_id in enumerate(ids):
+            obj = lookup.get(str(obj_id))
+            if obj is not None:
+                obj.order = index
+                updated.append(obj)
+        if updated:
+            type(updated[0]).objects.bulk_update(updated, ['order'])
+        return Response({'updated': len(updated)})
+
+
+class AdminExamViewSet(TenantAdminModelViewSet):
+    queryset = Exam.objects.all().order_by('name')
+    serializer_class = AdminExamSerializer
+    filterset_fields = ['exam_type', 'status', 'is_featured']
+    tenant_lookup = 'tenant'
+    ordering = ['name']
+
+
+class AdminSubjectViewSet(TenantAdminModelViewSet):
+    queryset = Subject.objects.select_related('exam').all()
+    serializer_class = AdminSubjectSerializer
+    filterset_fields = ['exam']
+    tenant_lookup = 'exam__tenant'
+
+
+class AdminChapterViewSet(TenantAdminModelViewSet):
+    queryset = Chapter.objects.select_related('subject').all()
+    serializer_class = AdminChapterSerializer
+    filterset_fields = ['subject', 'grade']
+    tenant_lookup = 'subject__exam__tenant'
+
+
+class AdminTopicViewSet(TenantAdminModelViewSet):
+    queryset = Topic.objects.select_related('subject').prefetch_related('chapter_topics').all()
+    serializer_class = AdminTopicSerializer
+    filterset_fields = ['subject', 'difficulty', 'importance', 'parent_topic']
+    tenant_lookup = 'subject__exam__tenant'
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        chapter_id = self.request.query_params.get('chapter')
+        if chapter_id:
+            topic_ids = ChapterTopic.objects.filter(
+                chapter_id=chapter_id
+            ).values_list('topic_id', flat=True)
+            qs = qs.filter(id__in=list(topic_ids))
+        return qs
+
+    def perform_destroy(self, instance):
+        ChapterTopic.objects.filter(topic=instance).delete()
+        instance.delete()

--- a/backend/exams/urls.py
+++ b/backend/exams/urls.py
@@ -8,6 +8,16 @@ from .views import (
     StudyExamsView, StudySubjectsView, StudyChaptersView, StudyChapterDetailView,
     StudyLeaderboardView, TenantContentExplorerView, AvailableExamsForEnrollmentView
 )
+from .admin_views import (
+    AdminExamViewSet, AdminSubjectViewSet, AdminChapterViewSet, AdminTopicViewSet,
+)
+
+# Admin Content Builder router (full CRUD, tenant-admin only)
+admin_router = DefaultRouter()
+admin_router.register(r'exams', AdminExamViewSet, basename='admin-exam')
+admin_router.register(r'subjects', AdminSubjectViewSet, basename='admin-subject')
+admin_router.register(r'chapters', AdminChapterViewSet, basename='admin-chapter')
+admin_router.register(r'topics', AdminTopicViewSet, basename='admin-topic')
 
 router = DefaultRouter()
 router.register(r'', ExamViewSet, basename='exam')
@@ -16,6 +26,7 @@ router.register(r'topics', TopicViewSet, basename='topic')
 router.register(r'chapters', ChapterViewSet, basename='chapter')
 
 urlpatterns = [
+    path('admin/', include(admin_router.urls)),
     path('available-for-enrollment/', AvailableExamsForEnrollmentView.as_view(), name='exams-available-for-enrollment'),
     path('study/exams/', StudyExamsView.as_view(), name='study-exams'),
     path('study/subjects/', StudySubjectsView.as_view(), name='study-subjects'),

--- a/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
@@ -1,0 +1,649 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { motion, AnimatePresence } from 'framer-motion'
+import toast from 'react-hot-toast'
+import {
+    Plus, Pencil, Trash2, X, ChevronDown, ChevronRight, Loader2, Save,
+    GraduationCap, Book, Layers, FileText, Hash, AlertTriangle, Search,
+} from 'lucide-react'
+import { contentBuilderService as svc } from '../../services/contentBuilderService'
+
+/* ===========================================================================
+ * Field / form configuration per entity
+ * ========================================================================= */
+const EXAM_TYPES = ['competitive', 'board', 'entrance', 'government']
+const EXAM_STATUS = ['active', 'coming_soon', 'inactive']
+const DIFFICULTY = ['easy', 'medium', 'hard']
+const IMPORTANCE = ['low', 'medium', 'high', 'critical']
+const CONTENT_TYPES = ['notes', 'pdf', 'interactive', 'revision', 'formula']
+const CONTENT_DIFFICULTY = ['beginner', 'intermediate', 'advanced']
+const CONTENT_STATUS = ['draft', 'published', 'archived']
+
+const opt = (arr) => arr.map((v) => ({ value: v, label: v.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) }))
+
+const SCHEMAS = {
+    exam: {
+        title: 'Exam',
+        fields: [
+            { name: 'name', label: 'Name', type: 'text', required: true },
+            { name: 'code', label: 'Code', type: 'text', required: true, hint: 'Unique slug, e.g. neet' },
+            { name: 'exam_type', label: 'Type', type: 'select', options: opt(EXAM_TYPES), default: 'competitive' },
+            { name: 'status', label: 'Status', type: 'select', options: opt(EXAM_STATUS), default: 'active' },
+            { name: 'color', label: 'Color', type: 'color', default: '#3B82F6' },
+            { name: 'duration_minutes', label: 'Duration (min)', type: 'number' },
+            { name: 'total_marks', label: 'Total Marks', type: 'number' },
+            { name: 'is_featured', label: 'Featured', type: 'checkbox' },
+            { name: 'negative_marking', label: 'Negative Marking', type: 'checkbox' },
+            { name: 'description', label: 'Description', type: 'textarea', full: true },
+        ],
+    },
+    subject: {
+        title: 'Subject',
+        fields: [
+            { name: 'name', label: 'Name', type: 'text', required: true },
+            { name: 'code', label: 'Code', type: 'text', required: true },
+            { name: 'weightage', label: 'Weightage (%)', type: 'number', step: '0.01' },
+            { name: 'order', label: 'Order', type: 'number', default: 0 },
+            { name: 'color', label: 'Color', type: 'color', default: '#10B981' },
+            { name: 'icon', label: 'Icon name', type: 'text' },
+            { name: 'description', label: 'Description', type: 'textarea', full: true },
+        ],
+    },
+    chapter: {
+        title: 'Chapter',
+        fields: [
+            { name: 'name', label: 'Name', type: 'text', required: true },
+            { name: 'code', label: 'Code', type: 'text', required: true },
+            { name: 'grade', label: 'Grade', type: 'text', hint: 'e.g. 11, 12' },
+            { name: 'book_reference', label: 'Book Reference', type: 'text' },
+            { name: 'estimated_hours', label: 'Est. Hours', type: 'number', step: '0.1', default: 2 },
+            { name: 'order', label: 'Order', type: 'number', default: 0 },
+            { name: 'description', label: 'Description', type: 'textarea', full: true },
+        ],
+    },
+    topic: {
+        title: 'Topic',
+        fields: [
+            { name: 'name', label: 'Name', type: 'text', required: true },
+            { name: 'code', label: 'Code', type: 'text', required: true },
+            { name: 'difficulty', label: 'Difficulty', type: 'select', options: opt(DIFFICULTY), default: 'medium' },
+            { name: 'importance', label: 'Importance', type: 'select', options: opt(IMPORTANCE), default: 'medium' },
+            { name: 'estimated_study_hours', label: 'Est. Study Hours', type: 'number', step: '0.1', default: 1 },
+            { name: 'order', label: 'Order', type: 'number', default: 0 },
+            { name: 'description', label: 'Description', type: 'textarea', full: true },
+        ],
+    },
+    content: {
+        title: 'Content',
+        fields: [
+            { name: 'title', label: 'Title', type: 'text', required: true, full: true },
+            { name: 'content_type', label: 'Type', type: 'select', options: opt(CONTENT_TYPES), default: 'notes' },
+            { name: 'status', label: 'Status', type: 'select', options: opt(CONTENT_STATUS), default: 'draft' },
+            { name: 'difficulty', label: 'Difficulty', type: 'select', options: opt(CONTENT_DIFFICULTY), default: 'intermediate' },
+            { name: 'estimated_time_minutes', label: 'Read Time (min)', type: 'number', default: 10 },
+            { name: 'order', label: 'Order', type: 'number', default: 0 },
+            { name: 'author_name', label: 'Author', type: 'text' },
+            { name: 'video_url', label: 'Video URL', type: 'text', full: true },
+            { name: 'is_free', label: 'Free', type: 'checkbox' },
+            { name: 'is_premium', label: 'Premium', type: 'checkbox' },
+            { name: 'description', label: 'Description', type: 'textarea', full: true },
+            { name: 'content_html', label: 'Content (HTML)', type: 'textarea', full: true, rows: 10 },
+        ],
+    },
+}
+
+/* ===========================================================================
+ * Generic modal form
+ * ========================================================================= */
+const buildInitial = (fields, instance) => {
+    const out = {}
+    fields.forEach((f) => {
+        let v = instance ? instance[f.name] : undefined
+        if (v === undefined || v === null) v = f.default ?? (f.type === 'checkbox' ? false : '')
+        out[f.name] = v
+    })
+    return out
+}
+
+const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
+    const schema = SCHEMAS[type]
+    const [values, setValues] = useState(() => buildInitial(schema.fields, instance))
+    const isEdit = !!instance
+
+    const set = (name, val) => setValues((p) => ({ ...p, [name]: val }))
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        const payload = {}
+        schema.fields.forEach((f) => {
+            let v = values[f.name]
+            if (f.type === 'number') {
+                v = v === '' || v === null ? null : Number(v)
+                if (v === null && !f.required) return
+            }
+            payload[f.name] = v
+        })
+        onSubmit(payload)
+    }
+
+    return (
+        <motion.div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+            onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+        >
+            <motion.div
+                className="card w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col"
+                initial={{ scale: 0.95, y: 20 }} animate={{ scale: 1, y: 0 }} exit={{ scale: 0.95, y: 20 }}
+            >
+                <div className="flex items-center justify-between p-5 border-b border-surface-200 dark:border-surface-800">
+                    <h3 className="text-lg font-bold text-surface-900 dark:text-white">
+                        {isEdit ? 'Edit' : 'New'} {schema.title}
+                    </h3>
+                    <button onClick={onClose} className="btn-icon"><X className="w-5 h-5" /></button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        {schema.fields.map((f) => (
+                            <div key={f.name} className={f.full || f.type === 'textarea' ? 'sm:col-span-2' : ''}>
+                                {f.type === 'checkbox' ? (
+                                    <label className="flex items-center gap-2 cursor-pointer py-2">
+                                        <input
+                                            type="checkbox"
+                                            checked={!!values[f.name]}
+                                            onChange={(e) => set(f.name, e.target.checked)}
+                                            className="w-4 h-4 rounded accent-primary-500"
+                                        />
+                                        <span className="text-sm font-medium text-surface-700 dark:text-surface-300">{f.label}</span>
+                                    </label>
+                                ) : (
+                                    <>
+                                        <label className="block text-xs font-semibold text-surface-500 mb-1.5">
+                                            {f.label}{f.required && <span className="text-rose-500"> *</span>}
+                                        </label>
+                                        {f.type === 'textarea' ? (
+                                            <textarea
+                                                className="input font-mono text-sm" rows={f.rows || 3}
+                                                value={values[f.name] ?? ''}
+                                                onChange={(e) => set(f.name, e.target.value)}
+                                            />
+                                        ) : f.type === 'select' ? (
+                                            <select className="input" value={values[f.name] ?? ''} onChange={(e) => set(f.name, e.target.value)}>
+                                                {f.options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                                            </select>
+                                        ) : f.type === 'color' ? (
+                                            <div className="flex items-center gap-2">
+                                                <input type="color" value={values[f.name] || '#3B82F6'} onChange={(e) => set(f.name, e.target.value)} className="h-11 w-14 rounded-lg border border-surface-200 dark:border-surface-700 bg-transparent cursor-pointer" />
+                                                <input type="text" className="input" value={values[f.name] ?? ''} onChange={(e) => set(f.name, e.target.value)} />
+                                            </div>
+                                        ) : (
+                                            <input
+                                                type={f.type} step={f.step}
+                                                className="input"
+                                                value={values[f.name] ?? ''}
+                                                onChange={(e) => set(f.name, e.target.value)}
+                                                required={f.required}
+                                            />
+                                        )}
+                                        {f.hint && <p className="text-[11px] text-surface-400 mt-1">{f.hint}</p>}
+                                    </>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="flex justify-end gap-2 pt-2">
+                        <button type="button" onClick={onClose} className="btn-secondary">Cancel</button>
+                        <button type="submit" disabled={saving} className="btn-primary">
+                            {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                            {isEdit ? 'Save Changes' : 'Create'}
+                        </button>
+                    </div>
+                </form>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+/* ===========================================================================
+ * Confirm delete dialog
+ * ========================================================================= */
+const ConfirmDialog = ({ label, onCancel, onConfirm, deleting }) => (
+    <motion.div
+        className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+        initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+        onMouseDown={(e) => e.target === e.currentTarget && onCancel()}
+    >
+        <motion.div className="card w-full max-w-md p-6 text-center" initial={{ scale: 0.95 }} animate={{ scale: 1 }}>
+            <div className="w-12 h-12 rounded-full bg-rose-100 dark:bg-rose-900/30 flex items-center justify-center mx-auto mb-4">
+                <AlertTriangle className="w-6 h-6 text-rose-500" />
+            </div>
+            <h3 className="text-lg font-bold text-surface-900 dark:text-white">Delete {label}?</h3>
+            <p className="text-sm text-surface-500 mt-1">This action cannot be undone. All nested content will be removed.</p>
+            <div className="flex justify-center gap-2 mt-5">
+                <button onClick={onCancel} className="btn-secondary">Cancel</button>
+                <button onClick={onConfirm} disabled={deleting} className="btn bg-rose-500 text-white hover:bg-rose-600">
+                    {deleting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />} Delete
+                </button>
+            </div>
+        </motion.div>
+    </motion.div>
+)
+
+/* ===========================================================================
+ * Small action buttons
+ * ========================================================================= */
+const RowActions = ({ onEdit, onDelete, onAdd, addLabel }) => (
+    <div className="flex items-center gap-1 shrink-0" onClick={(e) => e.stopPropagation()}>
+        {onAdd && (
+            <button onClick={onAdd} title={addLabel} className="p-1.5 rounded-lg text-surface-400 hover:text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-900/20 transition-colors">
+                <Plus className="w-4 h-4" />
+            </button>
+        )}
+        {onEdit && (
+            <button onClick={onEdit} title="Edit" className="p-1.5 rounded-lg text-surface-400 hover:text-primary-600 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors">
+                <Pencil className="w-3.5 h-3.5" />
+            </button>
+        )}
+        {onDelete && (
+            <button onClick={onDelete} title="Delete" className="p-1.5 rounded-lg text-surface-400 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20 transition-colors">
+                <Trash2 className="w-3.5 h-3.5" />
+            </button>
+        )}
+    </div>
+)
+
+/* ===========================================================================
+ * Content rows (leaf level for a topic)
+ * ========================================================================= */
+const ContentList = ({ topic, subjectId, openModal, askDelete }) => {
+    const { data: contents = [], isLoading } = useQuery({
+        queryKey: ['cb-contents', topic.id],
+        queryFn: () => svc.getContents(topic.id),
+    })
+
+    return (
+        <div className="pl-6 sm:pl-9 py-2 space-y-1">
+            <div className="flex items-center justify-between px-2">
+                <span className="text-[10px] font-black uppercase tracking-widest text-surface-400">Content</span>
+                <button
+                    onClick={() => openModal('content', null, { topic: topic.id, subject: subjectId })}
+                    className="text-xs font-semibold text-primary-600 hover:text-primary-700 inline-flex items-center gap-1"
+                >
+                    <Plus className="w-3.5 h-3.5" /> Add Content
+                </button>
+            </div>
+            {isLoading ? (
+                <div className="py-3 flex justify-center"><Loader2 className="w-4 h-4 animate-spin text-surface-400" /></div>
+            ) : contents.length === 0 ? (
+                <p className="text-xs text-surface-400 italic px-2 py-2">No content yet.</p>
+            ) : (
+                contents.map((ct) => (
+                    <div key={ct.id} className="group flex items-center justify-between gap-2 px-2 py-2 rounded-lg hover:bg-surface-50 dark:hover:bg-surface-800/50">
+                        <div className="flex items-center gap-2 min-w-0">
+                            <FileText className="w-3.5 h-3.5 text-surface-400 shrink-0" />
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">{ct.title}</p>
+                                <div className="flex items-center gap-1.5 mt-0.5">
+                                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-100 dark:bg-surface-800 text-surface-500 capitalize">{ct.content_type}</span>
+                                    <span className={`text-[10px] px-1.5 py-0.5 rounded capitalize ${ct.status === 'published' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'}`}>{ct.status}</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+                            <RowActions
+                                onEdit={() => openModal('content', ct, { topic: topic.id, subject: subjectId })}
+                                onDelete={() => askDelete('content', ct, ct.title)}
+                            />
+                        </div>
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+/* ===========================================================================
+ * Topic rows (under a chapter)
+ * ========================================================================= */
+const TopicList = ({ chapter, subjectId, openModal, askDelete }) => {
+    const [expanded, setExpanded] = useState(null)
+    const { data: topics = [], isLoading } = useQuery({
+        queryKey: ['cb-topics', chapter.id],
+        queryFn: () => svc.getTopics({ chapterId: chapter.id }),
+    })
+
+    return (
+        <div className="pl-6 sm:pl-9 py-2 space-y-1">
+            <div className="flex items-center justify-between px-2">
+                <span className="text-[10px] font-black uppercase tracking-widest text-surface-400">Topics</span>
+                <button
+                    onClick={() => openModal('topic', null, { subject: subjectId, chapter: chapter.id })}
+                    className="text-xs font-semibold text-primary-600 hover:text-primary-700 inline-flex items-center gap-1"
+                >
+                    <Plus className="w-3.5 h-3.5" /> Add Topic
+                </button>
+            </div>
+            {isLoading ? (
+                <div className="py-3 flex justify-center"><Loader2 className="w-4 h-4 animate-spin text-surface-400" /></div>
+            ) : topics.length === 0 ? (
+                <p className="text-xs text-surface-400 italic px-2 py-2">No topics yet.</p>
+            ) : (
+                topics.map((tp) => (
+                    <div key={tp.id} className="rounded-lg border border-surface-100 dark:border-surface-800 overflow-hidden">
+                        <div
+                            className="group flex items-center justify-between gap-2 px-2 py-2 cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-800/50"
+                            onClick={() => setExpanded(expanded === tp.id ? null : tp.id)}
+                        >
+                            <div className="flex items-center gap-2 min-w-0">
+                                {expanded === tp.id ? <ChevronDown className="w-3.5 h-3.5 text-surface-400 shrink-0" /> : <ChevronRight className="w-3.5 h-3.5 text-surface-400 shrink-0" />}
+                                <Hash className="w-3.5 h-3.5 text-primary-500 shrink-0" />
+                                <span className="text-sm font-medium text-surface-700 dark:text-surface-200 truncate">{tp.name}</span>
+                                <span className="text-[10px] text-surface-400 shrink-0 hidden sm:inline">{tp.content_count ?? 0} content</span>
+                            </div>
+                            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+                                <RowActions
+                                    onEdit={() => openModal('topic', tp, { subject: subjectId })}
+                                    onDelete={() => askDelete('topic', tp, tp.name)}
+                                />
+                            </div>
+                        </div>
+                        <AnimatePresence>
+                            {expanded === tp.id && (
+                                <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden bg-surface-50/40 dark:bg-surface-900/30 border-t border-surface-100 dark:border-surface-800">
+                                    <ContentList topic={tp} subjectId={subjectId} openModal={openModal} askDelete={askDelete} />
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+/* ===========================================================================
+ * Chapter rows (under a subject)
+ * ========================================================================= */
+const ChapterList = ({ subject, openModal, askDelete }) => {
+    const [expanded, setExpanded] = useState(null)
+    const { data: chapters = [], isLoading } = useQuery({
+        queryKey: ['cb-chapters', subject.id],
+        queryFn: () => svc.getChapters(subject.id),
+    })
+
+    return (
+        <div className="pl-4 sm:pl-6 py-2 space-y-1.5">
+            <div className="flex items-center justify-between px-2">
+                <span className="text-[10px] font-black uppercase tracking-widest text-surface-400">Chapters</span>
+                <button
+                    onClick={() => openModal('chapter', null, { subject: subject.id })}
+                    className="text-xs font-semibold text-primary-600 hover:text-primary-700 inline-flex items-center gap-1"
+                >
+                    <Plus className="w-3.5 h-3.5" /> Add Chapter
+                </button>
+            </div>
+            {isLoading ? (
+                <div className="py-3 flex justify-center"><Loader2 className="w-4 h-4 animate-spin text-surface-400" /></div>
+            ) : chapters.length === 0 ? (
+                <p className="text-xs text-surface-400 italic px-2 py-2">No chapters yet.</p>
+            ) : (
+                chapters.map((ch) => (
+                    <div key={ch.id} className="rounded-xl border border-surface-100 dark:border-surface-800 overflow-hidden bg-white dark:bg-surface-900">
+                        <div
+                            className="group flex items-center justify-between gap-2 px-3 py-2.5 cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-800/50"
+                            onClick={() => setExpanded(expanded === ch.id ? null : ch.id)}
+                        >
+                            <div className="flex items-center gap-2 min-w-0">
+                                {expanded === ch.id ? <ChevronDown className="w-4 h-4 text-surface-400 shrink-0" /> : <ChevronRight className="w-4 h-4 text-surface-400 shrink-0" />}
+                                <Layers className="w-4 h-4 text-indigo-500 shrink-0" />
+                                <span className="text-sm font-semibold text-surface-800 dark:text-surface-100 truncate">{ch.name}</span>
+                                <span className="text-[10px] bg-surface-100 dark:bg-surface-800 px-1.5 py-0.5 rounded-full text-surface-500 shrink-0">{ch.topics_count ?? 0} topics</span>
+                            </div>
+                            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+                                <RowActions
+                                    onEdit={() => openModal('chapter', ch, { subject: subject.id })}
+                                    onDelete={() => askDelete('chapter', ch, ch.name)}
+                                />
+                            </div>
+                        </div>
+                        <AnimatePresence>
+                            {expanded === ch.id && (
+                                <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden border-t border-surface-100 dark:border-surface-800">
+                                    <TopicList chapter={ch} subjectId={subject.id} openModal={openModal} askDelete={askDelete} />
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+/* ===========================================================================
+ * Subject rows (under an exam)
+ * ========================================================================= */
+const SubjectList = ({ examId, openModal, askDelete }) => {
+    const [expanded, setExpanded] = useState(null)
+    const { data: subjects = [], isLoading } = useQuery({
+        queryKey: ['cb-subjects', examId],
+        queryFn: () => svc.getSubjects(examId),
+    })
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold text-surface-700 dark:text-surface-200">Subjects</h3>
+                <button onClick={() => openModal('subject', null, { exam: examId })} className="btn-primary text-sm py-2">
+                    <Plus className="w-4 h-4" /> Add Subject
+                </button>
+            </div>
+            {isLoading ? (
+                <div className="py-8 flex justify-center"><Loader2 className="w-5 h-5 animate-spin text-primary-500" /></div>
+            ) : subjects.length === 0 ? (
+                <div className="card p-8 text-center text-sm text-surface-400 italic">No subjects yet. Add one to get started.</div>
+            ) : (
+                subjects.map((sb) => (
+                    <div key={sb.id} className="card overflow-hidden">
+                        <div
+                            className="group flex items-center justify-between gap-2 p-4 cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-800/40"
+                            onClick={() => setExpanded(expanded === sb.id ? null : sb.id)}
+                        >
+                            <div className="flex items-center gap-3 min-w-0">
+                                {expanded === sb.id ? <ChevronDown className="w-5 h-5 text-surface-400 shrink-0" /> : <ChevronRight className="w-5 h-5 text-surface-400 shrink-0" />}
+                                <div className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0" style={{ background: (sb.color || '#10B981') + '22' }}>
+                                    <Book className="w-4 h-4" style={{ color: sb.color || '#10B981' }} />
+                                </div>
+                                <div className="min-w-0">
+                                    <p className="font-bold text-surface-900 dark:text-white truncate">{sb.name}</p>
+                                    <p className="text-[11px] text-surface-500">{sb.weightage}% weightage • {sb.chapters_count ?? 0} chapters • {sb.topics_count ?? 0} topics</p>
+                                </div>
+                            </div>
+                            <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+                                <RowActions
+                                    onEdit={() => openModal('subject', sb, { exam: examId })}
+                                    onDelete={() => askDelete('subject', sb, sb.name)}
+                                />
+                            </div>
+                        </div>
+                        <AnimatePresence>
+                            {expanded === sb.id && (
+                                <motion.div initial={{ height: 0, opacity: 0 }} animate={{ height: 'auto', opacity: 1 }} exit={{ height: 0, opacity: 0 }} className="overflow-hidden border-t border-surface-200 dark:border-surface-800 bg-surface-50/30 dark:bg-surface-900/20">
+                                    <ChapterList subject={sb} openModal={openModal} askDelete={askDelete} />
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+                    </div>
+                ))
+            )}
+        </div>
+    )
+}
+
+/* ===========================================================================
+ * Root: ContentBuilder
+ * ========================================================================= */
+const SERVICE_MAP = {
+    exam: { create: svc.createExam, update: svc.updateExam, remove: svc.deleteExam },
+    subject: { create: svc.createSubject, update: svc.updateSubject, remove: svc.deleteSubject },
+    chapter: { create: svc.createChapter, update: svc.updateChapter, remove: svc.deleteChapter },
+    topic: { create: svc.createTopic, update: svc.updateTopic, remove: svc.deleteTopic },
+    content: { create: svc.createContent, update: svc.updateContent, remove: svc.deleteContent },
+}
+
+const ContentBuilder = () => {
+    const queryClient = useQueryClient()
+    const [activeExam, setActiveExam] = useState(null)
+    const [search, setSearch] = useState('')
+    const [modal, setModal] = useState(null)   // { type, instance, context }
+    const [confirm, setConfirm] = useState(null) // { type, instance, label }
+
+    const { data: exams = [], isLoading } = useQuery({
+        queryKey: ['cb-exams'],
+        queryFn: svc.getExams,
+    })
+
+    // Auto-select first exam once data is available
+    if (!activeExam && exams.length) setTimeout(() => setActiveExam(exams[0].id), 0)
+
+    const invalidateAll = () => {
+        ['cb-exams', 'cb-subjects', 'cb-chapters', 'cb-topics', 'cb-contents'].forEach((k) =>
+            queryClient.invalidateQueries({ queryKey: [k] })
+        )
+    }
+
+    const saveMutation = useMutation({
+        mutationFn: ({ type, instance, payload }) =>
+            instance ? SERVICE_MAP[type].update(instance.id, payload) : SERVICE_MAP[type].create(payload),
+        onSuccess: (_d, vars) => {
+            toast.success(`${SCHEMAS[vars.type].title} ${vars.instance ? 'updated' : 'created'}`)
+            invalidateAll()
+            setModal(null)
+        },
+        onError: (err) => {
+            const data = err?.response?.data
+            const msg = data && typeof data === 'object'
+                ? Object.entries(data).map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`).join(' | ')
+                : 'Something went wrong'
+            toast.error(msg)
+        },
+    })
+
+    const deleteMutation = useMutation({
+        mutationFn: ({ type, instance }) => SERVICE_MAP[type].remove(instance.id),
+        onSuccess: (_d, vars) => {
+            toast.success(`${SCHEMAS[vars.type].title} deleted`)
+            invalidateAll()
+            setConfirm(null)
+            if (vars.type === 'exam' && vars.instance.id === activeExam) setActiveExam(null)
+        },
+        onError: () => toast.error('Failed to delete'),
+    })
+
+    const openModal = (type, instance, context = {}) => setModal({ type, instance, context })
+    const askDelete = (type, instance, label) => setConfirm({ type, instance, label })
+
+    const handleSubmit = (payload) => {
+        const merged = { ...(modal.context || {}), ...payload }
+        saveMutation.mutate({ type: modal.type, instance: modal.instance, payload: merged })
+    }
+
+    const filteredExams = exams.filter((e) => e.name.toLowerCase().includes(search.toLowerCase()))
+    const activeExamObj = exams.find((e) => e.id === activeExam)
+
+    if (isLoading) {
+        return <div className="py-16 flex justify-center"><Loader2 className="w-7 h-7 animate-spin text-primary-500" /></div>
+    }
+
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <div>
+                    <h2 className="text-xl font-bold text-surface-900 dark:text-white">Content Builder</h2>
+                    <p className="text-sm text-surface-500">Create and manage exams, subjects, chapters, topics &amp; content</p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-400" />
+                        <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search exams…" className="input pl-9 py-2 w-full sm:w-48" />
+                    </div>
+                    <button onClick={() => openModal('exam', null, {})} className="btn-primary py-2 whitespace-nowrap">
+                        <Plus className="w-4 h-4" /> New Exam
+                    </button>
+                </div>
+            </div>
+
+            {exams.length === 0 ? (
+                <div className="card p-12 text-center">
+                    <GraduationCap className="w-10 h-10 mx-auto text-surface-300 mb-3" />
+                    <p className="text-surface-500">No exams yet. Create your first exam to start building content.</p>
+                </div>
+            ) : (
+                <>
+                    {/* Exam selector pills */}
+                    <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+                        {filteredExams.map((ex) => (
+                            <button
+                                key={ex.id}
+                                onClick={() => setActiveExam(ex.id)}
+                                className={`group relative px-4 py-2.5 rounded-2xl text-sm font-semibold whitespace-nowrap border transition-all flex items-center gap-2 ${activeExam === ex.id ? 'bg-primary-500 text-white border-primary-500 shadow-lg shadow-primary-500/25' : 'bg-white dark:bg-surface-900 text-surface-600 dark:text-surface-300 border-surface-200 dark:border-surface-800 hover:border-primary-300'}`}
+                            >
+                                <span className="w-2 h-2 rounded-full" style={{ background: ex.color || '#3B82F6' }} />
+                                {ex.name}
+                                <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${activeExam === ex.id ? 'bg-white/20' : 'bg-surface-100 dark:bg-surface-800'}`}>{ex.subjects_count ?? 0}</span>
+                            </button>
+                        ))}
+                    </div>
+
+                    {activeExamObj && (
+                        <div className="space-y-4">
+                            {/* Exam meta + actions */}
+                            <div className="card p-4 flex items-center justify-between gap-3">
+                                <div className="flex items-center gap-3 min-w-0">
+                                    <div className="w-11 h-11 rounded-2xl flex items-center justify-center shrink-0" style={{ background: (activeExamObj.color || '#3B82F6') + '22' }}>
+                                        <GraduationCap className="w-5 h-5" style={{ color: activeExamObj.color || '#3B82F6' }} />
+                                    </div>
+                                    <div className="min-w-0">
+                                        <p className="font-bold text-surface-900 dark:text-white truncate">{activeExamObj.name}</p>
+                                        <p className="text-[11px] text-surface-500 capitalize">{activeExamObj.exam_type} • {activeExamObj.status?.replace('_', ' ')}</p>
+                                    </div>
+                                </div>
+                                <RowActions
+                                    onEdit={() => openModal('exam', activeExamObj, {})}
+                                    onDelete={() => askDelete('exam', activeExamObj, activeExamObj.name)}
+                                />
+                            </div>
+
+                            <SubjectList examId={activeExam} openModal={openModal} askDelete={askDelete} />
+                        </div>
+                    )}
+                </>
+            )}
+
+            <AnimatePresence>
+                {modal && (
+                    <EntityModal
+                        type={modal.type}
+                        instance={modal.instance}
+                        saving={saveMutation.isPending}
+                        onClose={() => setModal(null)}
+                        onSubmit={handleSubmit}
+                    />
+                )}
+                {confirm && (
+                    <ConfirmDialog
+                        label={confirm.label}
+                        deleting={deleteMutation.isPending}
+                        onCancel={() => setConfirm(null)}
+                        onConfirm={() => deleteMutation.mutate({ type: confirm.type, instance: confirm.instance })}
+                    />
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+export default ContentBuilder

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast'
 import { analyticsService } from '../services/analyticsService'
 import { tenantAdminService } from '../services/tenantAdminService'
 import { examService } from '../services/examService'
+import ContentBuilder from '../components/admin/ContentBuilder'
 import {
     Users,
     GraduationCap,
@@ -1169,7 +1170,7 @@ const TABS = [
     { id: 'students', label: 'Student Records', icon: Users },
     { id: 'enrollments', label: 'Enrollments', icon: GraduationCap },
     { id: 'performance', label: 'Reports', icon: BarChart3 },
-    { id: 'content', label: 'Content', icon: Library },
+    { id: 'content', label: 'Content Builder', icon: Library },
 ]
 
 const AdminDashboard = () => {
@@ -1249,7 +1250,7 @@ const AdminDashboard = () => {
                     {activeTab === 'students' && <StudentManagement />}
                     {activeTab === 'enrollments' && <EnrollmentRequests />}
                     {activeTab === 'performance' && <PerformanceReports />}
-                    {activeTab === 'content' && <ContentManagement />}
+                    {activeTab === 'content' && <ContentBuilder />}
                 </motion.div>
             </AnimatePresence>
         </div>

--- a/frontend/exam-frontend/src/services/contentBuilderService.js
+++ b/frontend/exam-frontend/src/services/contentBuilderService.js
@@ -1,0 +1,55 @@
+import api from './api'
+
+// Unwrap DRF pagination -> always return a plain array
+const list = (res) => {
+  const d = res.data
+  return Array.isArray(d) ? d : d?.results || []
+}
+
+const PAGE = { page_size: 2000 }
+
+/**
+ * Admin Content Builder service.
+ * Full CRUD over the hierarchy: Exam -> Subject -> Chapter -> Topic -> Content.
+ */
+export const contentBuilderService = {
+  // ---- Exams ----
+  getExams: async () => list(await api.get('/exams/admin/exams/', { params: PAGE })),
+  createExam: async (data) => (await api.post('/exams/admin/exams/', data)).data,
+  updateExam: async (id, data) => (await api.patch(`/exams/admin/exams/${id}/`, data)).data,
+  deleteExam: async (id) => api.delete(`/exams/admin/exams/${id}/`),
+
+  // ---- Subjects ----
+  getSubjects: async (examId) =>
+    list(await api.get('/exams/admin/subjects/', { params: { exam: examId, ...PAGE } })),
+  createSubject: async (data) => (await api.post('/exams/admin/subjects/', data)).data,
+  updateSubject: async (id, data) => (await api.patch(`/exams/admin/subjects/${id}/`, data)).data,
+  deleteSubject: async (id) => api.delete(`/exams/admin/subjects/${id}/`),
+
+  // ---- Chapters ----
+  getChapters: async (subjectId) =>
+    list(await api.get('/exams/admin/chapters/', { params: { subject: subjectId, ...PAGE } })),
+  createChapter: async (data) => (await api.post('/exams/admin/chapters/', data)).data,
+  updateChapter: async (id, data) => (await api.patch(`/exams/admin/chapters/${id}/`, data)).data,
+  deleteChapter: async (id) => api.delete(`/exams/admin/chapters/${id}/`),
+
+  // ---- Topics ----
+  getTopics: async ({ chapterId, subjectId }) =>
+    list(
+      await api.get('/exams/admin/topics/', {
+        params: { ...(chapterId ? { chapter: chapterId } : {}), ...(subjectId ? { subject: subjectId } : {}), ...PAGE },
+      })
+    ),
+  createTopic: async (data) => (await api.post('/exams/admin/topics/', data)).data,
+  updateTopic: async (id, data) => (await api.patch(`/exams/admin/topics/${id}/`, data)).data,
+  deleteTopic: async (id) => api.delete(`/exams/admin/topics/${id}/`),
+
+  // ---- Content ----
+  getContents: async (topicId) =>
+    list(await api.get('/content/admin/contents/', { params: { topic: topicId, ...PAGE } })),
+  createContent: async (data) => (await api.post('/content/admin/contents/', data)).data,
+  updateContent: async (id, data) => (await api.patch(`/content/admin/contents/${id}/`, data)).data,
+  deleteContent: async (id) => api.delete(`/content/admin/contents/${id}/`),
+}
+
+export default contentBuilderService


### PR DESCRIPTION
## Overview

Adds an **Exam Content Builder** that lets tenant admins view, create, edit, and delete the entire content hierarchy — **Exam → Subject → Chapter → Topic → Content** — through a seamless, intuitive UI. Changes span both backend and frontend.

## Backend (Django REST)

- **`exams/admin_serializers.py` + `exams/admin_views.py`** — writable, tenant-admin-scoped CRUD viewsets for `Exam`, `Subject`, `Chapter`, and `Topic`:
  - Filtering (`?exam=`, `?subject=`, `?chapter=`), search, ordering, and a `reorder` action.
  - Creating a topic with a `chapter` auto-links it via `ChapterTopic`.
  - Builder-friendly pagination so lists aren't truncated.
- **`content/admin_serializers.py` + `content/admin_views.py`** — CRUD for `Content` with automatic unique slug generation and exam auto-inherited from the subject.
- Routes registered under `/api/v1/exams/admin/...` and `/api/v1/content/admin/contents/`.
- All endpoints require `IsTenantAdmin` and are scoped through `exam__tenant` (legacy child rows have a null `tenant`, so scoping goes via the exam relationship).

## Frontend (React)

- **`services/contentBuilderService.js`** — admin CRUD client (unwraps DRF pagination).
- **`components/admin/ContentBuilder.jsx`** — exam selector pills → expandable Subjects → Chapters → Topics → Content, with inline add/edit/delete, a reusable schema-driven modal form, confirm-delete dialogs, toasts, loading states, and react-query cache invalidation.
- Wired into the `AdminDashboard` **Content Builder** tab (replaces the old read-only explorer).

## Verification

- `manage.py check` passes; frontend `npm run build` passes.
- Verified end-to-end via the admin test account: create/list/filter/update/delete at every level, auto-slug, chapter-topic linking, count fields, `reorder`, and that non-admins receive `403`.

## Notes

- The old read-only `ContentManagement` component is left defined but unused to keep the change surgical; it can be removed in a follow-up.