### PR TITLE
Study content counts + brand-themed course tiles

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -259,6 +259,7 @@ class StudySubjectsView(APIView):
     def get(self, request):
         from content.models import Content, ContentProgress
         from quiz.models import Quiz, QuizAttempt
+        from assignments.models import Assignment, AssignmentSubmission
 
         student = request.user.profile
         course_id = request.query_params.get('course_id')
@@ -281,18 +282,36 @@ class StudySubjectsView(APIView):
                 {'error': 'Enrollment pending admin approval'}, status=403
             )
 
+        reading_types = ['notes', 'pdf', 'revision', 'formula']
+
         subjects = Subject.objects.filter(course=course).order_by('order')
         result = []
         for subj in subjects:
-            content_count = Content.objects.filter(
-                subject=subj, status='published'
+            subj_topic_ids = list(subj.topics.values_list('id', flat=True))
+
+            reading_total = Content.objects.filter(
+                subject=subj, status='published',
+                content_type__in=reading_types,
             ).count()
-            content_done = ContentProgress.objects.filter(
+            reading_done = ContentProgress.objects.filter(
                 student=student,
                 content__subject=subj,
                 content__status='published',
+                content__content_type__in=reading_types,
                 is_completed=True,
             ).count()
+
+            video_total = Content.objects.filter(
+                subject=subj, status='published', content_type='video',
+            ).count()
+            video_done = ContentProgress.objects.filter(
+                student=student,
+                content__subject=subj,
+                content__status='published',
+                content__content_type='video',
+                is_completed=True,
+            ).count()
+
             quiz_count = Quiz.objects.filter(
                 subject=subj, course=course, status='published'
             ).count()
@@ -304,8 +323,20 @@ class StudySubjectsView(APIView):
                 status='completed',
             ).values('quiz').distinct().count()
 
-            total_content = content_count + quiz_count
-            completed_content = content_done + quiz_done
+            assignment_total = Assignment.objects.filter(
+                topic_id__in=subj_topic_ids, status='published',
+            ).count()
+            assignment_done = AssignmentSubmission.objects.filter(
+                student=student,
+                assignment__topic_id__in=subj_topic_ids,
+                assignment__status='published',
+            ).values('assignment').distinct().count()
+
+            content_count = reading_total + video_total
+            content_done = reading_done + video_done
+
+            total_content = content_count + quiz_count + assignment_total
+            completed_content = content_done + quiz_done + assignment_done
             progress = (
                 round((completed_content / total_content) * 100)
                 if total_content > 0 else 0
@@ -327,6 +358,10 @@ class StudySubjectsView(APIView):
                 'total_content': total_content,
                 'completed_content': completed_content,
                 'progress': progress,
+                'reading': {'total': reading_total, 'completed': reading_done},
+                'videos': {'total': video_total, 'completed': video_done},
+                'quizzes': {'total': quiz_count, 'attempted': quiz_done},
+                'assignments': {'total': assignment_total, 'completed': assignment_done},
             })
 
         return Response(result)
@@ -342,6 +377,7 @@ class StudyChaptersView(APIView):
     def get(self, request, subject_id):
         from content.models import Content, ContentProgress
         from quiz.models import Quiz, QuizAttempt
+        from assignments.models import Assignment, AssignmentSubmission
 
         student = request.user.profile
         try:
@@ -385,9 +421,6 @@ class StudyChaptersView(APIView):
                 status='completed',
             ).values('quiz').distinct().count()
 
-            total_content = content_count + quiz_count
-            completed_content = content_done + quiz_done
-
             reading_total = Content.objects.filter(
                 topic_id__in=topic_ids, status='published',
                 content_type__in=['notes', 'pdf', 'revision', 'formula'],
@@ -421,6 +454,18 @@ class StudyChaptersView(APIView):
                 status='completed',
             ).values('quiz').distinct().count()
 
+            assignment_total = Assignment.objects.filter(
+                topic_id__in=topic_ids, status='published',
+            ).count()
+            assignment_done = AssignmentSubmission.objects.filter(
+                student=student,
+                assignment__topic_id__in=topic_ids,
+                assignment__status='published',
+            ).values('assignment').distinct().count()
+
+            total_content = content_count + quiz_count + assignment_total
+            completed_content = content_done + quiz_done + assignment_done
+
             progress = (
                 round((completed_content / total_content) * 100)
                 if total_content > 0 else 0
@@ -439,6 +484,7 @@ class StudyChaptersView(APIView):
                 'reading': {'total': reading_total, 'completed': reading_done},
                 'videos': {'total': video_total, 'completed': video_done},
                 'quizzes': {'total': quiz_total, 'attempted': quiz_attempted},
+                'assignments': {'total': assignment_total, 'completed': assignment_done},
             })
 
         return Response({
@@ -462,6 +508,7 @@ class StudyChapterDetailView(APIView):
     def get(self, request, chapter_id):
         from content.models import Content, ContentProgress
         from quiz.models import Quiz, QuizAttempt
+        from assignments.models import Assignment, AssignmentSubmission
 
         student = request.user.profile
         try:
@@ -564,6 +611,33 @@ class StudyChapterDetailView(APIView):
                 'last_attempt': attempts[0] if attempts else None,
             })
 
+        assignments = Assignment.objects.filter(
+            topic_id__in=topic_ids, status='published'
+        ).order_by('topic_id', 'order')
+        submission_map = {
+            s.assignment_id: s
+            for s in AssignmentSubmission.objects.filter(
+                student=student, assignment__in=assignments
+            )
+        }
+        assignment_by_topic = {}
+        for a in assignments:
+            tid = str(a.topic_id)
+            if tid not in assignment_by_topic:
+                assignment_by_topic[tid] = []
+            sub = submission_map.get(a.id)
+            assignment_by_topic[tid].append({
+                'id': str(a.id),
+                'title': a.title,
+                'submission_type': a.submission_type,
+                'is_timed': a.is_timed,
+                'due_at': a.due_at.isoformat() if a.due_at else None,
+                'max_marks': a.max_marks,
+                'is_open': a.is_open,
+                'is_completed': sub is not None,
+                'submission_status': sub.status if sub else None,
+            })
+
         topics_payload = []
         for ct in chapter_topics:
             t = ct.topic
@@ -581,6 +655,7 @@ class StudyChapterDetailView(APIView):
                 'reading': content_by_topic.get(tid, {}).get('reading', []),
                 'videos': content_by_topic.get(tid, {}).get('videos', []),
                 'quizzes': quiz_by_topic.get(tid, []),
+                'assignments': assignment_by_topic.get(tid, []),
             })
 
         return Response({

--- a/frontend/exam-frontend/src/components/course/CourseThumbnail.jsx
+++ b/frontend/exam-frontend/src/components/course/CourseThumbnail.jsx
@@ -15,7 +15,6 @@ const TYPE_LABELS = {
  */
 const CourseThumbnail = ({ course, statusBadge = null }) => {
   const [imgOk, setImgOk] = useState(true)
-  const color = course.color || '#f97316'
   const hasImage = !!course.thumbnail && imgOk
   const typeLabel = TYPE_LABELS[course.course_type] || null
 
@@ -32,17 +31,17 @@ const CourseThumbnail = ({ course, statusBadge = null }) => {
       ) : (
         <div
           className="w-full h-full flex items-center justify-center transition-transform duration-300 group-hover:scale-105"
-          style={{ background: `linear-gradient(135deg, ${color} 0%, ${color}cc 55%, ${color}99 100%)` }}
+          style={{ background: 'linear-gradient(135deg, #fdba74 0%, #f97316 45%, #ea580c 100%)' }}
         >
           {/* soft decorative rings */}
-          <div className="absolute -top-8 -right-8 w-32 h-32 rounded-full bg-white/10" />
+          <div className="absolute -top-8 -right-8 w-32 h-32 rounded-full bg-white/15" />
           <div className="absolute -bottom-10 -left-6 w-28 h-28 rounded-full bg-black/10" />
-          <span className="relative font-display font-bold text-white/95 text-5xl sm:text-6xl drop-shadow-sm select-none">
+          <span className="relative font-display font-bold text-white text-5xl sm:text-6xl drop-shadow-sm select-none">
             {course.name.charAt(0).toUpperCase()}
           </span>
           <GraduationCap
             size={40}
-            className="absolute bottom-3 right-3 text-white/25"
+            className="absolute bottom-3 right-3 text-white/30"
             strokeWidth={1.5}
           />
         </div>

--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -89,8 +89,7 @@ const Courses = () => {
                 >
                   <div className="flex items-center gap-3">
                     <span
-                      className="w-10 h-10 rounded-xl flex items-center justify-center text-white shrink-0"
-                      style={{ backgroundColor: course.color || '#f97316' }}
+                      className="w-10 h-10 rounded-xl flex items-center justify-center text-white shrink-0 bg-gradient-to-br from-primary-400 to-primary-600"
                     >
                       <GraduationCap size={20} />
                     </span>
@@ -122,7 +121,6 @@ const Courses = () => {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
           {available.map((course, index) => {
             const status = statusById[course.id]
-            const color = course.color || '#f97316'
             const statusBadge =
               status === 'approved' ? (
                 <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-success-500/95 text-white shadow-sm">
@@ -145,11 +143,6 @@ const Courses = () => {
 
                 <div className="p-4 sm:p-5 flex flex-col flex-1">
                   <h3 className="text-base sm:text-lg font-semibold leading-snug line-clamp-1">{course.name}</h3>
-                  {course.code && (
-                    <span className="inline-flex self-start items-center mt-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium tracking-wide uppercase bg-surface-100 dark:bg-surface-800 text-surface-500">
-                      {course.code}
-                    </span>
-                  )}
                   {course.description && (
                     <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
                   )}
@@ -160,7 +153,6 @@ const Courses = () => {
                         type="button"
                         onClick={() => navigate(`/study/course/${course.id}`)}
                         className="btn-primary w-full group/btn"
-                        style={{ backgroundImage: `linear-gradient(to right, ${color}, ${color})`, boxShadow: `0 8px 18px -8px ${color}` }}
                       >
                         Enter course
                         <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />

--- a/frontend/exam-frontend/src/pages/StudyChapterTopics.jsx
+++ b/frontend/exam-frontend/src/pages/StudyChapterTopics.jsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
 import {
-  BookOpen, PlayCircle, PenTool, ArrowLeft, ChevronRight, Clock,
+  BookOpen, PlayCircle, PenTool, ArrowLeft, ChevronRight, Clock, ClipboardList,
 } from 'lucide-react'
 
 /**
@@ -72,12 +72,13 @@ const StudyChapterTopics = () => {
         ) : (
           <div className="space-y-2">
             {topics.map((item, index) => {
-              const { topic, reading = [], videos = [], quizzes = [] } = item
+              const { topic, reading = [], videos = [], quizzes = [], assignments = [] } = item
               const readingDone = reading.filter(r => r.is_completed).length
               const videosDone = videos.filter(v => v.is_completed).length
               const quizzesAttempted = quizzes.filter(q => q.attempts_count > 0).length
-              const total = reading.length + videos.length + quizzes.length
-              const completed = readingDone + videosDone + quizzesAttempted
+              const assignmentsDone = assignments.filter(a => a.is_completed).length
+              const total = reading.length + videos.length + quizzes.length + assignments.length
+              const completed = readingDone + videosDone + quizzesAttempted + assignmentsDone
               const progress = total > 0 ? Math.round((completed / total) * 100) : 0
 
               return (
@@ -94,7 +95,7 @@ const StudyChapterTopics = () => {
                   </div>
                   <div className="flex-1 min-w-0">
                     <h3 className="font-semibold truncate">{topic.name}</h3>
-                    <div className="flex flex-wrap items-center gap-3 mt-1 text-xs text-surface-500">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs text-surface-500">
                       <span className="flex items-center gap-1">
                         <BookOpen size={12} />
                         {readingDone}/{reading.length} read
@@ -106,6 +107,10 @@ const StudyChapterTopics = () => {
                       <span className="flex items-center gap-1">
                         <PenTool size={12} />
                         {quizzesAttempted}/{quizzes.length} quizzes
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <ClipboardList size={12} />
+                        {assignmentsDone}/{assignments.length} assignments
                       </span>
                     </div>
                   </div>

--- a/frontend/exam-frontend/src/pages/StudyChapters.jsx
+++ b/frontend/exam-frontend/src/pages/StudyChapters.jsx
@@ -5,7 +5,7 @@ import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
 import {
   BookOpen, PlayCircle, PenTool, ChevronRight, ArrowLeft,
-  CheckCircle2, Trophy
+  CheckCircle2, Trophy, ClipboardList
 } from 'lucide-react'
 
 const StudyChapters = () => {
@@ -119,7 +119,7 @@ const StudyChapters = () => {
                       )}
 
                       {/* Stats row */}
-                      <div className="flex items-center gap-4 mt-2 text-xs text-surface-400">
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-surface-400">
                         <span className="flex items-center gap-1">
                           <BookOpen size={12} />
                           {chapter.reading.completed}/{chapter.reading.total} read
@@ -131,6 +131,10 @@ const StudyChapters = () => {
                         <span className="flex items-center gap-1">
                           <PenTool size={12} />
                           {chapter.quizzes.attempted}/{chapter.quizzes.total} quizzes
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <ClipboardList size={12} />
+                          {(chapter.assignments?.completed ?? 0)}/{(chapter.assignments?.total ?? 0)} assignments
                         </span>
                       </div>
 

--- a/frontend/exam-frontend/src/pages/StudyCourse.jsx
+++ b/frontend/exam-frontend/src/pages/StudyCourse.jsx
@@ -7,7 +7,8 @@ import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import {
   BookOpen, Atom, FlaskConical, Calculator, Leaf, Bug,
-  ChevronRight, GraduationCap, ArrowLeft, Settings2
+  ChevronRight, GraduationCap, ArrowLeft, Settings2,
+  PlayCircle, PenTool, ClipboardList
 } from 'lucide-react'
 
 const iconMap = {
@@ -128,8 +129,33 @@ const StudyCourse = () => {
                   </div>
                 </div>
 
-                <div className="flex items-center gap-4 mt-3 text-xs text-surface-400">
+                <div className="flex items-center justify-between mt-3 text-xs text-surface-400">
                   <span>{subject.completed_content}/{subject.total_content} completed</span>
+                  {subject.total_content > subject.completed_content && (
+                    <span className="text-surface-400">
+                      {subject.total_content - subject.completed_content} left
+                    </span>
+                  )}
+                </div>
+
+                {/* Content breakdown */}
+                <div className="grid grid-cols-2 gap-2 mt-3 pt-3 border-t border-surface-100 dark:border-surface-700 text-xs text-surface-500">
+                  <span className="flex items-center gap-1.5">
+                    <BookOpen size={13} className="text-blue-500" />
+                    {(subject.reading?.completed ?? 0)}/{(subject.reading?.total ?? 0)} read
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <PlayCircle size={13} className="text-red-500" />
+                    {(subject.videos?.completed ?? 0)}/{(subject.videos?.total ?? 0)} watched
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <PenTool size={13} className="text-green-500" />
+                    {(subject.quizzes?.attempted ?? 0)}/{(subject.quizzes?.total ?? 0)} quizzes
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <ClipboardList size={13} className="text-purple-500" />
+                    {(subject.assignments?.completed ?? 0)}/{(subject.assignments?.total ?? 0)} tasks
+                  </span>
                 </div>
               </motion.div>
             )


### PR DESCRIPTION
Combines two changes, cleanly rebased on main (supersedes #32, which conflicted due to the #31 squash-merge).

## 1. Content counts at subject, chapter & topic levels
- Subject tiles: per-type breakdown (reading/videos/quizzes/assignments) + 'N left'.
- Chapter tiles: added the missing assignments count.
- Topic tiles: added assignments count, folded into progress.
- Backend (`exams/views.py`): StudySubjectsView / StudyChaptersView / StudyChapterDetailView now return assignment counts; assignments count toward progress; done = student has a submission.

## 2. Brand-themed course tiles
- Course tile banner + Enter-course button use the brand orange gradient instead of per-course colors.
- Removed the course code pill.

## Testing
- `vite build` passes; backend `py_compile` passes.