### PR TITLE
Add Skill Development course type

### DIFF
--- a/backend/exams/migrations/0010_alter_course_course_type.py
+++ b/backend/exams/migrations/0010_alter_course_course_type.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exams', '0009_course_instructors'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='course',
+            name='course_type',
+            field=models.CharField(
+                choices=[
+                    ('competitive', 'Competitive Course'),
+                    ('board', 'Board Course'),
+                    ('entrance', 'Entrance Course'),
+                    ('government', 'Government Job Course'),
+                    ('skill', 'Skill Development'),
+                ],
+                max_length=20,
+            ),
+        ),
+    ]

--- a/backend/exams/models.py
+++ b/backend/exams/models.py
@@ -15,6 +15,7 @@ class Course(TimeStampedModel):
         ('board', 'Board Course'),
         ('entrance', 'Entrance Course'),
         ('government', 'Government Job Course'),
+        ('skill', 'Skill Development'),
     ]
     
     STATUS_CHOICES = [

--- a/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
@@ -12,7 +12,7 @@ import { contentBuilderService as svc } from '../../services/contentBuilderServi
 /* ===========================================================================
  * Field / form configuration per entity
  * ========================================================================= */
-const EXAM_TYPES = ['competitive', 'board', 'entrance', 'government']
+const EXAM_TYPES = ['competitive', 'board', 'entrance', 'government', 'skill']
 const EXAM_STATUS = ['active', 'coming_soon', 'inactive']
 const DIFFICULTY = ['easy', 'medium', 'hard']
 const IMPORTANCE = ['low', 'medium', 'high', 'critical']

--- a/frontend/exam-frontend/src/components/admin/builderShared.jsx
+++ b/frontend/exam-frontend/src/components/admin/builderShared.jsx
@@ -165,7 +165,7 @@ export const NotesTextarea = ({ value, onChange, rows }) => {
  * tools (ContentBuilder table view and the focused CourseManager).
  * Single source of truth so both stay in sync.
  * ========================================================================= */
-export const EXAM_TYPES = ['competitive', 'board', 'entrance', 'government']
+export const EXAM_TYPES = ['competitive', 'board', 'entrance', 'government', 'skill']
 export const EXAM_STATUS = ['active', 'coming_soon', 'inactive']
 export const DIFFICULTY = ['easy', 'medium', 'hard']
 export const IMPORTANCE = ['low', 'medium', 'high', 'critical']

--- a/frontend/exam-frontend/src/components/course/CourseThumbnail.jsx
+++ b/frontend/exam-frontend/src/components/course/CourseThumbnail.jsx
@@ -6,6 +6,7 @@ const TYPE_LABELS = {
   board: 'Board',
   entrance: 'Entrance',
   government: 'Government',
+  skill: 'Skill Development',
 }
 
 /**


### PR DESCRIPTION
## What
Adds a new `skill` course type (displayed as **Skill Development**) so non-exam courses like **Python Programming** are no longer miscategorised as **Entrance**.

## Why
On the Courses page, Python Programming showed an `ENTRANCE` badge, which is misleading — it's a skill-development course, not an entrance exam.

## Changes
- **backend/exams/models.py**: add `('skill', 'Skill Development')` to `COURSE_TYPES`
- **backend/exams/migrations/0010_alter_course_course_type.py**: choices migration
- **frontend** CourseThumbnail: `skill → 'Skill Development'` badge label
- **frontend** admin builder (`ContentBuilder.jsx`, `builderShared.jsx`): add `skill` to selectable `EXAM_TYPES`

## Follow-up (data, applied on server)
- Set the Python course `course_type = 'skill'`
- Fix its description (`&mdash;` → real em dash)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>