### PR TITLE
Fix 404 on content for students whose primary course differs

### DIFF
--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -39,12 +39,23 @@ class ContentViewSet(TenantAwareReadOnlyViewSet):
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        # Auto-filter by student's primary course
+        # Scope to every course the student is actively enrolled in, not just
+        # their primary course, so multi-course students can open content from
+        # any of their enrolled courses (e.g. a Python topic while primary is
+        # Class XI). Falls back to no course filter when the student has no
+        # enrollments (still tenant-scoped by the base viewset).
         if self.request.user.is_authenticated:
             try:
-                course = self.request.user.profile.primary_course
-                if course:
-                    queryset = queryset.filter(courses=course)
+                student = self.request.user.profile
+                enrolled_course_ids = list(
+                    student.enrollments.filter(
+                        status='approved', is_active=True
+                    ).values_list('course_id', flat=True)
+                )
+                if enrolled_course_ids:
+                    queryset = queryset.filter(
+                        courses__in=enrolled_course_ids
+                    ).distinct()
             except Exception:
                 pass
         return queryset


### PR DESCRIPTION
## Problem
`GET /api/v1/content/{id}/` (and the content list) returned **404** for content that clearly exists and is published — e.g. the Python course's "Operators & Expressions" reading.

Root cause: `ContentViewSet.get_queryset()` filtered content to the student's **`primary_course`** only. A student enrolled in multiple courses whose `primary_course` is a *different* course (e.g. `demo@dailytaiyari.in` has `primary_course=class-xi` but is also enrolled in `python-programming`) had all Python content filtered out → 404 in the study flow.

## Fix
Scope content to **all of the student's approved, active enrollments** instead of just the primary course. When the student has no enrollments, no course filter is applied (still tenant-scoped by the base viewset).

## Verification (live DB)
Simulated the new queryset for the two students enrolled in the Python course:
- `demo@dailytaiyari.in` (2 enrollments) → `can_access_content=True`
- `admin@testacademy.in` (3 enrollments) → `can_access_content=True`

Both previously 404'd; both now resolve the content. Tenant scoping and `status='published'` filtering are unchanged.