### PR TITLE
Add course thumbnails with professional placeholder

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -195,6 +195,9 @@ class AvailableCoursesForEnrollmentView(APIView):
                 'code': e.code,
                 'color': getattr(e, 'color', None) or '#3B82F6',
                 'is_featured': getattr(e, 'is_featured', False),
+                'course_type': getattr(e, 'course_type', '') or '',
+                'description': getattr(e, 'description', '') or '',
+                'thumbnail': (e.icon.url if getattr(e, 'icon', None) else None),
             }
             for e in courses
         ]
@@ -232,6 +235,9 @@ class StudyCoursesView(APIView):
                 'code': e.course.code,
                 'color': getattr(e.course, 'color', None) or '#3B82F6',
                 'is_featured': getattr(e.course, 'is_featured', False),
+                'course_type': getattr(e.course, 'course_type', '') or '',
+                'description': getattr(e.course, 'description', '') or '',
+                'thumbnail': (e.course.icon.url if getattr(e.course, 'icon', None) else None),
                 'enrollment_status': e.status,
             }
             if e.status == 'approved':

--- a/frontend/exam-frontend/src/components/course/CourseThumbnail.jsx
+++ b/frontend/exam-frontend/src/components/course/CourseThumbnail.jsx
@@ -1,0 +1,76 @@
+import { useState } from 'react'
+import { GraduationCap, Star } from 'lucide-react'
+
+const TYPE_LABELS = {
+  competitive: 'Competitive',
+  board: 'Board',
+  entrance: 'Entrance',
+  government: 'Government',
+}
+
+/**
+ * Course banner used on course tiles.
+ * Shows the uploaded thumbnail when available; otherwise renders a
+ * professional, theme-aligned placeholder derived from the course color.
+ */
+const CourseThumbnail = ({ course, statusBadge = null }) => {
+  const [imgOk, setImgOk] = useState(true)
+  const color = course.color || '#f97316'
+  const hasImage = !!course.thumbnail && imgOk
+  const typeLabel = TYPE_LABELS[course.course_type] || null
+
+  return (
+    <div className="relative aspect-[16/9] w-full overflow-hidden bg-surface-100 dark:bg-surface-800">
+      {hasImage ? (
+        <img
+          src={course.thumbnail}
+          alt={course.name}
+          loading="lazy"
+          onError={() => setImgOk(false)}
+          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+        />
+      ) : (
+        <div
+          className="w-full h-full flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
+          style={{ background: `linear-gradient(135deg, ${color} 0%, ${color}cc 55%, ${color}99 100%)` }}
+        >
+          {/* soft decorative rings */}
+          <div className="absolute -top-8 -right-8 w-32 h-32 rounded-full bg-white/10" />
+          <div className="absolute -bottom-10 -left-6 w-28 h-28 rounded-full bg-black/10" />
+          <span className="relative font-display font-bold text-white/95 text-5xl sm:text-6xl drop-shadow-sm select-none">
+            {course.name.charAt(0).toUpperCase()}
+          </span>
+          <GraduationCap
+            size={40}
+            className="absolute bottom-3 right-3 text-white/25"
+            strokeWidth={1.5}
+          />
+        </div>
+      )}
+
+      {/* readability gradient for overlays */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/25 via-transparent to-transparent pointer-events-none" />
+
+      {/* top-left: course type */}
+      {typeLabel && (
+        <span className="absolute top-2.5 left-2.5 px-2 py-0.5 rounded-md text-[11px] font-semibold tracking-wide uppercase bg-white/90 dark:bg-black/60 text-surface-700 dark:text-surface-100 backdrop-blur-sm shadow-sm">
+          {typeLabel}
+        </span>
+      )}
+
+      {/* top-right: featured */}
+      {course.is_featured && (
+        <span className="absolute top-2.5 right-2.5 inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-amber-400/95 text-amber-950 shadow-sm">
+          <Star size={11} className="fill-amber-950" /> Featured
+        </span>
+      )}
+
+      {/* bottom-left: status (enrolled / pending) */}
+      {statusBadge && (
+        <div className="absolute bottom-2.5 left-2.5">{statusBadge}</div>
+      )}
+    </div>
+  )
+}
+
+export default CourseThumbnail

--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -4,8 +4,9 @@ import { motion } from 'framer-motion'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
+import CourseThumbnail from '../components/course/CourseThumbnail'
 import toast from 'react-hot-toast'
-import { GraduationCap, CheckCircle2, Clock, PlusCircle, ArrowRight, Star } from 'lucide-react'
+import { GraduationCap, CheckCircle2, Clock, PlusCircle, ArrowRight } from 'lucide-react'
 
 const Courses = () => {
   const navigate = useNavigate()
@@ -63,6 +64,16 @@ const Courses = () => {
           {available.map((course, index) => {
             const status = statusById[course.id]
             const color = course.color || '#f97316'
+            const statusBadge =
+              status === 'approved' ? (
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-success-500/95 text-white shadow-sm">
+                  <CheckCircle2 size={11} /> Enrolled
+                </span>
+              ) : status === 'pending' ? (
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-amber-400/95 text-amber-950 shadow-sm">
+                  <Clock size={11} /> Pending
+                </span>
+              ) : null
             return (
               <motion.div
                 key={course.id}
@@ -71,42 +82,20 @@ const Courses = () => {
                 transition={{ delay: index * 0.06 }}
                 className="group card-hover overflow-hidden flex flex-col"
               >
-                <div className="h-1.5 w-full" style={{ background: `linear-gradient(90deg, ${color}, ${color}55)` }} />
+                <CourseThumbnail course={course} statusBadge={statusBadge} />
 
-                <div className="p-5 flex flex-col flex-1">
-                  <div className="flex items-start gap-3.5 mb-5">
-                    <div
-                      className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-bold text-2xl shrink-0 transition-transform duration-200 group-hover:scale-105"
-                      style={{ backgroundColor: color, boxShadow: `0 10px 22px -8px ${color}` }}
-                    >
-                      {course.name.charAt(0).toUpperCase()}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <h3 className="text-lg font-semibold truncate">{course.name}</h3>
-                        {course.is_featured && <Star size={15} className="text-amber-400 fill-amber-400 shrink-0" />}
-                      </div>
-                      <div className="flex flex-wrap items-center gap-2 mt-1.5">
-                        {course.code && (
-                          <span className="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
-                            {course.code}
-                          </span>
-                        )}
-                        {status === 'approved' && (
-                          <span className="badge-success">
-                            <CheckCircle2 size={12} /> Enrolled
-                          </span>
-                        )}
-                        {status === 'pending' && (
-                          <span className="badge-warning">
-                            <Clock size={12} /> Pending
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+                <div className="p-4 sm:p-5 flex flex-col flex-1">
+                  <h3 className="text-base sm:text-lg font-semibold leading-snug line-clamp-1">{course.name}</h3>
+                  {course.code && (
+                    <span className="inline-flex self-start items-center mt-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
+                      {course.code}
+                    </span>
+                  )}
+                  {course.description && (
+                    <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
+                  )}
 
-                  <div className="mt-auto pt-1">
+                  <div className="mt-auto pt-4">
                     {status === 'approved' ? (
                       <button
                         type="button"

--- a/frontend/exam-frontend/src/pages/Study.jsx
+++ b/frontend/exam-frontend/src/pages/Study.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { useQuery } from '@tanstack/react-query'
 import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
+import CourseThumbnail from '../components/course/CourseThumbnail'
 import { GraduationCap, Clock, Compass, ArrowRight } from 'lucide-react'
 
 const Study = () => {
@@ -85,30 +86,23 @@ const Study = () => {
               transition={{ delay: index * 0.07 }}
               className="group card-hover overflow-hidden flex flex-col"
             >
-              <div className="h-1.5 w-full" style={{ background: `linear-gradient(90deg, ${color}, ${color}55)` }} />
-              <div className="p-5 flex flex-col flex-1">
-                <div className="flex items-start gap-3.5 mb-5">
-                  <div
-                    className="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-bold text-2xl shrink-0 transition-transform duration-200 group-hover:scale-105"
-                    style={{ backgroundColor: color, boxShadow: `0 10px 22px -8px ${color}` }}
-                  >
-                    {course.name.charAt(0).toUpperCase()}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <h3 className="text-lg font-semibold truncate">{course.name}</h3>
-                    {course.code && (
-                      <span className="inline-flex items-center mt-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
-                        {course.code}
-                      </span>
-                    )}
-                  </div>
-                </div>
+              <CourseThumbnail course={course} />
+              <div className="p-4 sm:p-5 flex flex-col flex-1">
+                <h3 className="text-base sm:text-lg font-semibold leading-snug line-clamp-1">{course.name}</h3>
+                {course.code && (
+                  <span className="inline-flex self-start items-center mt-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
+                    {course.code}
+                  </span>
+                )}
+                {course.description && (
+                  <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
+                )}
 
                 <button
                   type="button"
                   onClick={() => navigate(`/study/course/${course.id}`)}
                   className="btn-primary mt-auto w-full group/btn"
-                  style={{ backgroundImage: `linear-gradient(to right, ${color}, ${color})`, boxShadow: `0 8px 18px -8px ${color}` }}
+                  style={{ backgroundImage: `linear-gradient(to right, ${color}, ${color})`, boxShadow: `0 8px 18px -8px ${color}`, marginTop: 'auto' }}
                 >
                   Enter course
                   <ArrowRight size={18} className="transition-transform group-hover/btn:translate-x-0.5" />


### PR DESCRIPTION
## What
Course tiles now lead with a **thumbnail**. If a course has an uploaded image (`icon`), it's shown; otherwise a **meaningful, theme-colored placeholder** is rendered (course initial + graduation-cap watermark on a gradient of the course's color). Professional and fully responsive.

### Backend
- `available-for-enrollment/` and `study/courses/` now also return `thumbnail` (the course `icon` URL), `course_type`, and `description`.

### Frontend
- New `CourseThumbnail` component:
  - 16:9 banner — real image (`object-cover`, lazy-loaded, hover zoom) or gradient placeholder.
  - `onError` fallback: if an image URL fails to load, it degrades to the placeholder.
  - Overlays: **course type** (top-left), **Featured** (top-right), **Enrolled/Pending** status (bottom-left).
- Reworked **Courses** and **Study** tiles around the banner: responsive padding (`p-4 sm:p-5`), 1-line clamped title, 2-line clamped description, code pill, themed CTA.

## Deploy
- Frontend: auto-deploys on merge (Netlify).
- Backend: needs a redeploy (I'll run it after merge) so the new `thumbnail`/`course_type`/`description` fields are served. UI-safe either way — placeholders show until the backend ships.

`npm run build` passes; backend view compiles.