### PR TITLE
Fix misaligned active-nav accent bar in sidebar

### DIFF
--- a/frontend/exam-frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/Sidebar.jsx
@@ -112,7 +112,7 @@ const Sidebar = () => {
               {isActive && (
                 <motion.div
                   layoutId="activeNav"
-                  className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-8 bg-primary-500 rounded-r-full"
+                  className="absolute -left-4 top-1/2 -translate-y-1/2 w-1 h-8 bg-primary-500 rounded-r-full"
                 />
               )}
               <IconComponent


### PR DESCRIPTION
## Summary
The active-nav accent bar in the sidebar looked detached/misaligned — it floated in the padding gap to the left of the active pill instead of hugging anything.

## Cause
The bar was `absolute left-0` relative to the NavLink pill, which sits inside the nav's `p-4` padding. So it landed 16px in from the sidebar's left border, in the empty gap beside the rounded pill.

## Fix
Changed `left-0` → `-left-4` so the bar sits flush against the sidebar's true left edge, reading as a proper active-item edge indicator.

One-line CSS change in `Sidebar.jsx`. `npm run build` passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>