### PR TITLE
Award XP for solving coding problems and graded assignments

### DIFF
--- a/backend/assignments/admin_views.py
+++ b/backend/assignments/admin_views.py
@@ -103,6 +103,23 @@ class AdminSubmissionViewSet(TenantAdminModelViewSet):
             obj.graded_by = self.request.user
             obj.save(update_fields=['status', 'graded_at', 'graded_by'])
 
+            # Award XP the first time this submission is graded.
+            from gamification.models import XPTransaction
+            from gamification.services import GamificationService
+            from core.utils import calculate_xp_for_assignment
+
+            already_awarded = XPTransaction.objects.filter(
+                student=obj.student, transaction_type='assignment_graded', reference_id=obj.id,
+            ).exists()
+            if not already_awarded:
+                GamificationService.award_xp(
+                    obj.student,
+                    calculate_xp_for_assignment(obj.marks, obj.assignment.max_marks),
+                    'assignment_graded',
+                    f'Assignment graded: {obj.assignment.title}',
+                    str(obj.id),
+                )
+
     @action(detail=True, methods=['get'], url_path='file')
     def file(self, request, pk=None):
         """Stream a student's submitted file inline (view-only) for grading."""

--- a/backend/coding/views.py
+++ b/backend/coding/views.py
@@ -173,7 +173,30 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
             total_points=outcome['total_points'],
             marks=marks,
         )
-        return Response(SubmissionResultSerializer(submission).data, status=status.HTTP_201_CREATED)
+
+        # Award XP the first time the student fully solves this problem.
+        xp_awarded = 0
+        if submission.total_count > 0 and submission.passed_count == submission.total_count:
+            from gamification.models import XPTransaction
+            from gamification.services import GamificationService
+            from core.utils import calculate_xp_for_coding
+
+            already_awarded = XPTransaction.objects.filter(
+                student=student, transaction_type='coding_solved', reference_id=problem.id,
+            ).exists()
+            if not already_awarded:
+                xp_awarded = calculate_xp_for_coding(problem.difficulty)
+                GamificationService.award_xp(
+                    student,
+                    xp_awarded,
+                    'coding_solved',
+                    f'Solved coding problem: {problem.title}',
+                    str(problem.id),
+                )
+
+        data = SubmissionResultSerializer(submission).data
+        data['xp_awarded'] = xp_awarded
+        return Response(data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=['get'], url_path='my-submissions')
     def my_submissions(self, request, pk=None):

--- a/backend/core/utils.py
+++ b/backend/core/utils.py
@@ -77,6 +77,28 @@ def get_mastery_level(accuracy):
 QUIZ_XP_CAP = 25
 QUIZ_XP_CAP_DAILY_CHALLENGE = 40
 
+# Coding-problem solve XP by difficulty. Awarded once, on the first fully-passing
+# submission. A solve is more effort than a single quiz, so it sits above the quiz cap.
+CODING_XP_BY_DIFFICULTY = {'easy': 15, 'medium': 25, 'hard': 40}
+
+# Assignment XP. Awarded once, when a submission is first graded. Scaled by the
+# score when the assignment defines max_marks; otherwise a flat completion award.
+ASSIGNMENT_XP_MAX = 30
+ASSIGNMENT_XP_MIN = 5
+
+
+def calculate_xp_for_coding(difficulty):
+    """XP for solving a coding problem (all test cases passed)."""
+    return CODING_XP_BY_DIFFICULTY.get(difficulty, CODING_XP_BY_DIFFICULTY['easy'])
+
+
+def calculate_xp_for_assignment(marks, max_marks):
+    """XP for a graded assignment submission, scaled by score when possible."""
+    if max_marks and marks is not None:
+        ratio = max(0.0, min(1.0, float(marks) / float(max_marks)))
+        return max(ASSIGNMENT_XP_MIN, round(ASSIGNMENT_XP_MAX * ratio))
+    return ASSIGNMENT_XP_MAX
+
 
 def calculate_xp_for_quiz(accuracy, questions_count, is_daily_challenge=False):
     """

--- a/backend/gamification/migrations/0008_xp_coding_assignment_types.py
+++ b/backend/gamification/migrations/0008_xp_coding_assignment_types.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gamification', '0007_alter_course_fk_metadata'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='xptransaction',
+            name='transaction_type',
+            field=models.CharField(choices=[('quiz_complete', 'Quiz Completed'), ('mock_complete', 'Mock Test Completed'), ('content_complete', 'Content Completed'), ('ai_quiz', 'AI Quiz Completed'), ('coding_solved', 'Coding Problem Solved'), ('assignment_graded', 'Assignment Graded'), ('daily_goal', 'Daily Goal Met'), ('streak_bonus', 'Streak Bonus'), ('badge_earned', 'Badge Earned'), ('level_up', 'Level Up Bonus'), ('referral', 'Referral Bonus'), ('challenge_win', 'Challenge Won'), ('community', 'Community Activity'), ('manual', 'Manual Adjustment')], max_length=30),
+        ),
+    ]

--- a/backend/gamification/models.py
+++ b/backend/gamification/models.py
@@ -91,6 +91,8 @@ class XPTransaction(TimeStampedModel):
         ('mock_complete', 'Mock Test Completed'),
         ('content_complete', 'Content Completed'),
         ('ai_quiz', 'AI Quiz Completed'),
+        ('coding_solved', 'Coding Problem Solved'),
+        ('assignment_graded', 'Assignment Graded'),
         ('daily_goal', 'Daily Goal Met'),
         ('streak_bonus', 'Streak Bonus'),
         ('badge_earned', 'Badge Earned'),

--- a/frontend/exam-frontend/src/pages/CodingProblem.jsx
+++ b/frontend/exam-frontend/src/pages/CodingProblem.jsx
@@ -85,8 +85,11 @@ const CodingProblem = () => {
     onSuccess: (data) => {
       setSubmitResult(data)
       setRunResult(null)
-      if (data.all_passed) toast.success('All test cases passed! 🎉')
-      else toast(`${data.passed_count}/${data.total_count} test cases passed`)
+      if (data.all_passed) {
+        toast.success(data.xp_awarded > 0 ? `All test cases passed! +${data.xp_awarded} XP 🎉` : 'All test cases passed! 🎉')
+      } else {
+        toast(`${data.passed_count}/${data.total_count} test cases passed`)
+      }
     },
     onError: (err) => toast.error(err?.response?.data?.error || 'Submission failed. Try again.'),
   })
@@ -248,6 +251,9 @@ const SubmitResultPanel = ({ result, maxMarks }) => {
           <p className="font-bold">{allPassed ? 'Accepted' : 'Partial'} — {result.passed_count}/{result.total_count} test cases passed</p>
           {maxMarks != null && result.marks != null && (
             <p className="text-sm text-surface-600 dark:text-surface-300">Score: {result.marks} / {maxMarks} marks</p>
+          )}
+          {result.xp_awarded > 0 && (
+            <p className="text-sm font-semibold text-success-600 dark:text-success-400">+{result.xp_awarded} XP earned</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Problem
XP was only awarded for quizzes, reading content, AI quizzes, and community activity. **Solving a coding problem and getting an assignment graded awarded no XP**, so those activities didn't count toward level/leaderboard progress.

## Changes

**Coding problems** (`coding/views.py`)
- On the **first fully-passing** submission, award difficulty-scaled XP: easy `15`, medium `25`, hard `40`. Idempotent — awarded once per problem (guarded by an existing `coding_solved` XP transaction for that problem).
- The `submit` response now includes `xp_awarded`.

**Assignments** (`assignments/admin_views.py`)
- When a submission is **first graded**, award XP scaled by score: `round(30 × marks/max_marks)`, min `5`; flat `30` when the assignment has no `max_marks`. Idempotent per submission.

**Gamification** (`gamification/models.py` + migration `0008`)
- New `XPTransaction` types: `coding_solved`, `assignment_graded`.

**Helpers** (`core/utils.py`)
- `calculate_xp_for_coding(difficulty)` and `calculate_xp_for_assignment(marks, max_marks)`, alongside the existing quiz XP helpers.

**Frontend** (`CodingProblem.jsx`)
- Solve page shows `+N XP earned` in the success toast and the accepted-result panel.

## Notes
- XP uses the existing `GamificationService.award_xp`, so daily activity, levels, and leaderboards update automatically.
- Awards are one-time; re-submitting a solved problem or re-grading an assignment does not double-award.
- Frontend `npm run build` passes.