### PR TITLE
Fix course card button spacing on Study page

### DIFF
--- a/frontend/exam-frontend/src/pages/Study.jsx
+++ b/frontend/exam-frontend/src/pages/Study.jsx
@@ -92,14 +92,16 @@ const Study = () => {
                   <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
                 )}
 
-                <button
-                  type="button"
-                  onClick={() => navigate(`/study/course/${course.id}`)}
-                  className="btn-primary mt-auto w-full group/btn"
-                >
-                  Enter course
-                  <ArrowRight size={18} className="transition-transform group-hover/btn:translate-x-0.5" />
-                </button>
+                <div className="mt-auto pt-4">
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/study/course/${course.id}`)}
+                    className="btn-primary w-full group/btn"
+                  >
+                    Enter course
+                    <ArrowRight size={18} className="transition-transform group-hover/btn:translate-x-0.5" />
+                  </button>
+                </div>
               </div>
             </motion.div>
             )


### PR DESCRIPTION
## Problem
On the **Study** page, when a course has a description (e.g. Python Programming), the "Enter course" button touched/overlapped the description text. The button used `mt-auto` directly, so when the card content filled the available space the auto-margin collapsed to `0` and left no gap.

## Fix
Wrap the button in a `mt-auto pt-4` container — the same pattern already used on the **Courses** page. This keeps the button pinned to the bottom of the card while guaranteeing a consistent gap above it regardless of description length.

Single-file, layout-only change. Verified with a production build.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>