### PR TITLE
Add in-app PDF reading material (view-only, no download)

### DIFF
--- a/backend/content/admin_serializers.py
+++ b/backend/content/admin_serializers.py
@@ -21,7 +21,7 @@ class AdminContentSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'title', 'slug', 'description', 'content_type',
             'topic', 'topic_name', 'subject', 'subject_name', 'courses',
-            'content_html', 'video_url', 'video_duration_minutes',
+            'content_html', 'video_url', 'video_duration_minutes', 'pdf_file',
             'difficulty', 'status', 'is_free', 'is_premium',
             'estimated_time_minutes', 'order', 'author_name',
             'views_count', 'likes_count', 'bookmarks_count',

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -24,9 +24,13 @@ class ContentSerializer(serializers.ModelSerializer):
 
 class ContentDetailSerializer(ContentSerializer):
     """Detailed serializer with content body."""
-    
+    has_pdf = serializers.SerializerMethodField()
+
     class Meta(ContentSerializer.Meta):
-        fields = ContentSerializer.Meta.fields + ['content_html', 'pdf_file']
+        fields = ContentSerializer.Meta.fields + ['content_html', 'has_pdf']
+
+    def get_has_pdf(self, obj):
+        return bool(obj.pdf_file)
 
 
 class ContentProgressSerializer(serializers.ModelSerializer):

--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -8,6 +8,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter, OrderingFilter
 from django.utils import timezone
 from django.db.models import Q
+from django.http import FileResponse, Http404
 
 from .models import Content, ContentProgress, StudyPlan, StudyPlanItem
 from .serializers import (
@@ -54,6 +55,28 @@ class ContentViewSet(TenantAwareReadOnlyViewSet):
         instance.views_count += 1
         instance.save(update_fields=['views_count'])
         return super().retrieve(request, *args, **kwargs)
+
+    @action(detail=True, methods=['get'], url_path='pdf')
+    def pdf(self, request, *args, **kwargs):
+        """
+        Stream the PDF bytes inline for in-app reading.
+
+        The raw blob URL is never exposed to the client; the file is proxied
+        through this authenticated endpoint and served with an inline
+        Content-Disposition so it is rendered rather than downloaded.
+        """
+        content = self.get_object()
+        if content.content_type != 'pdf' or not content.pdf_file:
+            raise Http404('No PDF available for this content.')
+        try:
+            fh = content.pdf_file.open('rb')
+        except Exception:
+            raise Http404('PDF file not found.')
+        response = FileResponse(fh, content_type='application/pdf')
+        response['Content-Disposition'] = 'inline; filename="document.pdf"'
+        response['X-Content-Type-Options'] = 'nosniff'
+        response['Cache-Control'] = 'private, no-store'
+        return response
 
     @action(detail=False, methods=['get'])
     def by_topic(self, request):

--- a/frontend/exam-frontend/package-lock.json
+++ b/frontend/exam-frontend/package-lock.json
@@ -27,6 +27,7 @@
         "react-easy-crop": "^5.5.6",
         "react-hot-toast": "^2.4.1",
         "react-markdown": "^9.0.1",
+        "react-pdf": "^9.2.1",
         "react-router-dom": "^6.22.0",
         "recharts": "^2.12.0",
         "rehype-katex": "^7.0.1",
@@ -1437,6 +1438,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.33",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
@@ -1459,6 +1481,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1517,6 +1551,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/call-bind": {
@@ -1605,6 +1664,21 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.3.tgz",
+      "integrity": "sha512-PzE5nJZPz72YUAfo8oTp0u3fqqY7IzlTubneAihqDYAUcBk7ryeCmBbdJBEdaH0bptSOe2VT2Zwcb3UaFyaSWw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
     },
     "node_modules/canvas-confetti": {
       "version": "1.9.4",
@@ -1704,6 +1778,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2008,6 +2089,32 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2063,6 +2170,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/devlop": {
@@ -2125,6 +2242,16 @@
       "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2610,6 +2737,16 @@
       "version": "4.0.7",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "license": "MIT"
@@ -2828,6 +2965,13 @@
         }
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -2959,6 +3103,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -3305,6 +3456,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3352,8 +3524,15 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -4100,6 +4279,24 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/make-cancellable-promise": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.3.2.tgz",
+      "integrity": "sha512-GCXh3bq/WuMbS+Ky4JBPW1hYTOU+znU+Q5m9Pu+pI8EoUqIHk9+tviOKC6/qhHh8C4/As3tzJ69IF32kdz85ww==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
+      }
+    },
+    "node_modules/make-event-props": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.6.2.tgz",
+      "integrity": "sha512-iDwf7mA03WPiR8QxvcVHmVWEPfMY1RZXerDVNCRYW7dUr2ppH3J58Rwb39/WG39yTZdRSxr3x+2v22tvI0VEvA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "license": "MIT",
@@ -4382,6 +4579,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/merge-refs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.3.0.tgz",
+      "integrity": "sha512-nqXPXbso+1dcKDpPCXvwZyJILz+vSLqGGOnDrYHQYE+B8n9JTCekVLC65AfCpR4ggVyA/45Y0iR9LDyS2iI+zA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/merge2": {
@@ -4949,6 +5163,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4961,6 +5188,23 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",
@@ -5008,12 +5252,52 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -5173,7 +5457,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5347,6 +5631,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/path2d": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
+      "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.8.69",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.8.69.tgz",
+      "integrity": "sha512-IHZsA4T7YElCKNNXtiLgqScw4zPd3pG9do8UrznC757gMd7UPeHSL2qwNNMJo4r79fl8oj1Xx+1nh2YkzdMpLQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^3.0.0-rc2",
+        "path2d": "^0.2.1"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5502,6 +5809,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5541,6 +5876,17 @@
       "version": "1.1.0",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5571,6 +5917,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -5669,6 +6041,35 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-pdf": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.2.1.tgz",
+      "integrity": "sha512-AJt0lAIkItWEZRA5d/mO+Om4nPCuTiQ0saA+qItO967DTjmGjnhmF+Bi2tL286mOTfBlF5CyLzJ35KTMaDoH+A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
+        "make-cancellable-promise": "^1.3.1",
+        "make-event-props": "^1.6.0",
+        "merge-refs": "^1.3.0",
+        "pdfjs-dist": "4.8.69",
+        "tiny-invariant": "^1.0.0",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "dev": true,
@@ -5738,6 +6139,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -6055,6 +6471,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6255,6 +6692,53 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "license": "BSD-3-Clause",
@@ -6292,6 +6776,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -6585,6 +7079,36 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -6700,6 +7224,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tween-functions": {
       "version": "1.2.0",
@@ -6975,7 +7512,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/vfile": {
@@ -7090,6 +7627,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/web-namespaces": {
@@ -7217,7 +7763,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/yallist": {

--- a/frontend/exam-frontend/package.json
+++ b/frontend/exam-frontend/package.json
@@ -29,6 +29,7 @@
     "react-easy-crop": "^5.5.6",
     "react-hot-toast": "^2.4.1",
     "react-markdown": "^9.0.1",
+    "react-pdf": "^9.2.1",
     "react-router-dom": "^6.22.0",
     "recharts": "^2.12.0",
     "rehype-katex": "^7.0.1",

--- a/frontend/exam-frontend/src/components/admin/builderShared.jsx
+++ b/frontend/exam-frontend/src/components/admin/builderShared.jsx
@@ -250,6 +250,7 @@ export const SCHEMAS = {
             { name: 'is_premium', label: 'Premium', type: 'checkbox' },
             { name: 'description', label: 'Description', type: 'textarea', full: true },
             { name: 'content_html', label: 'Content (HTML / Markdown — supports pasted images)', type: 'textarea', full: true, rows: 10, image: true },
+            { name: 'pdf_file', label: 'PDF File', type: 'pdf', full: true, showIf: (v) => v.content_type === 'pdf', hint: 'Uploaded PDF is shown in-app to students (view only — no download).' },
         ],
     },
     quiz: {
@@ -303,11 +304,18 @@ export const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
 
     const set = (name, val) => setValues((p) => ({ ...p, [name]: val }))
 
+    const visibleFields = schema.fields.filter((f) => !f.showIf || f.showIf(values))
+
     const handleSubmit = (e) => {
         e.preventDefault()
         const payload = {}
-        schema.fields.forEach((f) => {
+        visibleFields.forEach((f) => {
             let v = values[f.name]
+            if (f.type === 'pdf') {
+                // Only send when a new file was chosen; otherwise preserve existing.
+                if (v instanceof File) payload[f.name] = v
+                return
+            }
             if (f.type === 'number') {
                 v = v === '' || v === null ? null : Number(v)
                 if (v === null && !f.required) return
@@ -336,7 +344,7 @@ export const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
 
                 <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                        {schema.fields.map((f) => (
+                        {visibleFields.map((f) => (
                             <div key={f.name} className={f.full || f.type === 'textarea' ? 'sm:col-span-2' : ''}>
                                 {f.type === 'checkbox' ? (
                                     <label className="flex items-center gap-2 cursor-pointer py-2">
@@ -363,6 +371,22 @@ export const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
                                                     onChange={(e) => set(f.name, e.target.value)}
                                                 />
                                             )
+                                        ) : f.type === 'pdf' ? (
+                                            <div className="space-y-1.5">
+                                                <input
+                                                    type="file"
+                                                    accept="application/pdf"
+                                                    onChange={(e) => set(f.name, e.target.files?.[0] || values[f.name])}
+                                                    className="block w-full text-sm text-surface-600 dark:text-surface-300 file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100 dark:file:bg-primary-900/30 dark:file:text-primary-300 cursor-pointer"
+                                                />
+                                                {values[f.name] instanceof File ? (
+                                                    <p className="text-[11px] text-success-600 font-medium">New file: {values[f.name].name}</p>
+                                                ) : typeof values[f.name] === 'string' && values[f.name] ? (
+                                                    <p className="text-[11px] text-surface-400">A PDF is already uploaded. Choose a file to replace it.</p>
+                                                ) : (
+                                                    <p className="text-[11px] text-surface-400">No PDF uploaded yet.</p>
+                                                )}
+                                            </div>
                                         ) : f.type === 'select' ? (
                                             <select className="input" value={values[f.name] ?? ''} onChange={(e) => set(f.name, e.target.value)}>
                                                 {f.options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}

--- a/frontend/exam-frontend/src/components/content/PdfReader.jsx
+++ b/frontend/exam-frontend/src/components/content/PdfReader.jsx
@@ -1,0 +1,190 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Document, Page, pdfjs } from 'react-pdf'
+import 'react-pdf/dist/Page/AnnotationLayer.css'
+import 'react-pdf/dist/Page/TextLayer.css'
+import { Loader2, AlertCircle, ZoomIn, ZoomOut, ChevronUp, ChevronDown, Lock } from 'lucide-react'
+import api from '../../services/api'
+
+// Bundle the pdf.js worker with Vite (no external CDN dependency).
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url
+).toString()
+
+/**
+ * In-app PDF reader for reading material.
+ *
+ * The PDF bytes are streamed from an authenticated backend endpoint (the raw
+ * blob URL is never exposed) and rendered page-by-page with pdf.js — there is
+ * no browser download/print toolbar and the context menu is disabled, so the
+ * document can be read but not casually downloaded.
+ */
+const PdfReader = ({ contentId }) => {
+  const containerRef = useRef(null)
+  const pageRefs = useRef([])
+  const [data, setData] = useState(null)
+  const [error, setError] = useState(null)
+  const [numPages, setNumPages] = useState(0)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [scale, setScale] = useState(1)
+  const [width, setWidth] = useState(0)
+
+  // Fetch the PDF through the authenticated API (handles auth + token refresh).
+  useEffect(() => {
+    let cancelled = false
+    setData(null)
+    setError(null)
+    api
+      .get(`/content/${contentId}/pdf/`, { responseType: 'arraybuffer' })
+      .then((res) => {
+        if (!cancelled) setData(new Uint8Array(res.data))
+      })
+      .catch(() => {
+        if (!cancelled) setError('Unable to load this PDF. Please try again.')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [contentId])
+
+  // Track container width so pages render responsively.
+  useEffect(() => {
+    if (!containerRef.current) return
+    const el = containerRef.current
+    const update = () => setWidth(el.clientWidth)
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [data])
+
+  // Update the current-page indicator as the user scrolls.
+  useEffect(() => {
+    const root = containerRef.current
+    if (!root || !numPages) return
+    const onScroll = () => {
+      const mid = root.scrollTop + root.clientHeight / 2
+      let cur = 1
+      for (let i = 0; i < pageRefs.current.length; i++) {
+        const node = pageRefs.current[i]
+        if (node && node.offsetTop <= mid) cur = i + 1
+      }
+      setCurrentPage(cur)
+    }
+    root.addEventListener('scroll', onScroll, { passive: true })
+    return () => root.removeEventListener('scroll', onScroll)
+  }, [numPages])
+
+  const file = useMemo(() => (data ? { data } : null), [data])
+  const pageWidth = width ? Math.max(280, Math.floor(width * scale) - 24) : undefined
+
+  const goToPage = (n) => {
+    const node = pageRefs.current[n - 1]
+    if (node && containerRef.current) {
+      containerRef.current.scrollTo({ top: node.offsetTop - 8, behavior: 'smooth' })
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="card p-8 flex flex-col items-center justify-center text-center gap-2 text-surface-500">
+        <AlertCircle className="w-8 h-8 text-rose-500" />
+        <p>{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="card overflow-hidden mb-6">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between gap-3 px-4 py-2.5 border-b border-surface-200 dark:border-surface-800 bg-surface-50 dark:bg-surface-900/50">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-surface-500">
+          <Lock size={13} /> View only
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => goToPage(Math.max(1, currentPage - 1))}
+            disabled={currentPage <= 1}
+            className="btn-icon disabled:opacity-40"
+            title="Previous page"
+          >
+            <ChevronUp size={16} />
+          </button>
+          <span className="text-xs font-medium text-surface-600 dark:text-surface-300 tabular-nums px-1">
+            {numPages ? `${currentPage} / ${numPages}` : '—'}
+          </span>
+          <button
+            onClick={() => goToPage(Math.min(numPages, currentPage + 1))}
+            disabled={currentPage >= numPages}
+            className="btn-icon disabled:opacity-40"
+            title="Next page"
+          >
+            <ChevronDown size={16} />
+          </button>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setScale((s) => Math.max(0.5, +(s - 0.15).toFixed(2)))}
+            className="btn-icon"
+            title="Zoom out"
+          >
+            <ZoomOut size={16} />
+          </button>
+          <span className="text-xs font-medium text-surface-500 tabular-nums w-10 text-center">
+            {Math.round(scale * 100)}%
+          </span>
+          <button
+            onClick={() => setScale((s) => Math.min(2.5, +(s + 0.15).toFixed(2)))}
+            className="btn-icon"
+            title="Zoom in"
+          >
+            <ZoomIn size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Document */}
+      <div
+        ref={containerRef}
+        onContextMenu={(e) => e.preventDefault()}
+        className="max-h-[75vh] overflow-y-auto bg-surface-100 dark:bg-surface-950 px-3 py-4 flex flex-col items-center select-none"
+      >
+        {!file ? (
+          <div className="flex flex-col items-center gap-2 py-16 text-surface-400">
+            <Loader2 className="w-6 h-6 animate-spin" />
+            <span className="text-sm">Loading PDF…</span>
+          </div>
+        ) : (
+          <Document
+            file={file}
+            onLoadSuccess={({ numPages: n }) => setNumPages(n)}
+            onLoadError={() => setError('Unable to render this PDF.')}
+            loading={
+              <div className="flex flex-col items-center gap-2 py-16 text-surface-400">
+                <Loader2 className="w-6 h-6 animate-spin" />
+                <span className="text-sm">Loading PDF…</span>
+              </div>
+            }
+          >
+            {Array.from({ length: numPages }, (_, i) => (
+              <div
+                key={i}
+                ref={(el) => (pageRefs.current[i] = el)}
+                className="mb-4 shadow-lg rounded overflow-hidden bg-white"
+              >
+                <Page
+                  pageNumber={i + 1}
+                  width={pageWidth}
+                  renderTextLayer
+                  renderAnnotationLayer={false}
+                />
+              </div>
+            ))}
+          </Document>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PdfReader

--- a/frontend/exam-frontend/src/pages/ContentViewer.jsx
+++ b/frontend/exam-frontend/src/pages/ContentViewer.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, lazy, Suspense } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import ReactMarkdown from 'react-markdown'
@@ -14,6 +14,7 @@ import {
   CheckCircle2, ChevronLeft, PlayCircle, Clock
 } from 'lucide-react'
 import { useAuthStore } from '../context/authStore'
+const PdfReader = lazy(() => import('../components/content/PdfReader'))
 
 const ContentViewer = () => {
   const { contentId } = useParams()
@@ -212,18 +213,11 @@ const ContentViewer = () => {
         </div>
       )}
 
-      {/* PDF Viewer */}
-      {content?.content_type === 'pdf' && content?.pdf_file && (
-        <div className="card p-4 mb-6">
-          <a
-            href={content.pdf_file}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="btn-primary inline-flex items-center gap-2"
-          >
-            <FileText size={18} /> Open PDF
-          </a>
-        </div>
+      {/* PDF Viewer (in-app, view-only — no download) */}
+      {content?.content_type === 'pdf' && content?.has_pdf && (
+        <Suspense fallback={<div className="card p-8 text-center text-surface-400">Loading reader…</div>}>
+          <PdfReader contentId={contentId} />
+        </Suspense>
       )}
 
       {/* Actions Footer */}

--- a/frontend/exam-frontend/src/services/contentBuilderService.js
+++ b/frontend/exam-frontend/src/services/contentBuilderService.js
@@ -8,6 +8,19 @@ const list = (res) => {
 
 const PAGE = { page_size: 2000 }
 
+// Build a multipart request config when a payload carries a File (e.g. PDF
+// upload); otherwise send as plain JSON.
+const withFiles = (data) => {
+  const hasFile = Object.values(data).some((v) => v instanceof File)
+  if (!hasFile) return { body: data, config: undefined }
+  const fd = new FormData()
+  Object.entries(data).forEach(([k, v]) => {
+    if (v === undefined || v === null) return
+    fd.append(k, v instanceof File ? v : String(v))
+  })
+  return { body: fd, config: { headers: { 'Content-Type': undefined } } }
+}
+
 /**
  * Admin Content Builder service.
  * Full CRUD over the hierarchy: Exam -> Subject -> Chapter -> Topic -> Content.
@@ -47,8 +60,14 @@ export const contentBuilderService = {
   // ---- Content ----
   getContents: async (topicId) =>
     list(await api.get('/content/admin/contents/', { params: { topic: topicId, ...PAGE } })),
-  createContent: async (data) => (await api.post('/content/admin/contents/', data)).data,
-  updateContent: async (id, data) => (await api.patch(`/content/admin/contents/${id}/`, data)).data,
+  createContent: async (data) => {
+    const { body, config } = withFiles(data)
+    return (await api.post('/content/admin/contents/', body, config)).data
+  },
+  updateContent: async (id, data) => {
+    const { body, config } = withFiles(data)
+    return (await api.patch(`/content/admin/contents/${id}/`, body, config)).data
+  },
   deleteContent: async (id) => api.delete(`/content/admin/contents/${id}/`),
 
   // ---- Quizzes ----


### PR DESCRIPTION
## What
Adds PDF reading material end-to-end: admins upload PDFs from the Course Builder, and students read them in-app without being able to download.

## Admin (Course Builder)
- The content editor now shows a **PDF File** upload when `Type = PDF`.
- Uploads are sent as multipart to the existing content endpoint (preserves the file on edit if not replaced).

## Student
- New in-app **pdf.js reader** (`PdfReader.jsx`): continuous scroll, page indicator, prev/next, zoom, responsive width, loading/error states.
- **No download/print toolbar**, context menu disabled → view-only.
- PDF bytes are streamed via a new **authenticated endpoint** `GET /api/v1/content/<id>/pdf/` (inline disposition). The raw Azure Blob URL is no longer exposed to the client — the student serializer now returns `has_pdf` instead of `pdf_file`.
- **Mark as read** already works for PDFs through the existing content-progress flow, and PDFs already appear under the topic's **Reading** tab and count toward "X/Y read".

## Notes
- True download prevention is best-effort on the web (as with any browser PDF viewer), but this removes the download button, hides the blob URL behind auth, and disables the context menu.
- Added `react-pdf`; the reader is lazy-loaded so pdfjs stays out of the initial bundle.
- No DB migration required (`pdf_file` field already existed). nginx `client_max_body_size` is already 100M.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>