### PR TITLE
Add restart policy to db, web, and nginx services

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:16-alpine
+    restart: unless-stopped
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     environment:
@@ -15,6 +16,7 @@ services:
 
   web:
     build: .
+    restart: unless-stopped
     volumes:
       - .:/app
       - static_volume:/app/staticfiles
@@ -69,6 +71,7 @@ services:
 
   nginx:
     image: nginx:1.25-alpine
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
After the Azure VM was deallocated/restarted, only the `piston` container came back — `db`, `web`, and `nginx` stayed down, taking the whole API offline until manually restarted with `docker compose up -d`.

## Cause
`piston` already had `restart: unless-stopped`, but the other three services had no restart policy, so Docker didn't bring them back when the daemon started after the VM boot.

## Fix
Add `restart: unless-stopped` to `db`, `web`, and `nginx` so the full stack auto-recovers on VM reboot or Docker daemon restart (without overriding a deliberate manual stop).

No app code or migration changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>