### PR TITLE
Dedicated assignment grading + per-student review pages

### DIFF
--- a/backend/assignments/admin_serializers.py
+++ b/backend/assignments/admin_serializers.py
@@ -27,13 +27,22 @@ class AdminSubmissionSerializer(serializers.ModelSerializer):
     student_name = serializers.SerializerMethodField()
     student_email = serializers.SerializerMethodField()
     file_url = serializers.SerializerMethodField()
+    file_stream_url = serializers.SerializerMethodField()
+    file_name = serializers.SerializerMethodField()
+    assignment_title = serializers.CharField(source='assignment.title', read_only=True)
+    assignment_instructions = serializers.CharField(source='assignment.instructions', read_only=True)
+    assignment_max_marks = serializers.IntegerField(source='assignment.max_marks', read_only=True)
+    assignment_submission_type = serializers.CharField(source='assignment.submission_type', read_only=True)
+    topic_name = serializers.CharField(source='assignment.topic.name', read_only=True)
 
     class Meta:
         model = AssignmentSubmission
         fields = [
-            'id', 'assignment', 'student', 'student_name', 'student_email',
-            'submission_text', 'file_url', 'submitted_at',
-            'status', 'marks', 'feedback', 'graded_at',
+            'id', 'assignment', 'assignment_title', 'assignment_instructions',
+            'assignment_max_marks', 'assignment_submission_type', 'topic_name',
+            'student', 'student_name', 'student_email',
+            'submission_text', 'file_url', 'file_stream_url', 'file_name',
+            'submitted_at', 'status', 'marks', 'feedback', 'graded_at',
         ]
         read_only_fields = [
             'id', 'assignment', 'student', 'submission_text', 'file_url',
@@ -59,3 +68,14 @@ class AdminSubmissionSerializer(serializers.ModelSerializer):
         request = self.context.get('request')
         url = obj.submission_file.url
         return request.build_absolute_uri(url) if request else url
+
+    def get_file_stream_url(self, obj):
+        """Relative path the frontend PdfReader streams from (authenticated)."""
+        if not obj.submission_file:
+            return None
+        return f'/assignments/admin/submissions/{obj.id}/file/'
+
+    def get_file_name(self, obj):
+        if not obj.submission_file:
+            return None
+        return obj.submission_file.name.rsplit('/', 1)[-1]

--- a/backend/assignments/admin_views.py
+++ b/backend/assignments/admin_views.py
@@ -1,4 +1,7 @@
 """Admin CRUD + submission review for assignments (tenant-admin only)."""
+import mimetypes
+
+from django.http import FileResponse, Http404
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.decorators import action
@@ -48,6 +51,19 @@ class AdminAssignmentViewSet(TenantAdminModelViewSet):
         total = enrollments.count()
         submitted = len(submitted_ids)
         return Response({
+            'assignment': {
+                'id': str(assignment.id),
+                'title': assignment.title,
+                'instructions': assignment.instructions,
+                'submission_type': assignment.submission_type,
+                'max_marks': assignment.max_marks,
+                'status': assignment.status,
+                'is_timed': assignment.is_timed,
+                'due_at': assignment.due_at.isoformat() if assignment.due_at else None,
+                'topic_name': assignment.topic.name if assignment.topic else '',
+                'subject_name': assignment.subject.name if assignment.subject else '',
+                'course': str(assignment.course_id),
+            },
             'submitted': AdminSubmissionSerializer(subs, many=True, context={'request': request}).data,
             'pending': pending,
             'counts': {
@@ -86,3 +102,21 @@ class AdminSubmissionViewSet(TenantAdminModelViewSet):
             obj.graded_at = timezone.now()
             obj.graded_by = self.request.user
             obj.save(update_fields=['status', 'graded_at', 'graded_by'])
+
+    @action(detail=True, methods=['get'], url_path='file')
+    def file(self, request, pk=None):
+        """Stream a student's submitted file inline (view-only) for grading."""
+        submission = self.get_object()
+        if not submission.submission_file:
+            raise Http404('No file submitted.')
+        try:
+            fh = submission.submission_file.open('rb')
+        except Exception:
+            raise Http404('Submission file not found.')
+        name = submission.submission_file.name
+        content_type = mimetypes.guess_type(name)[0] or 'application/pdf'
+        response = FileResponse(fh, content_type=content_type)
+        response['Content-Disposition'] = 'inline; filename="submission.pdf"'
+        response['X-Content-Type-Options'] = 'nosniff'
+        response['Cache-Control'] = 'private, no-store'
+        return response

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -41,6 +41,8 @@ import CommunityPost from './pages/CommunityPost'
 import PreviousYearPapers from './pages/PreviousYearPapers'
 import AdminDashboard from './pages/AdminDashboard'
 import CourseManager from './pages/CourseManager'
+import AssignmentGrading from './pages/AssignmentGrading'
+import SubmissionReview from './pages/SubmissionReview'
 
 
 // Protected Route Component
@@ -141,6 +143,8 @@ function App() {
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/courses" element={<Courses />} />
           <Route path="/courses/:courseId/manage" element={<EditorRoute><CourseManager /></EditorRoute>} />
+          <Route path="/courses/:courseId/manage/assignments/:assignmentId" element={<EditorRoute><AssignmentGrading /></EditorRoute>} />
+          <Route path="/courses/:courseId/manage/assignments/:assignmentId/submissions/:submissionId" element={<EditorRoute><SubmissionReview /></EditorRoute>} />
           <Route path="/study" element={<Study />} />
           <Route path="/study/course/:courseId" element={<StudyCourse />} />
           <Route path="/study/:subjectId" element={<StudyChapters />} />

--- a/frontend/exam-frontend/src/pages/AssignmentGrading.jsx
+++ b/frontend/exam-frontend/src/pages/AssignmentGrading.jsx
@@ -1,0 +1,177 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { motion } from 'framer-motion'
+import {
+  ArrowLeft, Users, CheckCircle2, Clock, Trophy, FileText,
+  ChevronRight, Loader2, ClipboardList,
+} from 'lucide-react'
+import { contentBuilderService as svc } from '../services/contentBuilderService'
+import Loading from '../components/common/Loading'
+
+/**
+ * Dedicated assignment grading page (replaces the old submissions pop-up).
+ * Shows counts, the list of submissions (click to open a focused per-student
+ * review page), and the students still to submit.
+ */
+const AssignmentGrading = () => {
+  const { courseId, assignmentId } = useParams()
+  const navigate = useNavigate()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['cb-submissions', assignmentId],
+    queryFn: () => svc.getAssignmentSubmissions(assignmentId),
+    enabled: !!assignmentId,
+  })
+
+  if (isLoading) return <Loading fullScreen />
+
+  const assignment = data?.assignment || {}
+  const counts = data?.counts || { enrolled: 0, submitted: 0, pending: 0, graded: 0 }
+  const submitted = data?.submitted || []
+  const pending = data?.pending || []
+
+  const stats = [
+    { label: 'Enrolled', value: counts.enrolled, icon: Users, tint: 'text-surface-500 bg-surface-100 dark:bg-surface-800' },
+    { label: 'Submitted', value: counts.submitted, icon: CheckCircle2, tint: 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' },
+    { label: 'Pending', value: counts.pending, icon: Clock, tint: 'text-amber-600 bg-amber-50 dark:bg-amber-900/20' },
+    { label: 'Graded', value: counts.graded, icon: Trophy, tint: 'text-success-600 bg-success-50 dark:bg-success-900/20' },
+  ]
+
+  return (
+    <div className="space-y-6">
+      {/* Breadcrumb / back */}
+      <div className="flex items-center gap-2 text-sm flex-wrap">
+        <button
+          onClick={() => navigate(`/courses/${courseId}/manage`)}
+          className="text-surface-500 hover:text-primary-600 flex items-center gap-1"
+        >
+          <ArrowLeft size={16} /> Course Manager
+        </button>
+        {assignment.subject_name && (
+          <>
+            <span className="text-surface-400">/</span>
+            <span className="text-surface-500">{assignment.subject_name}</span>
+          </>
+        )}
+        {assignment.topic_name && (
+          <>
+            <span className="text-surface-400">/</span>
+            <span className="text-surface-500">{assignment.topic_name}</span>
+          </>
+        )}
+      </div>
+
+      {/* Header */}
+      <div className="card p-6">
+        <div className="flex items-start gap-3">
+          <div className="w-11 h-11 rounded-xl bg-orange-50 dark:bg-orange-900/20 text-orange-600 dark:text-orange-400 flex items-center justify-center shrink-0">
+            <ClipboardList className="w-5 h-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-2xl font-display font-bold">{assignment.title || 'Assignment'}</h1>
+            <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-surface-500">
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800 capitalize">{assignment.status}</span>
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800">
+                {assignment.submission_type === 'pdf' ? 'PDF upload' : assignment.submission_type === 'text' ? 'Text answer' : 'Text or PDF'}
+              </span>
+              {assignment.max_marks != null && (
+                <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800">Max {assignment.max_marks} marks</span>
+              )}
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800 inline-flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {assignment.is_timed && assignment.due_at ? `Due ${new Date(assignment.due_at).toLocaleDateString()}` : 'No deadline'}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {stats.map((s) => (
+          <div key={s.label} className="card p-4 flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${s.tint}`}>
+              <s.icon className="w-5 h-5" />
+            </div>
+            <div>
+              <div className="text-2xl font-bold leading-none">{s.value}</div>
+              <div className="text-xs text-surface-500 mt-1">{s.label}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Submissions list */}
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <CheckCircle2 className="w-5 h-5 text-success-500" /> Submissions ({submitted.length})
+        </h2>
+        {submitted.length === 0 ? (
+          <div className="card p-8 text-center text-surface-500">
+            <FileText className="w-10 h-10 mx-auto mb-2 text-surface-300" />
+            <p>No submissions yet.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {submitted.map((s, i) => (
+              <motion.button
+                key={s.id}
+                type="button"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: i * 0.03 }}
+                onClick={() => navigate(`/courses/${courseId}/manage/assignments/${assignmentId}/submissions/${s.id}`)}
+                className="w-full text-left card p-4 flex items-center gap-4 hover:border-primary-200 dark:hover:border-primary-800 hover:shadow-md transition-all group"
+              >
+                <div className="w-10 h-10 rounded-full bg-primary-50 dark:bg-primary-900/20 text-primary-600 dark:text-primary-400 flex items-center justify-center font-semibold text-sm shrink-0">
+                  {(s.student_name || s.student_email || '?').charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold truncate">{s.student_name || s.student_email}</p>
+                  <p className="text-xs text-surface-400 flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
+                    <span>{new Date(s.submitted_at).toLocaleString()}</span>
+                    {s.file_stream_url && <span className="inline-flex items-center gap-1 text-surface-500"><FileText className="w-3 h-3" /> PDF</span>}
+                    {s.submission_text && <span className="text-surface-500">Text answer</span>}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  {s.status === 'graded' ? (
+                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-success-50 dark:bg-success-900/20 text-success-700 dark:text-success-400">
+                      <Trophy className="w-3.5 h-3.5" />
+                      {s.marks != null ? `${s.marks}${assignment.max_marks ? `/${assignment.max_marks}` : ''}` : 'Graded'}
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400">
+                      Needs grading
+                    </span>
+                  )}
+                  <ChevronRight className="w-5 h-5 text-surface-300 group-hover:text-primary-500 transition-colors" />
+                </div>
+              </motion.button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pending */}
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <Users className="w-5 h-5 text-surface-400" /> Yet to submit ({pending.length})
+        </h2>
+        {pending.length === 0 ? (
+          <p className="text-sm text-surface-400">Everyone enrolled has submitted. 🎉</p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {pending.map((p) => (
+              <span key={p.student} className="text-xs px-3 py-1.5 rounded-full bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-300">
+                {p.student_name || p.student_email}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AssignmentGrading

--- a/frontend/exam-frontend/src/pages/CourseManager.jsx
+++ b/frontend/exam-frontend/src/pages/CourseManager.jsx
@@ -426,141 +426,18 @@ const EmptyHint = ({ icon: Icon, text, sub }) => (
  * Main panel: content + quizzes for the selected topic
  * ========================================================================= */
 /* ===========================================================================
- * Assignments for the selected topic + submissions review drawer
+ * Assignments for the selected topic
  * ========================================================================= */
 const SUBMISSION_TYPE_LABEL = { text: 'Text answer', pdf: 'PDF upload', either: 'Text or PDF' }
 
-const SubmissionsDrawer = ({ assignment, onClose }) => {
-    const queryClient = useQueryClient()
-    const { data, isLoading } = useQuery({
-        queryKey: ['cb-submissions', assignment.id],
-        queryFn: () => svc.getAssignmentSubmissions(assignment.id),
-    })
-    const [grading, setGrading] = useState({})   // subId -> { marks, feedback }
-
-    const gradeMutation = useMutation({
-        mutationFn: ({ id, payload }) => svc.gradeSubmission(id, payload),
-        onSuccess: () => {
-            toast.success('Grade saved')
-            queryClient.invalidateQueries({ queryKey: ['cb-submissions', assignment.id] })
-        },
-        onError: (err) => toast.error(formatApiError(err)),
-    })
-
-    const counts = data?.counts || { enrolled: 0, submitted: 0, pending: 0, graded: 0 }
-
-    return (
-        <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60"
-            {...{ initial: { opacity: 0 }, animate: { opacity: 1 }, exit: { opacity: 0 } }}
-            onMouseDown={(e) => e.target === e.currentTarget && onClose()}
-        >
-            <motion.div
-                className="card w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
-                initial={{ scale: 0.96, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.96, opacity: 0 }}
-            >
-                <div className="flex items-center justify-between p-5 border-b border-surface-200 dark:border-surface-800">
-                    <div className="min-w-0">
-                        <h3 className="text-lg font-bold truncate">{assignment.title}</h3>
-                        <p className="text-xs text-surface-500">Submissions</p>
-                    </div>
-                    <button onClick={onClose} className="btn-icon"><X className="w-5 h-5" /></button>
-                </div>
-
-                {/* Counters */}
-                <div className="grid grid-cols-4 gap-2 p-4 border-b border-surface-100 dark:border-surface-800 text-center">
-                    {[
-                        { label: 'Enrolled', value: counts.enrolled },
-                        { label: 'Submitted', value: counts.submitted },
-                        { label: 'Pending', value: counts.pending },
-                        { label: 'Graded', value: counts.graded },
-                    ].map((s) => (
-                        <div key={s.label} className="rounded-xl bg-surface-50 dark:bg-surface-800 py-2">
-                            <div className="text-xl font-bold text-surface-800 dark:text-surface-100">{s.value}</div>
-                            <div className="text-[11px] text-surface-500">{s.label}</div>
-                        </div>
-                    ))}
-                </div>
-
-                <div className="p-5 overflow-y-auto space-y-5">
-                    {isLoading ? (
-                        <div className="py-8 flex justify-center"><Loader2 className="w-5 h-5 animate-spin text-surface-400" /></div>
-                    ) : (
-                        <>
-                            {/* Submitted */}
-                            <div className="space-y-2">
-                                <h4 className="text-sm font-bold flex items-center gap-1.5"><CheckCircle2 className="w-4 h-4 text-success-500" /> Submitted ({data?.submitted?.length || 0})</h4>
-                                {(data?.submitted || []).length === 0 ? (
-                                    <p className="text-xs text-surface-400">No submissions yet.</p>
-                                ) : data.submitted.map((s) => {
-                                    const g = grading[s.id] || { marks: s.marks ?? '', feedback: s.feedback ?? '' }
-                                    return (
-                                        <div key={s.id} className="card p-3.5 space-y-2">
-                                            <div className="flex items-center justify-between gap-2">
-                                                <div className="min-w-0">
-                                                    <p className="text-sm font-semibold truncate">{s.student_name || s.student_email}</p>
-                                                    <p className="text-[11px] text-surface-400">{new Date(s.submitted_at).toLocaleString()}{s.status === 'graded' && <span className="ml-2 text-success-600 font-medium">• Graded</span>}</p>
-                                                </div>
-                                                {s.file_url && (
-                                                    <a href={s.file_url} target="_blank" rel="noopener noreferrer" className="btn-secondary text-xs px-2.5 py-1 shrink-0">View PDF</a>
-                                                )}
-                                            </div>
-                                            {s.submission_text && (
-                                                <div className="text-xs text-surface-600 dark:text-surface-300 bg-surface-50 dark:bg-surface-800 rounded-lg p-2 max-h-32 overflow-y-auto whitespace-pre-wrap">{s.submission_text}</div>
-                                            )}
-                                            <div className="flex items-end gap-2">
-                                                <div className="w-24">
-                                                    <label className="block text-[10px] font-semibold text-surface-500 mb-1">Marks{assignment.max_marks ? ` / ${assignment.max_marks}` : ''}</label>
-                                                    <input type="number" className="input py-1.5 text-sm" value={g.marks}
-                                                        onChange={(e) => setGrading((p) => ({ ...p, [s.id]: { ...g, marks: e.target.value } }))} />
-                                                </div>
-                                                <div className="flex-1">
-                                                    <label className="block text-[10px] font-semibold text-surface-500 mb-1">Feedback (student sees this)</label>
-                                                    <input type="text" className="input py-1.5 text-sm" value={g.feedback}
-                                                        onChange={(e) => setGrading((p) => ({ ...p, [s.id]: { ...g, feedback: e.target.value } }))} />
-                                                </div>
-                                                <button
-                                                    onClick={() => gradeMutation.mutate({ id: s.id, payload: { marks: g.marks === '' ? null : Number(g.marks), feedback: g.feedback } })}
-                                                    disabled={gradeMutation.isPending}
-                                                    className="btn-primary text-xs px-3 py-2 shrink-0"
-                                                >
-                                                    <Save className="w-3.5 h-3.5" /> Save
-                                                </button>
-                                            </div>
-                                        </div>
-                                    )
-                                })}
-                            </div>
-
-                            {/* Pending */}
-                            <div className="space-y-2">
-                                <h4 className="text-sm font-bold flex items-center gap-1.5"><Users className="w-4 h-4 text-surface-400" /> Yet to submit ({data?.pending?.length || 0})</h4>
-                                {(data?.pending || []).length === 0 ? (
-                                    <p className="text-xs text-surface-400">Everyone enrolled has submitted. 🎉</p>
-                                ) : (
-                                    <div className="flex flex-wrap gap-2">
-                                        {data.pending.map((p) => (
-                                            <span key={p.student} className="text-xs px-2.5 py-1 rounded-full bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-300">
-                                                {p.student_name || p.student_email}
-                                            </span>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        </>
-                    )}
-                </div>
-            </motion.div>
-        </motion.div>
-    )
-}
 
 const AssignmentSection = ({ topic, subjectId, openModal, askDelete }) => {
+    const navigate = useNavigate()
+    const { courseId } = useParams()
     const { data: assignments = [], isLoading } = useQuery({
         queryKey: ['cb-assignments', topic.id],
         queryFn: () => svc.getAssignments(topic.id),
     })
-    const [viewing, setViewing] = useState(null)
 
     if (isLoading) {
         return <div className="py-8 flex justify-center"><Loader2 className="w-5 h-5 animate-spin text-surface-400" /></div>
@@ -601,7 +478,7 @@ const AssignmentSection = ({ topic, subjectId, openModal, askDelete }) => {
                                 </div>
                             </div>
                             <div className="flex items-center gap-2 shrink-0">
-                                <button onClick={() => setViewing(a)} className="btn-secondary text-xs px-2.5 py-1.5">
+                                <button onClick={() => navigate(`/courses/${courseId}/manage/assignments/${a.id}`)} className="btn-secondary text-xs px-2.5 py-1.5">
                                     <Users className="w-3.5 h-3.5" /> <span className="hidden sm:inline">Submissions</span>
                                 </button>
                                 <div className="opacity-0 group-hover:opacity-100 transition-opacity">
@@ -615,10 +492,6 @@ const AssignmentSection = ({ topic, subjectId, openModal, askDelete }) => {
                     ))}
                 </div>
             )}
-
-            <AnimatePresence>
-                {viewing && <SubmissionsDrawer assignment={viewing} onClose={() => setViewing(null)} />}
-            </AnimatePresence>
         </div>
     )
 }

--- a/frontend/exam-frontend/src/pages/SubmissionReview.jsx
+++ b/frontend/exam-frontend/src/pages/SubmissionReview.jsx
@@ -1,0 +1,210 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import {
+  ArrowLeft, ChevronLeft, ChevronRight, Save, Trophy, Clock,
+  FileText, Loader2, User, CheckCircle2,
+} from 'lucide-react'
+import { contentBuilderService as svc } from '../services/contentBuilderService'
+import { formatApiError } from '../components/admin/builderShared'
+import PdfReader from '../components/content/PdfReader'
+import Loading from '../components/common/Loading'
+
+/**
+ * Focused per-student submission review + grading page.
+ * The submitted PDF is rendered inline (view-only) alongside the text answer,
+ * with a sticky grading panel and prev/next navigation across submissions.
+ */
+const SubmissionReview = () => {
+  const { courseId, assignmentId, submissionId } = useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const { data: submission, isLoading } = useQuery({
+    queryKey: ['cb-submission', submissionId],
+    queryFn: () => svc.getSubmission(submissionId),
+    enabled: !!submissionId,
+  })
+
+  // Sibling submissions for prev/next navigation.
+  const { data: listData } = useQuery({
+    queryKey: ['cb-submissions', assignmentId],
+    queryFn: () => svc.getAssignmentSubmissions(assignmentId),
+    enabled: !!assignmentId,
+  })
+
+  const submitted = useMemo(() => listData?.submitted || [], [listData])
+  const idx = submitted.findIndex((s) => String(s.id) === String(submissionId))
+  const prev = idx > 0 ? submitted[idx - 1] : null
+  const next = idx >= 0 && idx < submitted.length - 1 ? submitted[idx + 1] : null
+
+  const [marks, setMarks] = useState('')
+  const [feedback, setFeedback] = useState('')
+
+  useEffect(() => {
+    if (submission) {
+      setMarks(submission.marks ?? '')
+      setFeedback(submission.feedback ?? '')
+    }
+  }, [submission])
+
+  const gradeMutation = useMutation({
+    mutationFn: (payload) => svc.gradeSubmission(submissionId, payload),
+    onSuccess: () => {
+      toast.success('Grade saved')
+      queryClient.invalidateQueries({ queryKey: ['cb-submission', submissionId] })
+      queryClient.invalidateQueries({ queryKey: ['cb-submissions', assignmentId] })
+    },
+    onError: (err) => toast.error(formatApiError(err)),
+  })
+
+  if (isLoading) return <Loading fullScreen />
+  if (!submission) return null
+
+  const maxMarks = submission.assignment_max_marks
+  const goTo = (s) => navigate(`/courses/${courseId}/manage/assignments/${assignmentId}/submissions/${s.id}`)
+
+  return (
+    <div className="space-y-5">
+      {/* Breadcrumb / back */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <button
+          onClick={() => navigate(`/courses/${courseId}/manage/assignments/${assignmentId}`)}
+          className="text-sm text-surface-500 hover:text-primary-600 flex items-center gap-1"
+        >
+          <ArrowLeft size={16} /> Back to all submissions
+        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => prev && goTo(prev)}
+            disabled={!prev}
+            className="btn-secondary text-xs px-3 py-1.5 disabled:opacity-40"
+          >
+            <ChevronLeft size={15} /> Prev
+          </button>
+          {idx >= 0 && (
+            <span className="text-xs text-surface-500 tabular-nums">{idx + 1} / {submitted.length}</span>
+          )}
+          <button
+            onClick={() => next && goTo(next)}
+            disabled={!next}
+            className="btn-secondary text-xs px-3 py-1.5 disabled:opacity-40"
+          >
+            Next <ChevronRight size={15} />
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_340px] gap-5 items-start">
+        {/* Main: submission content */}
+        <div className="space-y-4 order-2 lg:order-1">
+          <div className="card p-5">
+            <h1 className="text-lg font-display font-bold truncate">{submission.assignment_title}</h1>
+            <p className="text-xs text-surface-500 mt-0.5">{submission.topic_name}</p>
+          </div>
+
+          {submission.submission_text && (
+            <div className="card p-5">
+              <h3 className="text-sm font-semibold mb-2 flex items-center gap-1.5 text-surface-600 dark:text-surface-300">
+                <FileText className="w-4 h-4" /> Text answer
+              </h3>
+              <div className="text-sm text-surface-700 dark:text-surface-200 whitespace-pre-wrap leading-relaxed">
+                {submission.submission_text}
+              </div>
+            </div>
+          )}
+
+          {submission.file_stream_url ? (
+            <div>
+              <h3 className="text-sm font-semibold mb-2 flex items-center gap-1.5 text-surface-600 dark:text-surface-300">
+                <FileText className="w-4 h-4" /> Submitted PDF
+              </h3>
+              <PdfReader url={submission.file_stream_url} />
+            </div>
+          ) : !submission.submission_text ? (
+            <div className="card p-8 text-center text-surface-500">
+              <FileText className="w-10 h-10 mx-auto mb-2 text-surface-300" />
+              <p>No content submitted.</p>
+            </div>
+          ) : null}
+        </div>
+
+        {/* Sidebar: student + grading */}
+        <aside className="order-1 lg:order-2 space-y-4 lg:sticky lg:top-6">
+          <div className="card p-5">
+            <div className="flex items-center gap-3">
+              <div className="w-11 h-11 rounded-full bg-primary-50 dark:bg-primary-900/20 text-primary-600 dark:text-primary-400 flex items-center justify-center font-semibold shrink-0">
+                {(submission.student_name || submission.student_email || '?').charAt(0).toUpperCase()}
+              </div>
+              <div className="min-w-0">
+                <p className="font-semibold truncate">{submission.student_name || 'Student'}</p>
+                <p className="text-xs text-surface-400 truncate">{submission.student_email}</p>
+              </div>
+            </div>
+            <div className="mt-3 pt-3 border-t border-surface-100 dark:border-surface-800 text-xs text-surface-500 space-y-1.5">
+              <p className="flex items-center gap-1.5"><Clock className="w-3.5 h-3.5" /> Submitted {new Date(submission.submitted_at).toLocaleString()}</p>
+              {submission.status === 'graded' ? (
+                <p className="flex items-center gap-1.5 text-success-600 dark:text-success-400 font-medium"><CheckCircle2 className="w-3.5 h-3.5" /> Graded</p>
+              ) : (
+                <p className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400 font-medium"><Clock className="w-3.5 h-3.5" /> Awaiting grade</p>
+              )}
+            </div>
+          </div>
+
+          <div className="card p-5 space-y-4">
+            <h3 className="font-semibold flex items-center gap-1.5"><Trophy className="w-4 h-4 text-warning-500" /> Grade</h3>
+            <div>
+              <label className="block text-xs font-semibold text-surface-500 mb-1">
+                Marks{maxMarks != null ? ` (out of ${maxMarks})` : ''}
+              </label>
+              <input
+                type="number"
+                min="0"
+                max={maxMarks ?? undefined}
+                className="input"
+                value={marks}
+                onChange={(e) => setMarks(e.target.value)}
+                placeholder="e.g. 18"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-surface-500 mb-1">Feedback (student sees this)</label>
+              <textarea
+                rows={5}
+                className="input resize-none"
+                value={feedback}
+                onChange={(e) => setFeedback(e.target.value)}
+                placeholder="Share what was good and what to improve…"
+              />
+            </div>
+            <button
+              onClick={() => gradeMutation.mutate({ marks: marks === '' ? null : Number(marks), feedback })}
+              disabled={gradeMutation.isPending}
+              className="btn-primary w-full"
+            >
+              {gradeMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+              Save grade
+            </button>
+            {next && (
+              <button
+                onClick={() => {
+                  gradeMutation.mutate(
+                    { marks: marks === '' ? null : Number(marks), feedback },
+                    { onSuccess: () => goTo(next) }
+                  )
+                }}
+                disabled={gradeMutation.isPending}
+                className="btn-secondary w-full text-sm"
+              >
+                Save & next <ChevronRight size={15} />
+              </button>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+export default SubmissionReview

--- a/frontend/exam-frontend/src/services/contentBuilderService.js
+++ b/frontend/exam-frontend/src/services/contentBuilderService.js
@@ -101,10 +101,16 @@ export const contentBuilderService = {
     return (await api.patch(`/assignments/admin/assignments/${id}/`, body, config)).data
   },
   deleteAssignment: async (id) => api.delete(`/assignments/admin/assignments/${id}/`),
+  getAssignment: async (id) =>
+    (await api.get(`/assignments/admin/assignments/${id}/`)).data,
   getAssignmentSubmissions: async (id) =>
     (await api.get(`/assignments/admin/assignments/${id}/submissions/`)).data,
+  getSubmission: async (id) =>
+    (await api.get(`/assignments/admin/submissions/${id}/`)).data,
   gradeSubmission: async (id, data) =>
     (await api.patch(`/assignments/admin/submissions/${id}/`, data)).data,
+  // Authenticated view-only stream of a student's submitted PDF (for PdfReader).
+  submissionFileUrl: (id) => `/assignments/admin/submissions/${id}/file/`,
 }
 
 export default contentBuilderService


### PR DESCRIPTION
Replaces the submissions pop-up drawer with full pages:

- **Assignment grading page** (`/courses/:courseId/manage/assignments/:assignmentId`) — stats cards + full submissions list, each row navigates to the focused review.
- **Per-student review page** (`.../submissions/:submissionId`) — renders the submitted PDF inline (view-only) with a sticky grade panel (marks, feedback, Save / Save & Next, prev/next nav).

Backend: submission summary block + inline PDF stream endpoint (`/assignments/admin/submissions/:id/file/`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>