### PR TITLE
Add netlify.toml for landing page deploy

### DIFF
--- a/frontend/landing-page/main/netlify.toml
+++ b/frontend/landing-page/main/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
## Summary

Fixes the **404 / "Page not found"** on the Netlify deploy of the marketing landing page.

The landing page is a standard Next.js app. When Netlify publishes the raw `.next` folder without the Next.js Runtime, routing isn't wired up and every path 404s. This adds a `netlify.toml` (at the app's base directory `frontend/landing-page/main`) that pins the build and enables the official runtime plugin.

## What it sets

```toml
[build]
  command = "npm run build"
  publish = ".next"

[build.environment]
  NODE_VERSION = "20"        # required by Next.js 16

[[plugins]]
  package = "@netlify/plugin-nextjs"
```

## Netlify site settings to match

- **Base directory:** `frontend/landing-page/main`
- Build command / publish directory / Node version now come from `netlify.toml` (no need to fill them manually).

Once merged, trigger a redeploy on Netlify and the site will serve correctly.