### PR TITLE
Show coding stats across study flow and hide empty (0/0) content categories

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -260,6 +260,7 @@ class StudySubjectsView(APIView):
         from content.models import Content, ContentProgress
         from quiz.models import Quiz, QuizAttempt
         from assignments.models import Assignment, AssignmentSubmission
+        from coding.models import CodingProblem, CodingSubmission
 
         student = request.user.profile
         course_id = request.query_params.get('course_id')
@@ -332,11 +333,22 @@ class StudySubjectsView(APIView):
                 assignment__status='published',
             ).values('assignment').distinct().count()
 
+            coding_total = CodingProblem.objects.filter(
+                topic_id__in=subj_topic_ids, status='published',
+            ).count()
+            coding_done = CodingSubmission.objects.filter(
+                student=student,
+                problem__topic_id__in=subj_topic_ids,
+                problem__status='published',
+                total_count__gt=0,
+                passed_count=F('total_count'),
+            ).values('problem').distinct().count()
+
             content_count = reading_total + video_total
             content_done = reading_done + video_done
 
-            total_content = content_count + quiz_count + assignment_total
-            completed_content = content_done + quiz_done + assignment_done
+            total_content = content_count + quiz_count + assignment_total + coding_total
+            completed_content = content_done + quiz_done + assignment_done + coding_done
             progress = (
                 round((completed_content / total_content) * 100)
                 if total_content > 0 else 0
@@ -362,6 +374,7 @@ class StudySubjectsView(APIView):
                 'videos': {'total': video_total, 'completed': video_done},
                 'quizzes': {'total': quiz_count, 'attempted': quiz_done},
                 'assignments': {'total': assignment_total, 'completed': assignment_done},
+                'coding': {'total': coding_total, 'completed': coding_done},
             })
 
         return Response(result)
@@ -378,6 +391,7 @@ class StudyChaptersView(APIView):
         from content.models import Content, ContentProgress
         from quiz.models import Quiz, QuizAttempt
         from assignments.models import Assignment, AssignmentSubmission
+        from coding.models import CodingProblem, CodingSubmission
 
         student = request.user.profile
         try:
@@ -463,8 +477,19 @@ class StudyChaptersView(APIView):
                 assignment__status='published',
             ).values('assignment').distinct().count()
 
-            total_content = content_count + quiz_count + assignment_total
-            completed_content = content_done + quiz_done + assignment_done
+            coding_total = CodingProblem.objects.filter(
+                topic_id__in=topic_ids, status='published',
+            ).count()
+            coding_done = CodingSubmission.objects.filter(
+                student=student,
+                problem__topic_id__in=topic_ids,
+                problem__status='published',
+                total_count__gt=0,
+                passed_count=F('total_count'),
+            ).values('problem').distinct().count()
+
+            total_content = content_count + quiz_count + assignment_total + coding_total
+            completed_content = content_done + quiz_done + assignment_done + coding_done
 
             progress = (
                 round((completed_content / total_content) * 100)
@@ -485,6 +510,7 @@ class StudyChaptersView(APIView):
                 'videos': {'total': video_total, 'completed': video_done},
                 'quizzes': {'total': quiz_total, 'attempted': quiz_attempted},
                 'assignments': {'total': assignment_total, 'completed': assignment_done},
+                'coding': {'total': coding_total, 'completed': coding_done},
             })
 
         return Response({
@@ -509,6 +535,7 @@ class StudyChapterDetailView(APIView):
         from content.models import Content, ContentProgress
         from quiz.models import Quiz, QuizAttempt
         from assignments.models import Assignment, AssignmentSubmission
+        from coding.models import CodingProblem, CodingSubmission
 
         student = request.user.profile
         try:
@@ -638,6 +665,32 @@ class StudyChapterDetailView(APIView):
                 'submission_status': sub.status if sub else None,
             })
 
+        coding_problems = CodingProblem.objects.filter(
+            topic_id__in=topic_ids, status='published'
+        ).order_by('topic_id', 'order')
+        coding_sub_map = {}
+        for cs in CodingSubmission.objects.filter(
+            student=student, problem__in=coding_problems
+        ):
+            info = coding_sub_map.setdefault(
+                cs.problem_id, {'attempts': 0, 'solved': False}
+            )
+            info['attempts'] += 1
+            if cs.total_count > 0 and cs.passed_count == cs.total_count:
+                info['solved'] = True
+        coding_by_topic = {}
+        for p in coding_problems:
+            tid = str(p.topic_id)
+            info = coding_sub_map.get(p.id, {'attempts': 0, 'solved': False})
+            coding_by_topic.setdefault(tid, []).append({
+                'id': str(p.id),
+                'title': p.title,
+                'difficulty': p.difficulty,
+                'max_marks': p.max_marks,
+                'attempts_count': info['attempts'],
+                'is_completed': info['solved'],
+            })
+
         topics_payload = []
         for ct in chapter_topics:
             t = ct.topic
@@ -656,6 +709,7 @@ class StudyChapterDetailView(APIView):
                 'videos': content_by_topic.get(tid, {}).get('videos', []),
                 'quizzes': quiz_by_topic.get(tid, []),
                 'assignments': assignment_by_topic.get(tid, []),
+                'coding': coding_by_topic.get(tid, []),
             })
 
         return Response({

--- a/frontend/exam-frontend/src/pages/StudyChapterTopics.jsx
+++ b/frontend/exam-frontend/src/pages/StudyChapterTopics.jsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
 import {
-  BookOpen, PlayCircle, PenTool, ArrowLeft, ChevronRight, Clock, ClipboardList,
+  BookOpen, PlayCircle, PenTool, ArrowLeft, ChevronRight, Clock, ClipboardList, Code2,
 } from 'lucide-react'
 
 /**
@@ -72,14 +72,22 @@ const StudyChapterTopics = () => {
         ) : (
           <div className="space-y-2">
             {topics.map((item, index) => {
-              const { topic, reading = [], videos = [], quizzes = [], assignments = [] } = item
+              const { topic, reading = [], videos = [], quizzes = [], assignments = [], coding = [] } = item
               const readingDone = reading.filter(r => r.is_completed).length
               const videosDone = videos.filter(v => v.is_completed).length
               const quizzesAttempted = quizzes.filter(q => q.attempts_count > 0).length
               const assignmentsDone = assignments.filter(a => a.is_completed).length
-              const total = reading.length + videos.length + quizzes.length + assignments.length
-              const completed = readingDone + videosDone + quizzesAttempted + assignmentsDone
+              const codingDone = coding.filter(c => c.is_completed).length
+              const total = reading.length + videos.length + quizzes.length + assignments.length + coding.length
+              const completed = readingDone + videosDone + quizzesAttempted + assignmentsDone + codingDone
               const progress = total > 0 ? Math.round((completed / total) * 100) : 0
+              const stats = [
+                { icon: BookOpen, done: readingDone, total: reading.length, label: 'read' },
+                { icon: PlayCircle, done: videosDone, total: videos.length, label: 'watched' },
+                { icon: PenTool, done: quizzesAttempted, total: quizzes.length, label: 'quizzes' },
+                { icon: Code2, done: codingDone, total: coding.length, label: 'coding' },
+                { icon: ClipboardList, done: assignmentsDone, total: assignments.length, label: 'assignments' },
+              ].filter(s => s.total > 0)
 
               return (
                 <motion.div
@@ -96,22 +104,15 @@ const StudyChapterTopics = () => {
                   <div className="flex-1 min-w-0">
                     <h3 className="font-semibold truncate">{topic.name}</h3>
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs text-surface-500">
-                      <span className="flex items-center gap-1">
-                        <BookOpen size={12} />
-                        {readingDone}/{reading.length} read
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <PlayCircle size={12} />
-                        {videosDone}/{videos.length} watched
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <PenTool size={12} />
-                        {quizzesAttempted}/{quizzes.length} quizzes
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <ClipboardList size={12} />
-                        {assignmentsDone}/{assignments.length} assignments
-                      </span>
+                      {stats.map((s, i) => {
+                        const Icon = s.icon
+                        return (
+                          <span key={i} className="flex items-center gap-1">
+                            <Icon size={12} />
+                            {s.done}/{s.total} {s.label}
+                          </span>
+                        )
+                      })}
                     </div>
                   </div>
                   <div className="flex items-center gap-3 flex-shrink-0">

--- a/frontend/exam-frontend/src/pages/StudyChapters.jsx
+++ b/frontend/exam-frontend/src/pages/StudyChapters.jsx
@@ -5,7 +5,7 @@ import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
 import {
   BookOpen, PlayCircle, PenTool, ChevronRight, ArrowLeft,
-  CheckCircle2, Trophy, ClipboardList
+  CheckCircle2, Trophy, ClipboardList, Code2
 } from 'lucide-react'
 
 const StudyChapters = () => {
@@ -118,24 +118,23 @@ const StudyChapters = () => {
                         </p>
                       )}
 
-                      {/* Stats row */}
+                      {/* Stats row — only categories that have content */}
                       <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-surface-400">
-                        <span className="flex items-center gap-1">
-                          <BookOpen size={12} />
-                          {chapter.reading.completed}/{chapter.reading.total} read
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <PlayCircle size={12} />
-                          {chapter.videos.completed}/{chapter.videos.total} watched
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <PenTool size={12} />
-                          {chapter.quizzes.attempted}/{chapter.quizzes.total} quizzes
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <ClipboardList size={12} />
-                          {(chapter.assignments?.completed ?? 0)}/{(chapter.assignments?.total ?? 0)} assignments
-                        </span>
+                        {[
+                          { icon: BookOpen, done: chapter.reading?.completed ?? 0, total: chapter.reading?.total ?? 0, label: 'read' },
+                          { icon: PlayCircle, done: chapter.videos?.completed ?? 0, total: chapter.videos?.total ?? 0, label: 'watched' },
+                          { icon: PenTool, done: chapter.quizzes?.attempted ?? 0, total: chapter.quizzes?.total ?? 0, label: 'quizzes' },
+                          { icon: Code2, done: chapter.coding?.completed ?? 0, total: chapter.coding?.total ?? 0, label: 'coding' },
+                          { icon: ClipboardList, done: chapter.assignments?.completed ?? 0, total: chapter.assignments?.total ?? 0, label: 'assignments' },
+                        ].filter((s) => s.total > 0).map((s, i) => {
+                          const Icon = s.icon
+                          return (
+                            <span key={i} className="flex items-center gap-1">
+                              <Icon size={12} />
+                              {s.done}/{s.total} {s.label}
+                            </span>
+                          )
+                        })}
                       </div>
 
                       {/* Progress bar */}

--- a/frontend/exam-frontend/src/pages/StudyCourse.jsx
+++ b/frontend/exam-frontend/src/pages/StudyCourse.jsx
@@ -8,7 +8,7 @@ import Loading from '../components/common/Loading'
 import {
   BookOpen, Atom, FlaskConical, Calculator, Leaf, Bug,
   ChevronRight, GraduationCap, ArrowLeft, Settings2,
-  PlayCircle, PenTool, ClipboardList
+  PlayCircle, PenTool, ClipboardList, Code2
 } from 'lucide-react'
 
 const iconMap = {
@@ -138,25 +138,30 @@ const StudyCourse = () => {
                   )}
                 </div>
 
-                {/* Content breakdown */}
-                <div className="grid grid-cols-2 gap-2 mt-3 pt-3 border-t border-surface-100 dark:border-surface-700 text-xs text-surface-500">
-                  <span className="flex items-center gap-1.5">
-                    <BookOpen size={13} className="text-blue-500" />
-                    {(subject.reading?.completed ?? 0)}/{(subject.reading?.total ?? 0)} read
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <PlayCircle size={13} className="text-red-500" />
-                    {(subject.videos?.completed ?? 0)}/{(subject.videos?.total ?? 0)} watched
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <PenTool size={13} className="text-green-500" />
-                    {(subject.quizzes?.attempted ?? 0)}/{(subject.quizzes?.total ?? 0)} quizzes
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <ClipboardList size={13} className="text-purple-500" />
-                    {(subject.assignments?.completed ?? 0)}/{(subject.assignments?.total ?? 0)} tasks
-                  </span>
-                </div>
+                {/* Content breakdown — only show categories that have content */}
+                {(() => {
+                  const stats = [
+                    { icon: BookOpen, color: 'text-blue-500', done: subject.reading?.completed ?? 0, total: subject.reading?.total ?? 0, label: 'read' },
+                    { icon: PlayCircle, color: 'text-red-500', done: subject.videos?.completed ?? 0, total: subject.videos?.total ?? 0, label: 'watched' },
+                    { icon: PenTool, color: 'text-green-500', done: subject.quizzes?.attempted ?? 0, total: subject.quizzes?.total ?? 0, label: 'quizzes' },
+                    { icon: Code2, color: 'text-primary-500', done: subject.coding?.completed ?? 0, total: subject.coding?.total ?? 0, label: 'coding' },
+                    { icon: ClipboardList, color: 'text-purple-500', done: subject.assignments?.completed ?? 0, total: subject.assignments?.total ?? 0, label: 'tasks' },
+                  ].filter((s) => s.total > 0)
+                  if (!stats.length) return null
+                  return (
+                    <div className="grid grid-cols-2 gap-2 mt-3 pt-3 border-t border-surface-100 dark:border-surface-700 text-xs text-surface-500">
+                      {stats.map((s, i) => {
+                        const Icon = s.icon
+                        return (
+                          <span key={i} className="flex items-center gap-1.5">
+                            <Icon size={13} className={s.color} />
+                            {s.done}/{s.total} {s.label}
+                          </span>
+                        )
+                      })}
+                    </div>
+                  )
+                })()}
               </motion.div>
             )
           })}

--- a/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
+++ b/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
@@ -75,6 +75,15 @@ const StudyTopicContent = () => {
   const readingDone = reading.filter(r => r.is_completed).length
   const videosDone = videos.filter(v => v.is_completed).length
   const quizzesAttempted = quizzes.filter(q => q.attempts_count > 0).length
+  const codingDone = codingProblems.filter(p => p.my_best?.all_passed).length
+  const assignmentsDone = assignments.filter(a => a.is_completed).length
+  const headerStats = [
+    { icon: BookOpen, color: 'text-blue-500', done: readingDone, total: reading.length, label: 'read' },
+    { icon: PlayCircle, color: 'text-red-500', done: videosDone, total: videos.length, label: 'watched' },
+    { icon: PenTool, color: 'text-green-500', done: quizzesAttempted, total: quizzes.length, label: 'quizzes' },
+    { icon: Code2, color: 'text-primary-500', done: codingDone, total: codingProblems.length, label: 'coding' },
+    { icon: ClipboardList, color: 'text-purple-500', done: assignmentsDone, total: assignments.length, label: 'assignments' },
+  ].filter(s => s.total > 0)
 
   return (
     <div className="space-y-6">
@@ -111,18 +120,15 @@ const StudyTopicContent = () => {
           Notes and quizzes for this topic
         </p>
         <div className="flex flex-wrap items-center gap-5 mt-4 text-sm text-surface-500">
-          <span className="flex items-center gap-1.5">
-            <BookOpen size={16} className="text-blue-500" />
-            {readingDone}/{reading.length} read
-          </span>
-          <span className="flex items-center gap-1.5">
-            <PlayCircle size={16} className="text-red-500" />
-            {videosDone}/{videos.length} watched
-          </span>
-          <span className="flex items-center gap-1.5">
-            <PenTool size={16} className="text-green-500" />
-            {quizzesAttempted}/{quizzes.length} quizzes
-          </span>
+          {headerStats.map((s, i) => {
+            const Icon = s.icon
+            return (
+              <span key={i} className="flex items-center gap-1.5">
+                <Icon size={16} className={s.color} />
+                {s.done}/{s.total} {s.label}
+              </span>
+            )
+          })}
           {topic.estimated_study_hours > 0 && (
             <span className="flex items-center gap-1.5">
               <Clock size={16} className="text-warning-500" />
@@ -143,6 +149,8 @@ const StudyTopicContent = () => {
             : tab.key === 'assignments' ? assignments.length
             : tab.key === 'coding' ? codingProblems.length
             : 0
+          // Hide categories that have no content (keep "All" always visible).
+          if (tab.key !== 'all' && count === 0) return null
           return (
             <button
               key={tab.key}


### PR DESCRIPTION
## What & why

Two related UX fixes reported from the deployed Python Programming course:

1. **Coding problems were invisible in progress stats.** The study surfaces (subject cards, chapter cards, topic rows, topic content header) counted reading / video / quiz / assignment but not coding. Coding is now shown everywhere alongside them.
2. **`0/0` looked broken.** Categories with no content (e.g. `0/0 watched`, `0/0 tasks`) rendered anyway. Now any category whose total is 0 is hidden, and empty tabs on the topic content page are hidden (the "All" tab always stays).

## Changes

**Backend (`exams/views.py`)**
- `StudySubjectsView`, `StudyChaptersView`: compute `coding_total` / `coding_done` (a problem is "solved" when a submission passes all test cases) and include coding in `total_content` / `completed_content` + a `coding` block in the response.
- `StudyChapterDetailView`: return a per-topic `coding` array (title, difficulty, marks, attempts, solved) so the topic list can show coding progress.

**Frontend**
- `StudyCourse.jsx`, `StudyChapters.jsx`, `StudyChapterTopics.jsx`: data-driven stat rows that add a **coding** stat and filter out any category with `total === 0`. The "X/Y completed" summary is unaffected.
- `StudyTopicContent.jsx`: header stats are now data-driven (adds coding + assignments, hides 0/0); empty tabs are hidden except "All".

## Verification
- Backend queries validated against the live DB (Python course: `coding_total=8`, `coding_done=1`).
- `npm run build` passes.