### PR TITLE
Add per-quiz leaderboard to Quiz Review page

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -759,6 +759,9 @@ class StudyLeaderboardView(APIView):
         scope_id = request.query_params.get('scope_id')
         student = request.user.profile
 
+        if scope == 'quiz' and scope_id:
+            return self._quiz_leaderboard(tenant, student, scope_id)
+
         if scope == 'subject' and scope_id:
             topic_ids = Topic.objects.filter(subject_id=scope_id).values_list('id', flat=True)
         elif scope == 'chapter' and scope_id:
@@ -862,3 +865,50 @@ class StudyLeaderboardView(APIView):
 
         return Response(entries)
 
+    def _quiz_leaderboard(self, tenant, student, quiz_id):
+        """Rank students by their best completed attempt on a single quiz."""
+        from quiz.models import QuizAttempt
+
+        attempts = (
+            QuizAttempt.objects.filter(
+                quiz_id=quiz_id,
+                status='completed',
+                student__user__tenant=tenant,
+            )
+            .select_related('student__user')
+        )
+
+        # Keep each student's best attempt: highest percentage, then fastest.
+        best = {}
+        for a in attempts:
+            cur = best.get(a.student_id)
+            score = (float(a.percentage or 0), -(a.time_taken_seconds or 0))
+            if cur is None or score > cur[0]:
+                best[a.student_id] = (score, a)
+
+        ranked = sorted(
+            (a for _score, a in best.values()),
+            key=lambda a: (
+                -float(a.percentage or 0),
+                a.time_taken_seconds or 0,
+            ),
+        )[:20]
+
+        entries = []
+        for rank, a in enumerate(ranked, start=1):
+            p = a.student
+            entries.append({
+                'rank': rank,
+                'student_name': p.user.full_name,
+                'role': p.user.role,
+                'avatar': p.user.avatar.url if p.user.avatar else None,
+                'total_xp': a.xp_earned or 0,
+                'xp_earned': a.xp_earned or 0,
+                'accuracy': round(float(a.percentage or 0), 1),
+                'marks_obtained': float(a.marks_obtained or 0),
+                'total_marks': float(a.total_marks or 0),
+                'time_taken_seconds': a.time_taken_seconds or 0,
+                'is_current_user': p.id == student.id,
+            })
+
+        return Response(entries)

--- a/frontend/exam-frontend/src/pages/QuizReview.jsx
+++ b/frontend/exam-frontend/src/pages/QuizReview.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { quizService } from '../services/quizService'
+import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
 import toast from 'react-hot-toast'
 import {
@@ -20,7 +21,9 @@ import {
   CheckCircle2,
   X,
   ChevronLeft,
-  RotateCcw
+  RotateCcw,
+  Trophy,
+  Clock
 } from 'lucide-react'
 
 const REPORT_TYPES = [
@@ -47,6 +50,12 @@ const QuizReview = () => {
   const { data: attempt, isLoading, error } = useQuery({
     queryKey: ['attemptReview', attemptId],
     queryFn: () => quizService.getAttemptReview(attemptId),
+  })
+
+  const { data: leaderboard } = useQuery({
+    queryKey: ['quizLeaderboard', attempt?.quiz],
+    queryFn: () => courseService.getStudyLeaderboard('quiz', attempt.quiz),
+    enabled: !!attempt?.quiz,
   })
 
   const reportMutation = useMutation({
@@ -202,6 +211,69 @@ const QuizReview = () => {
           </div>
         </div>
       </motion.div>
+
+      {/* Quiz Leaderboard */}
+      {leaderboard && leaderboard.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="card p-5"
+        >
+          <div className="flex items-center gap-2 mb-4">
+            <Trophy size={20} className="text-warning-500" />
+            <h2 className="font-semibold text-lg">Quiz Leaderboard</h2>
+            <span className="text-sm text-surface-500">Top scores</span>
+          </div>
+
+          <div className="space-y-2">
+            {leaderboard.map((entry) => (
+              <div
+                key={entry.rank}
+                className={`p-3 rounded-xl flex items-center gap-3 border ${
+                  entry.is_current_user
+                    ? 'border-primary-300 bg-primary-50/60 dark:border-primary-700 dark:bg-primary-900/20'
+                    : 'border-surface-200 dark:border-surface-700'
+                }`}
+              >
+                <div className={`w-9 h-9 rounded-full flex items-center justify-center font-bold text-sm flex-shrink-0 ${
+                  entry.rank === 1 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-400' :
+                  entry.rank === 2 ? 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' :
+                  entry.rank === 3 ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-400' :
+                  'bg-surface-100 dark:bg-surface-800 text-surface-500'
+                }`}>
+                  {entry.rank <= 3 ? ['🥇', '🥈', '🥉'][entry.rank - 1] : `#${entry.rank}`}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium truncate">
+                    {entry.student_name}
+                    {entry.is_current_user && (
+                      <span className="text-xs text-primary-600 dark:text-primary-400 ml-2">(You)</span>
+                    )}
+                  </p>
+                  <div className="flex items-center gap-2 text-xs text-surface-500 mt-0.5">
+                    <span className={getScoreColor(entry.accuracy)}>{Math.round(entry.accuracy)}%</span>
+                    {entry.time_taken_seconds > 0 && (
+                      <>
+                        <span>•</span>
+                        <span className="flex items-center gap-1">
+                          <Clock size={12} />
+                          {Math.floor(entry.time_taken_seconds / 60)}:{String(entry.time_taken_seconds % 60).padStart(2, '0')}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </div>
+                {entry.total_marks > 0 && (
+                  <div className="text-right flex-shrink-0">
+                    <p className="font-bold text-sm">{entry.marks_obtained}<span className="text-surface-400 font-normal">/{entry.total_marks}</span></p>
+                    <p className="text-xs text-surface-500">marks</p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </motion.div>
+      )}
 
       {/* Filter Tabs */}
       <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">


### PR DESCRIPTION
## Summary
Adds a leaderboard to the Quiz Review page so students can see how they rank against peers on the specific quiz they just reviewed.

## Backend
- `StudyLeaderboardView` now supports `scope=quiz` (previously only `subject`/`chapter`, despite the docstring).
- New `_quiz_leaderboard` ranks students by their **best completed attempt** on that quiz: highest percentage first, then fastest time as a tiebreak. Returns top 20 with rank, name, accuracy, marks, time, XP, and `is_current_user`.
- Tenant-scoped; no new endpoint or migration (reuses `/courses/study/leaderboard/`).

## Frontend
- `QuizReview.jsx` fetches the quiz-scoped leaderboard via the existing `courseService.getStudyLeaderboard('quiz', attempt.quiz)`.
- New "Quiz Leaderboard" card between the score card and filter tabs: rank medals (🥇🥈🥉), accuracy, time, marks, current-user highlight, full dark-mode support.
- Card is hidden entirely when there's no leaderboard data (no empty "0/0" UI).

## Testing
- `python -m py_compile` passes on `backend/exams/views.py`.
- `npm run build` succeeds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>