### PR TITLE
Rich Mock Tests — Phase 3: attempt + autograde + submit API

### DIFF
--- a/backend/quiz/mock_grading.py
+++ b/backend/quiz/mock_grading.py
@@ -1,0 +1,218 @@
+"""
+Access + autograding helpers for the rich Mock Test attempt flow (Phase 3).
+
+A rich mock test serves a merged, ordered paper composed of:
+  * bank questions (via ``MockTestQuestion`` -> shared ``Question``), and
+  * inline items (``MockTestItem``), which additionally support subjective and
+    coding types.
+
+Bank answers are recorded via the shared ``Answer`` model (auto-graded by
+``Answer.check_answer``); inline answers via ``MockTestAnswer``. Subjective inline
+items are flagged for manual grading and leave the attempt ``pending_manual``.
+"""
+from decimal import Decimal
+from types import SimpleNamespace
+
+from django.db.models import Q
+from django.utils import timezone
+
+from .models import MockTestItem, MockTestQuestion
+
+
+def accessible_mock_tests_q(course_ids):
+    """Q filtering published mock tests a student may attempt.
+
+    - Linked ``courses`` (M2M) non-empty -> enrolled in one of them.
+    - Else legacy ``course`` set -> enrolled in that course (existing behaviour).
+    - Else (no course links at all) -> open to all students in the tenant.
+    """
+    course_ids = list(course_ids or [])
+    all_tenant = Q(course__isnull=True) & Q(courses__isnull=True)
+    if course_ids:
+        return Q(course__in=course_ids) | Q(courses__in=course_ids) | all_tenant
+    return all_tenant
+
+
+def student_can_access(mock_test, course_ids):
+    """Bool access check mirroring :func:`accessible_mock_tests_q`."""
+    course_ids = set(str(c) for c in (course_ids or []))
+    linked = set(str(c) for c in mock_test.courses.values_list('id', flat=True))
+    if linked:
+        return bool(linked & course_ids)
+    if mock_test.course_id:
+        return str(mock_test.course_id) in course_ids
+    return True  # open to all registered students in the tenant
+
+
+def _bank_question_payload(mtq):
+    q = mtq.question
+    options = [
+        {'index': i, 'text': o.option_text,
+         'image': o.option_image.url if o.option_image else None}
+        for i, o in enumerate(q.options.all().order_by('order'))
+    ]
+    return {
+        'kind': 'bank',
+        'ref_id': str(q.id),           # what the client sends back as question_id
+        'section': mtq.section,
+        'order': mtq.order,
+        'item_type': q.question_type,
+        'question_text': q.question_text,
+        'question_html': getattr(q, 'question_html', '') or '',
+        'question_image': q.question_image.url if getattr(q, 'question_image', None) else None,
+        'marks': float(mtq.effective_marks),
+        'negative_marks': float(mtq.effective_negative_marks),
+        'options': options,
+    }
+
+
+def _item_payload(item):
+    data = {
+        'kind': 'item',
+        'ref_id': str(item.id),        # what the client sends back as item_id
+        'section': item.section,
+        'order': item.order,
+        'item_type': item.item_type,
+        'question_text': item.question_text,
+        'question_html': item.question_html or '',
+        'question_image': item.question_image.url if item.question_image else None,
+        'marks': float(item.marks),
+        'negative_marks': float(item.negative_marks),
+    }
+    if item.item_type in ('mcq', 'mcq_multi'):
+        data['options'] = [
+            {'index': i, 'text': o.get('text', ''), 'image': o.get('image')}
+            for i, o in enumerate(item.options or [])
+        ]
+    elif item.item_type == 'numerical':
+        data['numerical_tolerance'] = float(item.numerical_tolerance)
+    elif item.item_type == 'subjective':
+        data['max_words'] = item.max_words
+    elif item.item_type == 'coding':
+        data.update({
+            'allowed_languages': item.allowed_languages or [],
+            'starter_code': item.starter_code or {},
+            'time_limit_ms': item.time_limit_ms,
+            'memory_limit_mb': item.memory_limit_mb,
+            'sample_test_cases': [
+                {'stdin': c.get('stdin', ''),
+                 'expected_output': c.get('expected_output', ''),
+                 'explanation': c.get('explanation', '')}
+                for c in (item.coding_test_cases or []) if c.get('is_sample')
+            ],
+        })
+    return data
+
+
+def build_paper(mock_test):
+    """Merged, ordered question list for the attempt UI (no correct answers)."""
+    entries = []
+    for mtq in (MockTestQuestion.objects.filter(mock_test=mock_test)
+                .select_related('question')
+                .prefetch_related('question__options')
+                .order_by('section', 'order')):
+        entries.append(_bank_question_payload(mtq))
+    for item in MockTestItem.objects.filter(mock_test=mock_test).order_by('section', 'order'):
+        entries.append(_item_payload(item))
+    # Stable merge by (section, order); bank before item on ties.
+    entries.sort(key=lambda e: (e['section'], e['order'], 0 if e['kind'] == 'bank' else 1))
+    return entries
+
+
+def has_subjective_items(mock_test):
+    return MockTestItem.objects.filter(mock_test=mock_test, item_type='subjective').exists()
+
+
+# ---------------------------------------------------------------------------
+# Inline item grading
+# ---------------------------------------------------------------------------
+
+def grade_item_answer(item, ans):
+    """Auto-grade (in place) a ``MockTestAnswer`` for its ``MockTestItem``.
+
+    Sets is_correct, is_auto_graded, needs_manual_grading, marks_obtained,
+    max_marks and (for coding) coding_results / passed_count / total_count.
+    Does not save.
+    """
+    marks = Decimal(str(item.marks))
+    neg = Decimal(str(item.negative_marks))
+    ans.max_marks = marks
+    ans.is_auto_graded = False
+    ans.needs_manual_grading = False
+    ans.is_correct = False
+    ans.marks_obtained = Decimal('0')
+
+    if item.item_type in ('mcq', 'mcq_multi'):
+        selected = set(int(i) for i in (ans.selected_options or []))
+        correct = set(item.correct_option_indices)
+        ans.is_correct = bool(correct) and selected == correct
+        ans.is_auto_graded = True
+        ans.marks_obtained = marks if ans.is_correct else (-neg if selected else Decimal('0'))
+
+    elif item.item_type == 'numerical':
+        ans.is_auto_graded = True
+        if ans.numerical_answer is not None and item.numerical_answer is not None:
+            diff = abs(ans.numerical_answer - item.numerical_answer)
+            ans.is_correct = diff <= item.numerical_tolerance
+        ans.marks_obtained = marks if ans.is_correct else (
+            -neg if ans.numerical_answer is not None else Decimal('0'))
+
+    elif item.item_type == 'coding':
+        _grade_coding(item, ans, marks)
+
+    elif item.item_type == 'subjective':
+        # Manual grading only.
+        ans.needs_manual_grading = True
+        ans.is_auto_graded = False
+
+    return ans
+
+
+def _grade_coding(item, ans, marks):
+    from django.conf import settings
+    if not getattr(settings, 'CODING_ENABLED', True):
+        ans.needs_manual_grading = True
+        return
+    cases = [
+        SimpleNamespace(
+            stdin=c.get('stdin', ''),
+            expected_output=c.get('expected_output', ''),
+            points=int(c.get('points', 1) or 1),
+            is_sample=bool(c.get('is_sample', False)),
+            id=idx,
+            order=idx,
+        )
+        for idx, c in enumerate(item.coding_test_cases or [])
+    ]
+    if not ans.code or not ans.language or not cases:
+        # Nothing to run (blank submission) -> zero, still auto-graded.
+        ans.is_auto_graded = True
+        ans.total_count = len(cases)
+        return
+    try:
+        from coding.services import run_against_cases, EngineError
+    except Exception:
+        ans.needs_manual_grading = True
+        return
+    try:
+        result = run_against_cases(
+            language=ans.language,
+            source=ans.code,
+            cases=cases,
+            time_limit_ms=item.time_limit_ms,
+            memory_limit_mb=item.memory_limit_mb,
+            reveal_io=False,   # never leak hidden-case IO to the client
+        )
+    except EngineError:
+        # Execution service unavailable -> defer to manual grading.
+        ans.needs_manual_grading = True
+        return
+    ans.is_auto_graded = True
+    ans.coding_results = result['results']
+    ans.passed_count = result['passed_count']
+    ans.total_count = result['total_count']
+    total_points = result['total_points'] or 0
+    if total_points > 0:
+        fraction = Decimal(result['passed_points']) / Decimal(total_points)
+        ans.marks_obtained = (marks * fraction).quantize(Decimal('0.01'))
+    ans.is_correct = total_points > 0 and result['passed_points'] == total_points

--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -11,7 +11,8 @@ from django.utils import timezone
 from django.db.models import Q, Count, F
 
 from .models import (
-    Question, Quiz, QuizQuestion, MockTest, MockTestQuestion, QuizAttempt, MockTestAttempt, Answer, QuestionReport
+    Question, Quiz, QuizQuestion, MockTest, MockTestQuestion, QuizAttempt, MockTestAttempt, Answer, QuestionReport,
+    MockTestItem, MockTestAnswer,
 )
 from .serializers import (
     QuestionSerializer, QuestionWithAnswerSerializer,
@@ -588,13 +589,16 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
         queryset = super().get_queryset()
         request = self.request
         
-        # Auto-filter by the student's enrolled courses (unless an explicit
-        # course filter is provided). Scopes to ALL approved enrollments so a
-        # mock test from any enrolled course opens, not just the primary course.
+        # Auto-filter to mock tests the student may attempt (unless an explicit
+        # course filter is provided). Access covers: linked `courses` (M2M),
+        # legacy `course`, or fully-open tests (no course links) for any student
+        # in the tenant.
         if not request.query_params.get('course'):
+            from .mock_grading import accessible_mock_tests_q
             course_ids = _get_student_course_ids(request)
-            if course_ids:
-                queryset = queryset.filter(course__in=course_ids)
+            # Non-enrolled viewers (e.g. staff) stay tenant-scoped only.
+            if course_ids is not None:
+                queryset = queryset.filter(accessible_mock_tests_q(course_ids)).distinct()
         
         # Filter by attempted status
         attempted_filter = request.query_params.get('attempted')
@@ -895,6 +899,221 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
             'leaderboard': leaderboard,
             'user_rank': user_rank,
             'total_participants': len(seen_students),
+        })
+
+    # ------------------------------------------------------------------
+    # Rich mock test flow (Phase 3): merged bank + inline items, autograde
+    # for MCQ / numerical / coding, manual grading for subjective.
+    # ------------------------------------------------------------------
+
+    def _rich_access_or_403(self, mock_test, request):
+        from .mock_grading import student_can_access
+        course_ids = _get_student_course_ids(request)
+        if course_ids is None:
+            course_ids = []
+        if not student_can_access(mock_test, course_ids):
+            return Response(
+                {'error': 'You are not eligible to attempt this test.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return None
+
+    @action(detail=True, methods=['get'])
+    def paper(self, request, pk=None):
+        """Merged, ordered question paper for the rich attempt UI (no answers)."""
+        from .mock_grading import build_paper
+        mock_test = self.get_object()
+        denied = self._rich_access_or_403(mock_test, request)
+        if denied:
+            return denied
+        student = request.user.profile
+        active = MockTestAttempt.objects.filter(
+            student=student, mock_test=mock_test, status='in_progress'
+        ).first()
+        return Response({
+            'mock_test': {
+                'id': str(mock_test.id),
+                'title': mock_test.title,
+                'description': mock_test.description,
+                'duration_minutes': mock_test.duration_minutes,
+                'total_marks': float(mock_test.total_marks),
+                'negative_marking': mock_test.negative_marking,
+                'fullscreen_required': mock_test.fullscreen_required,
+                'result_visibility': mock_test.result_visibility,
+                'start_deadline': mock_test.start_deadline.isoformat() if mock_test.start_deadline else None,
+                'sections': mock_test.sections,
+            },
+            'questions': build_paper(mock_test),
+            'active_attempt_id': str(active.id) if active else None,
+        })
+
+    @action(detail=True, methods=['post'])
+    def start_rich(self, request, pk=None):
+        """Start (or resume) a rich mock test attempt after access + deadline checks."""
+        from .mock_grading import build_paper
+        mock_test = self.get_object()
+        denied = self._rich_access_or_403(mock_test, request)
+        if denied:
+            return denied
+        student = request.user.profile
+
+        existing = MockTestAttempt.objects.filter(
+            student=student, mock_test=mock_test, status='in_progress'
+        ).first()
+        if existing:
+            return Response({
+                'attempt': MockTestAttemptSerializer(existing).data,
+                'questions': build_paper(mock_test),
+                'resumed': True,
+            })
+
+        if mock_test.start_deadline and timezone.now() > mock_test.start_deadline:
+            return Response(
+                {'error': 'The window to start this test has closed.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        bank_count = MockTestQuestion.objects.filter(mock_test=mock_test).count()
+        item_count = MockTestItem.objects.filter(mock_test=mock_test).count()
+        attempt = MockTestAttempt.objects.create(
+            student=student,
+            mock_test=mock_test,
+            total_questions=bank_count + item_count,
+            total_marks=mock_test.total_marks,
+            tenant=getattr(request, 'tenant', None),
+        )
+        return Response({
+            'attempt': MockTestAttemptSerializer(attempt).data,
+            'questions': build_paper(mock_test),
+            'resumed': False,
+        }, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'], throttle_classes=[QuizSubmitThrottle])
+    def submit_rich(self, request, pk=None):
+        """Submit a rich attempt: grade bank + inline answers; flag subjective."""
+        from decimal import Decimal
+        from .mock_grading import grade_item_answer, has_subjective_items
+        mock_test = self.get_object()
+        denied = self._rich_access_or_403(mock_test, request)
+        if denied:
+            return denied
+        student = request.user.profile
+
+        attempt = MockTestAttempt.objects.filter(
+            student=student, mock_test=mock_test, status='in_progress'
+        ).first()
+        if not attempt:
+            return Response({'error': 'No active attempt found'},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        tenant = getattr(request, 'tenant', None)
+        bank_answers = request.data.get('bank_answers', []) or []
+        item_answers = request.data.get('item_answers', []) or []
+        time_taken = int(request.data.get('time_taken_seconds', 0) or 0)
+
+        # --- bank questions (shared Answer model, existing autograde) ---
+        mtq_map = {
+            str(mtq.question_id): mtq
+            for mtq in MockTestQuestion.objects.filter(mock_test=mock_test).select_related('question')
+        }
+        for a in bank_answers:
+            qid = str(a.get('question_id'))
+            mtq = mtq_map.get(qid)
+            if not mtq:
+                continue
+            answer, _ = Answer.objects.get_or_create(
+                mock_test_attempt=attempt, question=mtq.question,
+                defaults={'tenant': tenant},
+            )
+            answer.selected_option = a.get('selected_option', '') or ''
+            answer.numerical_answer = a.get('numerical_answer')
+            answer.answer_text = a.get('answer_text', '') or ''
+            answer.time_taken_seconds = int(a.get('time_taken_seconds', 0) or 0)
+            answer.is_marked_for_review = bool(a.get('is_marked_for_review', False))
+            answer.check_answer(
+                marks_override=mtq.marks_override,
+                negative_marks_override=mtq.negative_marks_override,
+            )
+
+        # --- inline items (MockTestAnswer, autograde or manual) ---
+        item_map = {
+            str(it.id): it
+            for it in MockTestItem.objects.filter(mock_test=mock_test)
+        }
+        for a in item_answers:
+            item = item_map.get(str(a.get('item_id')))
+            if not item:
+                continue
+            ans, _ = MockTestAnswer.objects.get_or_create(
+                attempt=attempt, item=item, defaults={'tenant': tenant},
+            )
+            ans.selected_options = a.get('selected_options', []) or []
+            ans.numerical_answer = a.get('numerical_answer')
+            ans.answer_text = a.get('answer_text', '') or ''
+            ans.code = a.get('code', '') or ''
+            ans.language = a.get('language', '') or ''
+            ans.time_taken_seconds = int(a.get('time_taken_seconds', 0) or 0)
+            ans.is_marked_for_review = bool(a.get('is_marked_for_review', False))
+            grade_item_answer(item, ans)
+            ans.save()
+
+        # --- aggregate results ---
+        bank_qs = attempt.answers.all()
+        item_qs = attempt.item_answers.all()
+        bank_marks = sum((x.marks_obtained for x in bank_qs), Decimal('0'))
+        item_marks = sum((x.marks_obtained for x in item_qs), Decimal('0'))
+        attempt.marks_obtained = bank_marks + item_marks
+        attempt.attempted_questions = bank_qs.count() + item_qs.count()
+        attempt.correct_answers = (
+            bank_qs.filter(is_correct=True).count() + item_qs.filter(is_correct=True).count()
+        )
+        attempt.wrong_answers = (
+            bank_qs.filter(is_correct=False).count()
+            + item_qs.filter(is_correct=False, needs_manual_grading=False).count()
+        )
+        total = float(mock_test.total_marks) or 0
+        attempt.percentage = max(0, (float(attempt.marks_obtained) / total) * 100) if total > 0 else 0
+
+        pending_manual = item_qs.filter(needs_manual_grading=True).exists()
+        attempt.grading_status = 'pending_manual' if pending_manual else 'auto_graded'
+        attempt.status = 'completed'
+        attempt.completed_at = timezone.now()
+        attempt.time_taken_seconds = time_taken
+        attempt.save()
+
+        # XP only when fully auto-graded and first completion. Manual-grading
+        # attempts get XP finalized after admin grading (later phase).
+        awarded_xp = 0
+        if not pending_manual:
+            already = MockTestAttempt.objects.filter(
+                student=student, mock_test=mock_test, status='completed'
+            ).exclude(id=attempt.id).exists()
+            if not already:
+                awarded_xp = calculate_xp_for_quiz(
+                    attempt.percentage, attempt.total_questions, is_daily_challenge=False
+                ) * 2
+                attempt.xp_earned = awarded_xp
+                attempt.save(update_fields=['xp_earned'])
+                GamificationService.award_xp(
+                    student, awarded_xp, 'mock_complete',
+                    f'Completed mock test: {mock_test.title}', str(attempt.id),
+                )
+
+        # Stats
+        mock_test.total_attempts += 1
+        if attempt.marks_obtained > mock_test.highest_score:
+            mock_test.highest_score = attempt.marks_obtained
+        mock_test.save(update_fields=['total_attempts', 'highest_score'])
+
+        results_visible = (
+            mock_test.result_visibility == 'immediate' and not pending_manual
+        ) or mock_test.results_released
+
+        return Response({
+            'attempt': MockTestAttemptSerializer(attempt).data,
+            'grading_status': attempt.grading_status,
+            'results_visible': results_visible,
+            'pending_manual': pending_manual,
         })
 
 


### PR DESCRIPTION
## Phase 3 of the rich Mock Test system — student attempt + autograde + submit API

Builds on #48 (models) and #49 (admin builder). Adds the **student-facing rich attempt flow** as new actions on `MockTestViewSet` (additive — legacy PYP/competitive `start`/`submit` remain untouched). No frontend yet (Phase 4).

### New endpoints (under `/api/v1/quiz/mock-tests/{id}/`)
- **`GET paper/`** — the merged, ordered question paper (bank questions + inline items) with **no correct answers**. Bank options come from the shared bank; inline items expose per-type fields (MCQ options, numerical tolerance, subjective max-words, coding: allowed languages / starter code / **sample** test cases only — hidden cases never leak).
- **`POST start_rich/`** — validates access and the start deadline, then creates or resumes an attempt and returns the paper.
- **`POST submit_rich/`** — grades the submission:
  - **Bank** answers via the shared `Answer` model (existing autograde + per-mock marks overrides).
  - **Inline** answers via `MockTestAnswer`: MCQ / mcq_multi (exact-set match), numerical (tolerance), **coding via Piston** (`run_against_cases`, marks proportional to points passed, hidden-case I/O never revealed). **Subjective** is flagged `needs_manual_grading`.
  - Sets `grading_status` (`auto_graded` vs `pending_manual`), aggregates marks/percentage, and awards XP **only when fully auto-graded** on first completion (manual-grading attempts get XP after grading in a later phase).

### Access model
`MockTest` access broadened: linked `courses` (M2M) → enrolled students of those courses; else legacy `course` → that course's students (preserves existing behavior); else → open to all students in the tenant. Non-enrolled viewers stay tenant-scoped only. Helpers live in the new `quiz/mock_grading.py`.

### Validation
- `python manage.py check` → **no issues** against the branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>