### PR TITLE
Rich Mock Tests — Phase 2: admin CRUD + builder API

### DIFF
--- a/backend/quiz/admin_serializers.py
+++ b/backend/quiz/admin_serializers.py
@@ -11,7 +11,11 @@ index of the correct option (matching ``Answer.selected_option``); for
 from rest_framework import serializers
 
 from core.serializer_fields import Base64ImageField
-from .models import Quiz, Question, QuestionOption, QuizQuestion
+from .models import (
+    Quiz, Question, QuestionOption, QuizQuestion,
+    MockTest, MockTestItem, MockTestQuestion,
+)
+from coding.languages import LANGUAGE_KEYS
 
 
 class AdminQuestionOptionSerializer(serializers.ModelSerializer):
@@ -202,4 +206,146 @@ class AdminQuizSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({'subject': 'Subject not found for this tenant.'})
             if topic is not None and getattr(topic.subject.course, 'tenant_id', None) != tenant.id:
                 raise serializers.ValidationError({'topic': 'Topic not found for this tenant.'})
+        return attrs
+
+
+# ---------------------------------------------------------------------------
+# Rich Mock Test builder (Phase 2)
+# ---------------------------------------------------------------------------
+
+class AdminMockTestItemSerializer(serializers.ModelSerializer):
+    """Writable serializer for a single inline mock-test item (any type)."""
+    id = serializers.UUIDField(required=False)
+    question_image = Base64ImageField(required=False, allow_null=True)
+
+    class Meta:
+        model = MockTestItem
+        fields = [
+            'id', 'mock_test', 'item_type', 'section', 'order',
+            'question_text', 'question_html', 'question_image', 'explanation',
+            'marks', 'negative_marks', 'options',
+            'numerical_answer', 'numerical_tolerance',
+            'max_words', 'rubric', 'model_answer',
+            'allowed_languages', 'starter_code', 'time_limit_ms',
+            'memory_limit_mb', 'coding_test_cases',
+            'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'created_at', 'updated_at']
+        extra_kwargs = {
+            'mock_test': {'required': False},   # set by the viewset on create
+            'order': {'required': False},
+        }
+
+    def validate_allowed_languages(self, value):
+        if value in (None, ''):
+            return []
+        if not isinstance(value, list):
+            raise serializers.ValidationError('Must be a list of language keys.')
+        bad = [v for v in value if v not in LANGUAGE_KEYS]
+        if bad:
+            raise serializers.ValidationError(f'Unsupported languages: {", ".join(bad)}')
+        return value
+
+    def validate_options(self, value):
+        if value in (None, ''):
+            return []
+        if not isinstance(value, list):
+            raise serializers.ValidationError('Options must be a list.')
+        return value
+
+    def validate_coding_test_cases(self, value):
+        if value in (None, ''):
+            return []
+        if not isinstance(value, list):
+            raise serializers.ValidationError('Test cases must be a list.')
+        return value
+
+
+class AdminMockTestQuestionSerializer(serializers.ModelSerializer):
+    """Read-oriented serializer for a bank question linked into a mock test."""
+    question_detail = serializers.SerializerMethodField()
+    effective_marks = serializers.DecimalField(max_digits=6, decimal_places=2, read_only=True)
+    effective_negative_marks = serializers.DecimalField(
+        max_digits=6, decimal_places=2, read_only=True,
+    )
+
+    class Meta:
+        model = MockTestQuestion
+        fields = [
+            'id', 'question', 'section', 'order',
+            'marks_override', 'negative_marks_override',
+            'effective_marks', 'effective_negative_marks', 'question_detail',
+        ]
+        read_only_fields = ['id']
+
+    def get_question_detail(self, obj):
+        q = obj.question
+        return {
+            'id': str(q.id),
+            'question_text': q.question_text,
+            'question_type': q.question_type,
+            'marks': float(q.marks),
+            'negative_marks': float(q.negative_marks),
+            'topic': str(q.topic_id) if q.topic_id else None,
+            'subject': str(q.subject_id) if q.subject_id else None,
+        }
+
+
+class AdminMockTestSerializer(serializers.ModelSerializer):
+    """Writable serializer for the rich mock-test builder (scalars + course links).
+
+    Inline items and bank questions are managed via dedicated endpoints; they are
+    exposed here read-only for display.
+    """
+    course_name = serializers.CharField(source='course.name', read_only=True, default=None)
+    items = AdminMockTestItemSerializer(many=True, read_only=True)
+    items_count = serializers.SerializerMethodField()
+    bank_questions_count = serializers.SerializerMethodField()
+    computed_total_marks = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MockTest
+        fields = [
+            'id', 'title', 'description', 'course', 'course_name', 'courses',
+            'sections', 'duration_minutes', 'total_marks', 'negative_marking',
+            'status', 'is_free', 'result_visibility', 'results_released',
+            'start_deadline', 'fullscreen_required',
+            'available_from', 'available_until',
+            'is_pyp', 'pyp_year', 'pyp_shift', 'pyp_session', 'pyp_date',
+            'items', 'items_count', 'bank_questions_count', 'computed_total_marks',
+            'total_attempts', 'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'total_attempts', 'created_at', 'updated_at']
+        extra_kwargs = {
+            'course': {'required': False, 'allow_null': True},
+            'courses': {'required': False},
+            'total_marks': {'required': False},
+            'sections': {'required': False},
+        }
+
+    def get_items_count(self, obj):
+        return obj.items.count()
+
+    def get_bank_questions_count(self, obj):
+        return MockTestQuestion.objects.filter(mock_test=obj).count()
+
+    def get_computed_total_marks(self, obj):
+        items_total = sum((i.marks for i in obj.items.all()), 0)
+        bank_total = sum(
+            (mtq.effective_marks for mtq in
+             MockTestQuestion.objects.filter(mock_test=obj).select_related('question')),
+            0,
+        )
+        return float(items_total) + float(bank_total)
+
+    def validate(self, attrs):
+        request = self.context.get('request')
+        tenant = getattr(request, 'tenant', None)
+        if tenant is not None:
+            course = attrs.get('course')
+            if course is not None and getattr(course, 'tenant_id', None) != tenant.id:
+                raise serializers.ValidationError({'course': 'Course not found for this tenant.'})
+            for c in attrs.get('courses', []) or []:
+                if getattr(c, 'tenant_id', None) != tenant.id:
+                    raise serializers.ValidationError({'courses': 'One or more courses not found for this tenant.'})
         return attrs

--- a/backend/quiz/admin_views.py
+++ b/backend/quiz/admin_views.py
@@ -54,3 +54,182 @@ class AdminQuestionViewSet(TenantAdminModelViewSet):
     def perform_destroy(self, instance):
         QuizQuestion.objects.filter(question=instance).delete()
         instance.delete()
+
+
+# ---------------------------------------------------------------------------
+# Rich Mock Test builder (Phase 2)
+# ---------------------------------------------------------------------------
+from decimal import Decimal
+
+from rest_framework import viewsets, filters, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError, NotFound
+from django_filters.rest_framework import DjangoFilterBackend
+
+from core.permissions import IsTenantAdmin
+from exams.admin_views import BuilderPagination
+from .models import MockTest, MockTestItem, MockTestQuestion, Question
+from .admin_serializers import (
+    AdminMockTestSerializer, AdminMockTestItemSerializer,
+    AdminMockTestQuestionSerializer,
+)
+
+
+def recompute_mock_total(mock_test):
+    """Recompute and persist ``total_marks`` = inline items + linked bank questions."""
+    items_total = sum((i.marks for i in mock_test.items.all()), Decimal('0'))
+    bank_total = sum(
+        (mtq.effective_marks for mtq in
+         MockTestQuestion.objects.filter(mock_test=mock_test).select_related('question')),
+        Decimal('0'),
+    )
+    mock_test.total_marks = items_total + bank_total
+    mock_test.save(update_fields=['total_marks', 'updated_at'])
+    return mock_test.total_marks
+
+
+class AdminMockTestViewSet(viewsets.ModelViewSet):
+    """Admin-only CRUD for rich mock tests (tenant-scoped)."""
+    permission_classes = [IsTenantAdmin]
+    serializer_class = AdminMockTestSerializer
+    pagination_class = BuilderPagination
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
+    search_fields = ['title', 'description']
+    ordering_fields = ['created_at', 'title', 'status']
+    ordering = ['-created_at']
+    filterset_fields = ['status', 'is_pyp', 'is_free', 'result_visibility']
+    queryset = MockTest.objects.all().prefetch_related('items', 'courses')
+
+    def _tenant(self):
+        return getattr(self.request, 'tenant', None)
+
+    def get_queryset(self):
+        tenant = self._tenant()
+        if not tenant:
+            return MockTest.objects.none()
+        return super().get_queryset().filter(tenant=tenant)
+
+    def perform_create(self, serializer):
+        extra = {'tenant': self._tenant()}
+        if serializer.validated_data.get('total_marks') is None:
+            extra['total_marks'] = Decimal('0')
+        serializer.save(**extra)
+
+    # --- bank-question linking -------------------------------------------
+
+    @action(detail=True, methods=['get'])
+    def bank_questions(self, request, pk=None):
+        mock_test = self.get_object()
+        mtqs = (MockTestQuestion.objects.filter(mock_test=mock_test)
+                .select_related('question').order_by('section', 'order'))
+        return Response(AdminMockTestQuestionSerializer(mtqs, many=True).data)
+
+    @action(detail=True, methods=['post'])
+    def add_bank_questions(self, request, pk=None):
+        mock_test = self.get_object()
+        tenant = self._tenant()
+        ids = request.data.get('question_ids', [])
+        if not isinstance(ids, list) or not ids:
+            raise ValidationError({'question_ids': 'Provide a non-empty list of question ids.'})
+        section = request.data.get('section', 0)
+        marks_override = request.data.get('marks_override')
+        neg_override = request.data.get('negative_marks_override')
+        # Only questions in this tenant (via subject->course) or already tenant-linked.
+        valid = Question.objects.filter(id__in=ids).filter(
+            subject__course__tenant=tenant
+        )
+        valid_ids = {str(q.id) for q in valid}
+        base_order = MockTestQuestion.objects.filter(mock_test=mock_test).count()
+        created = 0
+        for qid in ids:
+            if str(qid) not in valid_ids:
+                continue
+            if MockTestQuestion.objects.filter(mock_test=mock_test, question_id=qid).exists():
+                continue
+            MockTestQuestion.objects.create(
+                mock_test=mock_test, question_id=qid, section=section,
+                order=base_order + created,
+                marks_override=marks_override, negative_marks_override=neg_override,
+                tenant=tenant,
+            )
+            created += 1
+        recompute_mock_total(mock_test)
+        return Response({'added': created}, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'])
+    def remove_bank_question(self, request, pk=None):
+        mock_test = self.get_object()
+        qid = request.data.get('question_id')
+        if not qid:
+            raise ValidationError({'question_id': 'Required.'})
+        deleted, _ = MockTestQuestion.objects.filter(
+            mock_test=mock_test, question_id=qid).delete()
+        recompute_mock_total(mock_test)
+        return Response({'removed': deleted})
+
+    @action(detail=True, methods=['post'])
+    def recompute_marks(self, request, pk=None):
+        mock_test = self.get_object()
+        total = recompute_mock_total(mock_test)
+        return Response({'total_marks': float(total)})
+
+
+class AdminMockTestItemViewSet(viewsets.ModelViewSet):
+    """Admin-only CRUD for inline mock-test items. Filter by ``?mock_test=<id>``."""
+    permission_classes = [IsTenantAdmin]
+    serializer_class = AdminMockTestItemSerializer
+    pagination_class = BuilderPagination
+    queryset = MockTestItem.objects.all()
+
+    def _tenant(self):
+        return getattr(self.request, 'tenant', None)
+
+    def get_queryset(self):
+        tenant = self._tenant()
+        if not tenant:
+            return MockTestItem.objects.none()
+        qs = MockTestItem.objects.filter(mock_test__tenant=tenant)
+        mock_test_id = self.request.query_params.get('mock_test')
+        if mock_test_id:
+            qs = qs.filter(mock_test_id=mock_test_id)
+        return qs.order_by('section', 'order')
+
+    def _resolve_mock_test(self, serializer):
+        mock_test = serializer.validated_data.get('mock_test')
+        if mock_test is None or mock_test.tenant_id != self._tenant().id:
+            raise ValidationError({'mock_test': 'Mock test not found for this tenant.'})
+        return mock_test
+
+    def perform_create(self, serializer):
+        mock_test = self._resolve_mock_test(serializer)
+        if not serializer.validated_data.get('order'):
+            serializer.validated_data['order'] = MockTestItem.objects.filter(
+                mock_test=mock_test).count()
+        item = serializer.save(tenant=self._tenant())
+        recompute_mock_total(item.mock_test)
+
+    def perform_update(self, serializer):
+        item = serializer.save()
+        recompute_mock_total(item.mock_test)
+
+    def perform_destroy(self, instance):
+        mock_test = instance.mock_test
+        instance.delete()
+        recompute_mock_total(mock_test)
+
+    @action(detail=False, methods=['post'])
+    def reorder(self, request):
+        """Body: {"order": [item_id, ...]}. Reorders items within the tenant."""
+        ids = request.data.get('order', [])
+        qs = self.get_queryset()
+        lookup = {str(obj.id): obj for obj in qs.filter(id__in=ids)}
+        updated = []
+        for index, obj_id in enumerate(ids):
+            obj = lookup.get(str(obj_id))
+            if obj is not None:
+                obj.order = index
+                updated.append(obj)
+        if updated:
+            MockTestItem.objects.bulk_update(updated, ['order'])
+        return Response({'updated': len(updated)})

--- a/backend/quiz/urls.py
+++ b/backend/quiz/urls.py
@@ -8,7 +8,10 @@ from .views import (
     PreviousYearPaperViewSet,
     QuizAttemptViewSet, MockTestAttemptViewSet, QuestionReportViewSet
 )
-from .admin_views import AdminQuizViewSet, AdminQuestionViewSet
+from .admin_views import (
+    AdminQuizViewSet, AdminQuestionViewSet,
+    AdminMockTestViewSet, AdminMockTestItemViewSet,
+)
 
 router = DefaultRouter()
 router.register(r'questions', QuestionViewSet, basename='question')
@@ -22,6 +25,8 @@ router.register(r'reports', QuestionReportViewSet, basename='question-report')
 admin_router = DefaultRouter()
 admin_router.register(r'quizzes', AdminQuizViewSet, basename='admin-quiz')
 admin_router.register(r'questions', AdminQuestionViewSet, basename='admin-question')
+admin_router.register(r'mock-tests', AdminMockTestViewSet, basename='admin-mock-test')
+admin_router.register(r'mock-items', AdminMockTestItemViewSet, basename='admin-mock-item')
 
 urlpatterns = [
     path('admin/', include(admin_router.urls)),


### PR DESCRIPTION
## Phase 2 of the rich Mock Test system — admin CRUD + builder API

Builds on Phase 1's data model (#48). Adds **admin-only, tenant-scoped** REST endpoints so admins can author rich mock tests. No student-facing behavior yet — that's Phase 3/4.

### New endpoints (under `/api/v1/quiz/admin/`)
- **`mock-tests/`** — `AdminMockTestViewSet` (full CRUD). Writable scalars: title, description, legacy `course`, `courses` M2M, sections, duration, negative marking, status, `is_free`, `result_visibility`, `results_released`, `start_deadline`, `fullscreen_required`, availability window, PYP fields. Read-only nested `items`, `items_count`, `bank_questions_count`, `computed_total_marks`.
  - `POST mock-tests/{id}/add_bank_questions/` — link existing question-bank questions (`{question_ids, section, marks_override, negative_marks_override}`); only questions in the current tenant are linked.
  - `GET mock-tests/{id}/bank_questions/` — list linked bank questions with effective marks.
  - `POST mock-tests/{id}/remove_bank_question/` — unlink one.
  - `POST mock-tests/{id}/recompute_marks/` — recompute `total_marks`.
- **`mock-items/`** — `AdminMockTestItemViewSet` (CRUD for inline items, any of the 5 types). Filter by `?mock_test=<id>`. `POST mock-items/reorder/` reorders.

### Behavior
- All queries scoped to `request.tenant`; writes gated by `IsTenantAdmin`.
- `tenant` is set explicitly on created mock tests / items / bank links (the base model's `tenant` FK is nullable).
- `total_marks` is auto-recomputed (inline item marks + linked bank-question effective marks) whenever items or bank links change.
- `allowed_languages` validated against the supported coding languages; `options`/`coding_test_cases` validated as lists.

### Validation
- `python manage.py check` → **no issues** against the branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>