### PR TITLE
Polish course tiles to match app theme

### DIFF
--- a/frontend/exam-frontend/src/components/profile/MyCourses.jsx
+++ b/frontend/exam-frontend/src/components/profile/MyCourses.jsx
@@ -91,7 +91,7 @@ const MyCourses = () => {
           type="button"
           onClick={() => requestEnroll(selectedCourse)}
           disabled={!selectedCourse || submitting}
-          className="btn primary inline-flex items-center justify-center gap-2 disabled:opacity-50"
+          className="btn-primary inline-flex items-center justify-center gap-2 disabled:opacity-50"
         >
           <PlusCircle size={18} />
           Request enrollment

--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -62,56 +62,77 @@ const Courses = () => {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
           {available.map((course, index) => {
             const status = statusById[course.id]
+            const color = course.color || '#f97316'
             return (
               <motion.div
                 key={course.id}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.06 }}
-                className="card p-6 flex flex-col"
+                className="group card-hover overflow-hidden flex flex-col"
               >
-                <div className="flex items-start gap-3 mb-4">
-                  <div
-                    className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-bold text-xl shrink-0"
-                    style={{ backgroundColor: course.color || '#3B82F6' }}
-                  >
-                    {course.name.charAt(0)}
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-1.5">
-                      <h3 className="text-lg font-semibold truncate">{course.name}</h3>
-                      {course.is_featured && <Star size={15} className="text-amber-400 fill-amber-400 shrink-0" />}
-                    </div>
-                    {course.code && <p className="text-xs text-surface-500 mt-0.5">{course.code}</p>}
-                  </div>
-                </div>
+                <div className="h-1.5 w-full" style={{ background: `linear-gradient(90deg, ${color}, ${color}55)` }} />
 
-                <div className="mt-auto">
-                  {status === 'approved' ? (
-                    <button
-                      type="button"
-                      onClick={() => navigate(`/study/course/${course.id}`)}
-                      className="btn primary w-full inline-flex items-center justify-center gap-2"
+                <div className="p-5 flex flex-col flex-1">
+                  <div className="flex items-start gap-3.5 mb-5">
+                    <div
+                      className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-bold text-2xl shrink-0 transition-transform duration-200 group-hover:scale-105"
+                      style={{ backgroundColor: color, boxShadow: `0 10px 22px -8px ${color}` }}
                     >
-                      <CheckCircle2 size={18} />
-                      Enrolled · Enter course
-                      <ArrowRight size={16} />
-                    </button>
-                  ) : status === 'pending' ? (
-                    <span className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
-                      <Clock size={16} />
-                      Awaiting approval
-                    </span>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => requestEnroll(course.id)}
-                      className="btn secondary w-full inline-flex items-center justify-center gap-2"
-                    >
-                      <PlusCircle size={18} />
-                      Request enrollment
-                    </button>
-                  )}
+                      {course.name.charAt(0).toUpperCase()}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5">
+                        <h3 className="text-lg font-semibold truncate">{course.name}</h3>
+                        {course.is_featured && <Star size={15} className="text-amber-400 fill-amber-400 shrink-0" />}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 mt-1.5">
+                        {course.code && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
+                            {course.code}
+                          </span>
+                        )}
+                        {status === 'approved' && (
+                          <span className="badge-success">
+                            <CheckCircle2 size={12} /> Enrolled
+                          </span>
+                        )}
+                        {status === 'pending' && (
+                          <span className="badge-warning">
+                            <Clock size={12} /> Pending
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-auto pt-1">
+                    {status === 'approved' ? (
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/study/course/${course.id}`)}
+                        className="btn-primary w-full group/btn"
+                        style={{ backgroundImage: `linear-gradient(to right, ${color}, ${color})`, boxShadow: `0 8px 18px -8px ${color}` }}
+                      >
+                        Enter course
+                        <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />
+                      </button>
+                    ) : status === 'pending' ? (
+                      <span className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800/60">
+                        <Clock size={16} />
+                        Awaiting admin approval
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => requestEnroll(course.id)}
+                        className="btn-secondary w-full border border-surface-200 dark:border-surface-700 hover:border-primary-300 dark:hover:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400"
+                      >
+                        <PlusCircle size={18} />
+                        Request enrollment
+                      </button>
+                    )}
+                  </div>
                 </div>
               </motion.div>
             )

--- a/frontend/exam-frontend/src/pages/Study.jsx
+++ b/frontend/exam-frontend/src/pages/Study.jsx
@@ -48,7 +48,7 @@ const Study = () => {
         <button
           type="button"
           onClick={() => navigate('/courses')}
-          className="btn secondary inline-flex items-center gap-2 text-sm"
+          className="btn-secondary inline-flex items-center gap-2 text-sm"
         >
           <Compass size={18} />
           Browse all courses
@@ -67,7 +67,7 @@ const Study = () => {
           <button
             type="button"
             onClick={() => navigate('/courses')}
-            className="btn primary inline-flex items-center gap-2"
+            className="btn-primary inline-flex items-center gap-2"
           >
             <Compass size={20} />
             Explore courses
@@ -75,38 +75,48 @@ const Study = () => {
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-          {courses.map((course, index) => (
+          {courses.map((course, index) => {
+            const color = course.color || '#f97316'
+            return (
             <motion.div
               key={course.id}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: index * 0.07 }}
-              className="card p-6 flex flex-col hover:shadow-lg transition-all"
+              className="group card-hover overflow-hidden flex flex-col"
             >
-              <div className="flex items-start gap-3 mb-4">
-                <div
-                  className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-bold text-xl shrink-0"
-                  style={{ backgroundColor: course.color || '#3B82F6' }}
-                >
-                  {course.name.charAt(0)}
+              <div className="h-1.5 w-full" style={{ background: `linear-gradient(90deg, ${color}, ${color}55)` }} />
+              <div className="p-5 flex flex-col flex-1">
+                <div className="flex items-start gap-3.5 mb-5">
+                  <div
+                    className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-bold text-2xl shrink-0 transition-transform duration-200 group-hover:scale-105"
+                    style={{ backgroundColor: color, boxShadow: `0 10px 22px -8px ${color}` }}
+                  >
+                    {course.name.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-lg font-semibold truncate">{course.name}</h3>
+                    {course.code && (
+                      <span className="inline-flex items-center mt-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
+                        {course.code}
+                      </span>
+                    )}
+                  </div>
                 </div>
-                <div className="min-w-0">
-                  <h3 className="text-lg font-semibold truncate">{course.name}</h3>
-                  {course.code && <p className="text-xs text-surface-500 mt-0.5">{course.code}</p>}
-                </div>
-              </div>
 
-              <button
-                type="button"
-                onClick={() => navigate(`/study/course/${course.id}`)}
-                className="btn primary mt-auto w-full inline-flex items-center justify-center gap-2"
-                style={course.color ? { backgroundColor: course.color, borderColor: course.color } : undefined}
-              >
-                Enter course
-                <ArrowRight size={18} />
-              </button>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/study/course/${course.id}`)}
+                  className="btn-primary mt-auto w-full group/btn"
+                  style={{ backgroundImage: `linear-gradient(to right, ${color}, ${color})`, boxShadow: `0 8px 18px -8px ${color}` }}
+                >
+                  Enter course
+                  <ArrowRight size={18} className="transition-transform group-hover/btn:translate-x-0.5" />
+                </button>
+              </div>
             </motion.div>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## What
Improves the Course/Study tiles to align with the app's orange/fuchsia theme and fixes a rendering bug.

### Bug fix
The CTAs used `btn primary` / `btn secondary` (space) but the real utility classes are `btn-primary` / `btn-secondary`. So buttons like "Enrolled · Enter course" rendered as **unstyled plain black text** (visible in the screenshot). Fixed across `Courses.jsx`, `Study.jsx`, and `MyCourses.jsx`.

### Redesign
- **Colored accent header** strip per course (uses the course's own color).
- **Avatar glow** — the letter badge gets a soft color-tinted shadow and scales slightly on hover.
- **Hover lift** via the shared `card-hover` style (matches the rest of the app).
- **Status badges** — `Enrolled` (green) / `Pending` (amber) shown inline under the title.
- **Themed CTAs** — "Enter course" button tinted with the course color and an arrow that nudges on hover; "Request enrollment" is a clean secondary button that picks up the primary accent on hover; pending shows a soft amber "Awaiting admin approval" pill.

UI-only; no API/logic changes. `npm run build` passes.