### PR TITLE
Rich Mock Test frontend: admin builder + fullscreen student attempt (Phase 4)

### DIFF
--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -1116,6 +1116,49 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
             'pending_manual': pending_manual,
         })
 
+    @action(detail=True, methods=['post'], throttle_classes=[QuizSubmitThrottle])
+    def run_item(self, request, pk=None):
+        """Run a coding item's SAMPLE cases against submitted code (ungraded)."""
+        from types import SimpleNamespace
+        from django.conf import settings
+        mock_test = self.get_object()
+        denied = self._rich_access_or_403(mock_test, request)
+        if denied:
+            return denied
+        if not getattr(settings, 'CODING_ENABLED', True):
+            return Response({'error': 'Coding execution is disabled.'},
+                            status=status.HTTP_400_BAD_REQUEST)
+        item = MockTestItem.objects.filter(
+            mock_test=mock_test, id=request.data.get('item_id'), item_type='coding'
+        ).first()
+        if not item:
+            return Response({'error': 'Coding item not found.'},
+                            status=status.HTTP_400_BAD_REQUEST)
+        code = request.data.get('code', '') or ''
+        language = request.data.get('language', '') or ''
+        if not code or not language:
+            return Response({'error': 'code and language are required.'},
+                            status=status.HTTP_400_BAD_REQUEST)
+        samples = [
+            SimpleNamespace(
+                stdin=c.get('stdin', ''), expected_output=c.get('expected_output', ''),
+                points=int(c.get('points', 1) or 1), is_sample=True, id=i, order=i,
+            )
+            for i, c in enumerate(item.coding_test_cases or []) if c.get('is_sample')
+        ]
+        if not samples:
+            return Response({'results': [], 'passed_count': 0, 'total_count': 0})
+        try:
+            from coding.services import run_against_cases, EngineError
+            result = run_against_cases(
+                language=language, source=code, cases=samples,
+                time_limit_ms=item.time_limit_ms, memory_limit_mb=item.memory_limit_mb,
+                reveal_io=True,
+            )
+        except EngineError as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return Response(result)
+
 
 class PreviousYearPaperViewSet(MockTestViewSet):
     """

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -46,6 +46,9 @@ import SubmissionReview from './pages/SubmissionReview'
 import CodingProblem from './pages/CodingProblem'
 import CodingGrading from './pages/CodingGrading'
 import CodingSubmissionReview from './pages/CodingSubmissionReview'
+import MockTestManager from './pages/MockTestManager'
+import MockTestBuilder from './pages/MockTestBuilder'
+import RichMockAttempt from './pages/RichMockAttempt'
 
 
 // Protected Route Component
@@ -163,6 +166,7 @@ function App() {
           <Route path="/quiz/:quizId" element={<QuizAttempt />} />
           <Route path="/quiz/review/:attemptId" element={<QuizReview />} />
           <Route path="/mock-test" element={<MockTest />} />
+          <Route path="/mock-test/live/:testId" element={<RichMockAttempt />} />
           <Route path="/mock-test/:testId" element={<MockTestAttempt />} />
           <Route path="/mock-test/review/:attemptId" element={<MockTestReview />} />
           <Route path="/pyp" element={<PreviousYearPapers />} />
@@ -178,6 +182,8 @@ function App() {
 
           {/* Admin Dashboard */}
           <Route path="/admin-dashboard" element={<AdminDashboard />} />
+          <Route path="/admin/mock-tests" element={<AdminRoute><MockTestManager /></AdminRoute>} />
+          <Route path="/admin/mock-tests/:testId" element={<AdminRoute><MockTestBuilder /></AdminRoute>} />
         </Route>
 
 

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import { analyticsService } from '../services/analyticsService'
@@ -40,6 +41,7 @@ import {
     Mail,
     Phone,
     Filter,
+    ClipboardList,
 } from 'lucide-react'
 
 /* ---------------------------------------------------------------------------
@@ -1176,6 +1178,7 @@ const TABS = [
 const AdminDashboard = () => {
     const [activeTab, setActiveTab] = useState('overview')
     const queryClient = useQueryClient()
+    const navigate = useNavigate()
 
     const { data: stats, isLoading, error, isFetching } = useQuery({
         queryKey: ['tenantAdminStats'],
@@ -1225,6 +1228,14 @@ const AdminDashboard = () => {
                     <button onClick={refreshAll} className="self-start sm:self-auto inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
                         <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} /> Refresh
                     </button>
+                    <div className="flex items-center gap-2 self-start sm:self-auto">
+                        <button onClick={() => navigate('/admin/mock-tests')} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
+                            <ClipboardList className="w-4 h-4" /> Mock Tests
+                        </button>
+                        <button onClick={refreshAll} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
+                            <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} /> Refresh
+                        </button>
+                    </div>
                 </div>
             </div>
 

--- a/frontend/exam-frontend/src/pages/MockTest.jsx
+++ b/frontend/exam-frontend/src/pages/MockTest.jsx
@@ -70,12 +70,7 @@ const MockTest = () => {
   }, [filters.course])
 
   const handleStartTest = async (testId) => {
-    try {
-      await quizService.startMockTest(testId)
-      navigate(`/mock-test/${testId}`)
-    } catch (error) {
-      console.error('Failed to start mock test:', error)
-    }
+    navigate(`/mock-test/live/${testId}`)
   }
 
   const updateFilter = (key, value) => {

--- a/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
@@ -1,0 +1,492 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import {
+  ArrowLeft, Save, Plus, Trash2, GripVertical, Loader2, Settings2,
+  ListChecks, Calculator, FileText, Code2, CheckSquare, Library, X, Search,
+} from 'lucide-react'
+import { mockTestBuilderService } from '../services/mockTestBuilderService'
+
+const ITEM_TYPES = [
+  { value: 'mcq', label: 'MCQ (single)', icon: ListChecks, color: 'text-blue-500' },
+  { value: 'mcq_multi', label: 'MCQ (multiple)', icon: CheckSquare, color: 'text-cyan-500' },
+  { value: 'numerical', label: 'Numerical', icon: Calculator, color: 'text-violet-500' },
+  { value: 'subjective', label: 'Subjective', icon: FileText, color: 'text-amber-500' },
+  { value: 'coding', label: 'Coding', icon: Code2, color: 'text-emerald-500' },
+]
+const typeMeta = (t) => ITEM_TYPES.find((x) => x.value === t) || ITEM_TYPES[0]
+
+const Field = ({ label, children, hint }) => (
+  <label className="block">
+    <span className="text-sm font-medium text-surface-700 dark:text-surface-300">{label}</span>
+    {hint && <span className="text-xs text-surface-400 ml-2">{hint}</span>}
+    <div className="mt-1">{children}</div>
+  </label>
+)
+const inputCls =
+  'w-full px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/40'
+
+export default function MockTestBuilder() {
+  const { testId } = useParams()
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+  const [tab, setTab] = useState('settings')
+  const [form, setForm] = useState(null)
+  const [editingItem, setEditingItem] = useState(null)
+  const [showBank, setShowBank] = useState(false)
+
+  const { data: test, isLoading } = useQuery({
+    queryKey: ['admin-mock-test', testId],
+    queryFn: () => mockTestBuilderService.get(testId),
+  })
+  const { data: items = [] } = useQuery({
+    queryKey: ['admin-mock-items', testId],
+    queryFn: () => mockTestBuilderService.listItems(testId),
+  })
+  const { data: bankLinks = [] } = useQuery({
+    queryKey: ['admin-mock-bank', testId],
+    queryFn: () => mockTestBuilderService.getBankQuestions(testId),
+  })
+  const { data: courses = [] } = useQuery({
+    queryKey: ['admin-courses-for-mock'],
+    queryFn: () => mockTestBuilderService.getCourses(),
+  })
+
+  useEffect(() => { if (test) setForm(test) }, [test])
+
+  const saveMut = useMutation({
+    mutationFn: (payload) => mockTestBuilderService.update(testId, payload),
+    onSuccess: (updated) => {
+      setForm(updated)
+      qc.invalidateQueries({ queryKey: ['admin-mock-test', testId] })
+      qc.invalidateQueries({ queryKey: ['admin-mock-tests'] })
+      toast.success('Saved')
+    },
+    onError: (e) => toast.error(e?.response?.data?.detail || 'Save failed'),
+  })
+
+  const set = (k) => (v) => setForm((f) => ({ ...f, [k]: v }))
+  const toggleCourse = (id) => setForm((f) => {
+    const has = (f.courses || []).includes(id)
+    return { ...f, courses: has ? f.courses.filter((c) => c !== id) : [...(f.courses || []), id] }
+  })
+
+  const saveSettings = () => {
+    const { id, created_at, updated_at, items: _i, course_name, items_count,
+      bank_questions_count, computed_total_marks, total_attempts, ...payload } = form
+    saveMut.mutate(payload)
+  }
+
+  if (isLoading || !form) {
+    return <div className="flex justify-center py-24"><Loader2 className="w-6 h-6 animate-spin text-primary-500" /></div>
+  }
+
+  const totalQuestions = items.length + bankLinks.length
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <button onClick={() => navigate('/admin/mock-tests')}
+        className="flex items-center gap-2 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200 mb-4">
+        <ArrowLeft className="w-4 h-4" /> All Mock Tests
+      </button>
+
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
+        <div>
+          <input
+            value={form.title}
+            onChange={(e) => set('title')(e.target.value)}
+            onBlur={saveSettings}
+            className="text-2xl font-bold bg-transparent text-surface-900 dark:text-white focus:outline-none border-b-2 border-transparent focus:border-primary-400 w-full"
+          />
+          <p className="text-xs text-surface-400 mt-1">
+            {totalQuestions} questions · {Number(form.computed_total_marks || 0)} marks · {form.duration_minutes} min
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select value={form.status} onChange={(e) => { set('status')(e.target.value); saveMut.mutate({ status: e.target.value }) }}
+            className={`${inputCls} w-auto`}>
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+            <option value="archived">Archived</option>
+          </select>
+          <button onClick={saveSettings} disabled={saveMut.isPending}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium disabled:opacity-60">
+            {saveMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />} Save
+          </button>
+        </div>
+      </div>
+
+      <div className="flex gap-1 border-b border-surface-200 dark:border-surface-700 mb-6">
+        {[['settings', 'Settings', Settings2], ['questions', `Questions (${totalQuestions})`, ListChecks]].map(([k, label, Icon]) => (
+          <button key={k} onClick={() => setTab(k)}
+            className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition ${
+              tab === k ? 'border-primary-500 text-primary-600' : 'border-transparent text-surface-500 hover:text-surface-800'}`}>
+            <Icon className="w-4 h-4" /> {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'settings' && (
+        <div className="grid md:grid-cols-2 gap-5">
+          <Field label="Description">
+            <textarea value={form.description || ''} onChange={(e) => set('description')(e.target.value)} rows={3} className={inputCls} />
+          </Field>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Duration (min)">
+              <input type="number" min={1} value={form.duration_minutes || ''} onChange={(e) => set('duration_minutes')(Number(e.target.value))} className={inputCls} />
+            </Field>
+            <Field label="Start deadline" hint="optional">
+              <input type="datetime-local" value={form.start_deadline ? form.start_deadline.slice(0, 16) : ''}
+                onChange={(e) => set('start_deadline')(e.target.value ? new Date(e.target.value).toISOString() : null)} className={inputCls} />
+            </Field>
+          </div>
+
+          <Field label="Result visibility">
+            <select value={form.result_visibility} onChange={(e) => set('result_visibility')(e.target.value)} className={inputCls}>
+              <option value="immediate">Show results on submission</option>
+              <option value="on_release">Hide until I release them</option>
+            </select>
+          </Field>
+          <div className="flex flex-col gap-3 justify-end">
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.fullscreen_required} onChange={(e) => set('fullscreen_required')(e.target.checked)} /> Require fullscreen during attempt
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.negative_marking} onChange={(e) => set('negative_marking')(e.target.checked)} /> Enable negative marking
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.results_released} onChange={(e) => set('results_released')(e.target.checked)} /> Results released (for hidden results)
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input type="checkbox" checked={form.is_free} onChange={(e) => set('is_free')(e.target.checked)} /> Free to attempt
+            </label>
+          </div>
+
+          <div className="md:col-span-2">
+            <Field label="Linked courses" hint="empty = open to all registered students">
+              <div className="grid sm:grid-cols-2 gap-2 max-h-52 overflow-auto p-2 rounded-lg border border-surface-200 dark:border-surface-700">
+                {courses.length === 0 && <span className="text-sm text-surface-400">No courses</span>}
+                {courses.map((c) => (
+                  <label key={c.id} className="flex items-center gap-2 text-sm p-1.5 rounded hover:bg-surface-50 dark:hover:bg-surface-700/50">
+                    <input type="checkbox" checked={(form.courses || []).includes(c.id)} onChange={() => toggleCourse(c.id)} />
+                    {c.name}
+                  </label>
+                ))}
+              </div>
+            </Field>
+          </div>
+          <div className="md:col-span-2">
+            <button onClick={saveSettings} disabled={saveMut.isPending}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium disabled:opacity-60">
+              {saveMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />} Save settings
+            </button>
+          </div>
+        </div>
+      )}
+
+      {tab === 'questions' && (
+        <QuestionsTab
+          testId={testId} items={items} bankLinks={bankLinks}
+          onEditItem={setEditingItem} onOpenBank={() => setShowBank(true)}
+        />
+      )}
+
+      {editingItem && (
+        <ItemEditor testId={testId} item={editingItem} onClose={() => setEditingItem(null)} />
+      )}
+      {showBank && (
+        <BankImport testId={testId} onClose={() => setShowBank(false)} />
+      )}
+    </div>
+  )
+}
+
+/* ----------------------------- Questions tab ----------------------------- */
+function QuestionsTab({ testId, items, bankLinks, onEditItem, onOpenBank }) {
+  const qc = useQueryClient()
+  const [addType, setAddType] = useState('mcq')
+
+  const createMut = useMutation({
+    mutationFn: (item_type) => mockTestBuilderService.createItem({ mock_test: testId, item_type, marks: 1 }),
+    onSuccess: (created) => {
+      qc.invalidateQueries({ queryKey: ['admin-mock-items', testId] })
+      qc.invalidateQueries({ queryKey: ['admin-mock-test', testId] })
+      onEditItem(created)
+    },
+    onError: () => toast.error('Could not add item'),
+  })
+  const delItem = useMutation({
+    mutationFn: (id) => mockTestBuilderService.deleteItem(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-mock-items', testId] })
+      qc.invalidateQueries({ queryKey: ['admin-mock-test', testId] })
+    },
+  })
+  const delBank = useMutation({
+    mutationFn: (qid) => mockTestBuilderService.removeBankQuestion(testId, qid),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-mock-bank', testId] })
+      qc.invalidateQueries({ queryKey: ['admin-mock-test', testId] })
+    },
+  })
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 mb-5">
+        <select value={addType} onChange={(e) => setAddType(e.target.value)} className={`${inputCls} w-auto`}>
+          {ITEM_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+        </select>
+        <button onClick={() => createMut.mutate(addType)} disabled={createMut.isPending}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium disabled:opacity-60">
+          <Plus className="w-4 h-4" /> Add inline question
+        </button>
+        <button onClick={onOpenBank}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-200 dark:border-surface-700 text-sm font-medium hover:bg-surface-50 dark:hover:bg-surface-800">
+          <Library className="w-4 h-4" /> Import from question bank
+        </button>
+      </div>
+
+      {items.length === 0 && bankLinks.length === 0 && (
+        <div className="text-center py-16 border-2 border-dashed border-surface-200 dark:border-surface-700 rounded-2xl text-surface-500">
+          No questions yet. Add an inline question or import from the bank.
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {items.map((it, i) => {
+          const m = typeMeta(it.item_type)
+          const Icon = m.icon
+          return (
+            <div key={it.id} className="flex items-center gap-3 p-3 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800">
+              <GripVertical className="w-4 h-4 text-surface-300" />
+              <span className="text-xs font-mono text-surface-400 w-6">{i + 1}</span>
+              <Icon className={`w-4 h-4 ${m.color}`} />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-surface-800 dark:text-surface-200 truncate">
+                  {it.question_text || <span className="italic text-surface-400">Untitled {m.label}</span>}
+                </p>
+                <p className="text-xs text-surface-400">{m.label} · {Number(it.marks)} marks</p>
+              </div>
+              <button onClick={() => onEditItem(it)} className="px-3 py-1.5 rounded-lg text-sm text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-900/20">Edit</button>
+              <button onClick={() => { if (confirm('Delete this question?')) delItem.mutate(it.id) }} className="p-1.5 rounded-lg text-surface-400 hover:text-rose-600"><Trash2 className="w-4 h-4" /></button>
+            </div>
+          )
+        })}
+        {bankLinks.map((b) => (
+          <div key={b.id} className="flex items-center gap-3 p-3 rounded-xl border border-indigo-200 dark:border-indigo-800 bg-indigo-50/50 dark:bg-indigo-900/10">
+            <Library className="w-4 h-4 text-indigo-500" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-surface-800 dark:text-surface-200 truncate">{b.question_detail?.question_text || 'Bank question'}</p>
+              <p className="text-xs text-surface-400">Bank · {b.question_detail?.question_type} · {Number(b.effective_marks)} marks</p>
+            </div>
+            <button onClick={() => { if (confirm('Remove this bank question?')) delBank.mutate(b.question) }} className="p-1.5 rounded-lg text-surface-400 hover:text-rose-600"><Trash2 className="w-4 h-4" /></button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------ Item editor ------------------------------ */
+function ItemEditor({ testId, item, onClose }) {
+  const qc = useQueryClient()
+  const [f, setF] = useState(() => ({
+    ...item,
+    options: item.options?.length ? item.options : (['mcq', 'mcq_multi'].includes(item.item_type) ? [{ text: '', is_correct: false }, { text: '', is_correct: false }] : []),
+    allowed_languages: item.allowed_languages || [],
+    starter_code: item.starter_code || {},
+    coding_test_cases: item.coding_test_cases || [],
+  }))
+  const { data: meta } = useQuery({ queryKey: ['coding-meta'], queryFn: () => mockTestBuilderService.getLanguages(), enabled: f.item_type === 'coding' })
+  const set = (k) => (v) => setF((s) => ({ ...s, [k]: v }))
+
+  const saveMut = useMutation({
+    mutationFn: () => {
+      const payload = {
+        item_type: f.item_type, question_text: f.question_text || '', question_html: f.question_html || '',
+        explanation: f.explanation || '', marks: f.marks, negative_marks: f.negative_marks || 0, section: f.section || 0,
+      }
+      if (['mcq', 'mcq_multi'].includes(f.item_type)) payload.options = f.options
+      if (f.item_type === 'numerical') { payload.numerical_answer = f.numerical_answer; payload.numerical_tolerance = f.numerical_tolerance || 0.01 }
+      if (f.item_type === 'subjective') { payload.max_words = f.max_words || null; payload.rubric = f.rubric || ''; payload.model_answer = f.model_answer || '' }
+      if (f.item_type === 'coding') {
+        payload.allowed_languages = f.allowed_languages; payload.starter_code = f.starter_code
+        payload.time_limit_ms = f.time_limit_ms || 3000; payload.memory_limit_mb = f.memory_limit_mb || 256
+        payload.coding_test_cases = f.coding_test_cases
+      }
+      return mockTestBuilderService.updateItem(item.id, payload)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin-mock-items', testId] })
+      qc.invalidateQueries({ queryKey: ['admin-mock-test', testId] })
+      toast.success('Question saved'); onClose()
+    },
+    onError: (e) => toast.error(e?.response?.data ? JSON.stringify(e.response.data) : 'Save failed'),
+  })
+
+  const setOpt = (i, patch) => setF((s) => ({ ...s, options: s.options.map((o, idx) => idx === i ? { ...o, ...patch } : (patch.is_correct && f.item_type === 'mcq' ? { ...o, is_correct: false } : o)) }))
+  const langs = meta?.languages || []
+  const m = typeMeta(f.item_type)
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center overflow-auto p-4">
+      <div className="bg-white dark:bg-surface-900 rounded-2xl w-full max-w-2xl my-6 shadow-2xl">
+        <div className="flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-700">
+          <h3 className="font-semibold flex items-center gap-2"><m.icon className={`w-5 h-5 ${m.color}`} /> Edit {m.label}</h3>
+          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800"><X className="w-5 h-5" /></button>
+        </div>
+        <div className="p-5 space-y-4 max-h-[70vh] overflow-auto">
+          <Field label="Question"><textarea value={f.question_text || ''} onChange={(e) => set('question_text')(e.target.value)} rows={3} className={inputCls} /></Field>
+          <div className="grid grid-cols-3 gap-3">
+            <Field label="Marks"><input type="number" step="0.5" value={f.marks} onChange={(e) => set('marks')(Number(e.target.value))} className={inputCls} /></Field>
+            <Field label="Negative"><input type="number" step="0.5" value={f.negative_marks || 0} onChange={(e) => set('negative_marks')(Number(e.target.value))} className={inputCls} /></Field>
+            <Field label="Section"><input type="number" value={f.section || 0} onChange={(e) => set('section')(Number(e.target.value))} className={inputCls} /></Field>
+          </div>
+
+          {['mcq', 'mcq_multi'].includes(f.item_type) && (
+            <div>
+              <p className="text-sm font-medium mb-2">Options <span className="text-xs text-surface-400">(check the correct one{f.item_type === 'mcq_multi' ? 's' : ''})</span></p>
+              <div className="space-y-2">
+                {f.options.map((o, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <input type={f.item_type === 'mcq' ? 'radio' : 'checkbox'} checked={!!o.is_correct} name="correct" onChange={(e) => setOpt(i, { is_correct: e.target.checked })} />
+                    <input value={o.text || ''} onChange={(e) => setF((s) => ({ ...s, options: s.options.map((x, idx) => idx === i ? { ...x, text: e.target.value } : x) }))} placeholder={`Option ${i + 1}`} className={inputCls} />
+                    <button onClick={() => setF((s) => ({ ...s, options: s.options.filter((_, idx) => idx !== i) }))} className="p-1.5 text-surface-400 hover:text-rose-600"><Trash2 className="w-4 h-4" /></button>
+                  </div>
+                ))}
+              </div>
+              <button onClick={() => setF((s) => ({ ...s, options: [...s.options, { text: '', is_correct: false }] }))} className="mt-2 text-sm text-primary-600 flex items-center gap-1"><Plus className="w-4 h-4" /> Add option</button>
+            </div>
+          )}
+
+          {f.item_type === 'numerical' && (
+            <div className="grid grid-cols-2 gap-3">
+              <Field label="Correct answer"><input type="number" step="any" value={f.numerical_answer ?? ''} onChange={(e) => set('numerical_answer')(e.target.value === '' ? null : Number(e.target.value))} className={inputCls} /></Field>
+              <Field label="Tolerance (±)"><input type="number" step="any" value={f.numerical_tolerance ?? 0.01} onChange={(e) => set('numerical_tolerance')(Number(e.target.value))} className={inputCls} /></Field>
+            </div>
+          )}
+
+          {f.item_type === 'subjective' && (
+            <>
+              <Field label="Max words" hint="optional"><input type="number" value={f.max_words ?? ''} onChange={(e) => set('max_words')(e.target.value === '' ? null : Number(e.target.value))} className={inputCls} /></Field>
+              <Field label="Grading rubric" hint="admins only"><textarea value={f.rubric || ''} onChange={(e) => set('rubric')(e.target.value)} rows={2} className={inputCls} /></Field>
+              <Field label="Model answer" hint="admins only"><textarea value={f.model_answer || ''} onChange={(e) => set('model_answer')(e.target.value)} rows={2} className={inputCls} /></Field>
+            </>
+          )}
+
+          {f.item_type === 'coding' && (
+            <div className="space-y-3">
+              <Field label="Allowed languages">
+                <div className="flex flex-wrap gap-3">
+                  {langs.map((l) => (
+                    <label key={l.key} className="flex items-center gap-1.5 text-sm">
+                      <input type="checkbox" checked={f.allowed_languages.includes(l.key)}
+                        onChange={(e) => set('allowed_languages')(e.target.checked ? [...f.allowed_languages, l.key] : f.allowed_languages.filter((x) => x !== l.key))} />
+                      {l.label}
+                    </label>
+                  ))}
+                </div>
+              </Field>
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Time limit (ms)"><input type="number" value={f.time_limit_ms || 3000} onChange={(e) => set('time_limit_ms')(Number(e.target.value))} className={inputCls} /></Field>
+                <Field label="Memory (MB)"><input type="number" value={f.memory_limit_mb || 256} onChange={(e) => set('memory_limit_mb')(Number(e.target.value))} className={inputCls} /></Field>
+              </div>
+              <div>
+                <p className="text-sm font-medium mb-2">Test cases <span className="text-xs text-surface-400">(mark some as sample to show students)</span></p>
+                <div className="space-y-2">
+                  {f.coding_test_cases.map((c, i) => (
+                    <div key={i} className="p-3 rounded-lg border border-surface-200 dark:border-surface-700 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium">Case {i + 1}</span>
+                        <div className="flex items-center gap-3">
+                          <label className="text-xs flex items-center gap-1"><input type="checkbox" checked={!!c.is_sample} onChange={(e) => setF((s) => ({ ...s, coding_test_cases: s.coding_test_cases.map((x, idx) => idx === i ? { ...x, is_sample: e.target.checked } : x) }))} /> sample</label>
+                          <input type="number" value={c.points ?? 1} onChange={(e) => setF((s) => ({ ...s, coding_test_cases: s.coding_test_cases.map((x, idx) => idx === i ? { ...x, points: Number(e.target.value) } : x) }))} className="w-16 px-2 py-1 text-xs rounded border border-surface-200 dark:border-surface-700 bg-transparent" title="points" />
+                          <button onClick={() => setF((s) => ({ ...s, coding_test_cases: s.coding_test_cases.filter((_, idx) => idx !== i) }))} className="text-surface-400 hover:text-rose-600"><Trash2 className="w-4 h-4" /></button>
+                        </div>
+                      </div>
+                      <textarea value={c.stdin || ''} onChange={(e) => setF((s) => ({ ...s, coding_test_cases: s.coding_test_cases.map((x, idx) => idx === i ? { ...x, stdin: e.target.value } : x) }))} placeholder="stdin" rows={2} className={`${inputCls} font-mono text-xs`} />
+                      <textarea value={c.expected_output || ''} onChange={(e) => setF((s) => ({ ...s, coding_test_cases: s.coding_test_cases.map((x, idx) => idx === i ? { ...x, expected_output: e.target.value } : x) }))} placeholder="expected output" rows={2} className={`${inputCls} font-mono text-xs`} />
+                    </div>
+                  ))}
+                </div>
+                <button onClick={() => setF((s) => ({ ...s, coding_test_cases: [...s.coding_test_cases, { stdin: '', expected_output: '', points: 1, is_sample: false }] }))} className="mt-2 text-sm text-primary-600 flex items-center gap-1"><Plus className="w-4 h-4" /> Add test case</button>
+              </div>
+            </div>
+          )}
+
+          <Field label="Explanation" hint="shown after submission"><textarea value={f.explanation || ''} onChange={(e) => set('explanation')(e.target.value)} rows={2} className={inputCls} /></Field>
+        </div>
+        <div className="flex justify-end gap-2 p-4 border-t border-surface-200 dark:border-surface-700">
+          <button onClick={onClose} className="px-4 py-2 rounded-xl border border-surface-200 dark:border-surface-700 text-sm">Cancel</button>
+          <button onClick={() => saveMut.mutate()} disabled={saveMut.isPending}
+            className="inline-flex items-center gap-2 px-5 py-2 rounded-xl bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium disabled:opacity-60">
+            {saveMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />} Save question
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ------------------------------ Bank import ------------------------------ */
+function BankImport({ testId, onClose }) {
+  const qc = useQueryClient()
+  const [q, setQ] = useState('')
+  const [selected, setSelected] = useState([])
+  const { data: results = [], isFetching } = useQuery({
+    queryKey: ['bank-search', q],
+    queryFn: () => mockTestBuilderService.searchBankQuestions(q ? { search: q } : {}),
+  })
+  const addMut = useMutation({
+    mutationFn: () => mockTestBuilderService.addBankQuestions(testId, { question_ids: selected }),
+    onSuccess: (r) => {
+      toast.success(`${r.added} question(s) added`)
+      qc.invalidateQueries({ queryKey: ['admin-mock-bank', testId] })
+      qc.invalidateQueries({ queryKey: ['admin-mock-test', testId] })
+      onClose()
+    },
+    onError: () => toast.error('Import failed'),
+  })
+  const toggle = (id) => setSelected((s) => s.includes(id) ? s.filter((x) => x !== id) : [...s, id])
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center overflow-auto p-4">
+      <div className="bg-white dark:bg-surface-900 rounded-2xl w-full max-w-2xl my-6 shadow-2xl">
+        <div className="flex items-center justify-between p-4 border-b border-surface-200 dark:border-surface-700">
+          <h3 className="font-semibold flex items-center gap-2"><Library className="w-5 h-5 text-indigo-500" /> Import from question bank</h3>
+          <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800"><X className="w-5 h-5" /></button>
+        </div>
+        <div className="p-4">
+          <div className="relative mb-3">
+            <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-surface-400" />
+            <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search questions…" className={`${inputCls} pl-9`} />
+          </div>
+          <div className="max-h-[50vh] overflow-auto space-y-2">
+            {isFetching && <div className="flex justify-center py-6"><Loader2 className="w-5 h-5 animate-spin text-primary-500" /></div>}
+            {results.map((r) => (
+              <label key={r.id} className="flex items-start gap-3 p-3 rounded-lg border border-surface-200 dark:border-surface-700 cursor-pointer hover:bg-surface-50 dark:hover:bg-surface-800">
+                <input type="checkbox" checked={selected.includes(r.id)} onChange={() => toggle(r.id)} className="mt-1" />
+                <div className="min-w-0">
+                  <p className="text-sm text-surface-800 dark:text-surface-200 line-clamp-2">{r.question_text}</p>
+                  <p className="text-xs text-surface-400 mt-0.5">{r.question_type} · {Number(r.marks)} marks</p>
+                </div>
+              </label>
+            ))}
+            {!isFetching && results.length === 0 && <p className="text-center text-sm text-surface-400 py-6">No questions found.</p>}
+          </div>
+        </div>
+        <div className="flex justify-between items-center gap-2 p-4 border-t border-surface-200 dark:border-surface-700">
+          <span className="text-sm text-surface-500">{selected.length} selected</span>
+          <div className="flex gap-2">
+            <button onClick={onClose} className="px-4 py-2 rounded-xl border border-surface-200 dark:border-surface-700 text-sm">Cancel</button>
+            <button onClick={() => addMut.mutate()} disabled={!selected.length || addMut.isPending}
+              className="inline-flex items-center gap-2 px-5 py-2 rounded-xl bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium disabled:opacity-60">
+              {addMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />} Import selected
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/exam-frontend/src/pages/MockTestManager.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestManager.jsx
@@ -1,0 +1,166 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import {
+  Plus, ClipboardList, Clock, Users, Trash2, Pencil, Search,
+  CheckCircle2, FileEdit, Archive, Loader2, ArrowLeft,
+} from 'lucide-react'
+import { mockTestBuilderService } from '../services/mockTestBuilderService'
+
+const STATUS_BADGE = {
+  draft: { label: 'Draft', cls: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300', icon: FileEdit },
+  published: { label: 'Published', cls: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300', icon: CheckCircle2 },
+  archived: { label: 'Archived', cls: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300', icon: Archive },
+}
+
+export default function MockTestManager() {
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState('all')
+
+  const { data: tests = [], isLoading } = useQuery({
+    queryKey: ['admin-mock-tests'],
+    queryFn: () => mockTestBuilderService.list(),
+  })
+
+  const createMut = useMutation({
+    mutationFn: () => mockTestBuilderService.create({
+      title: 'Untitled Mock Test', duration_minutes: 60, status: 'draft',
+    }),
+    onSuccess: (created) => {
+      qc.invalidateQueries({ queryKey: ['admin-mock-tests'] })
+      navigate(`/admin/mock-tests/${created.id}`)
+    },
+    onError: () => toast.error('Could not create mock test'),
+  })
+
+  const deleteMut = useMutation({
+    mutationFn: (id) => mockTestBuilderService.remove(id),
+    onSuccess: () => {
+      toast.success('Mock test deleted')
+      qc.invalidateQueries({ queryKey: ['admin-mock-tests'] })
+    },
+    onError: () => toast.error('Delete failed'),
+  })
+
+  const filtered = tests.filter((t) => {
+    if (statusFilter !== 'all' && t.status !== statusFilter) return false
+    if (search && !t.title.toLowerCase().includes(search.toLowerCase())) return false
+    return true
+  })
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8">
+      <button
+        onClick={() => navigate('/admin-dashboard')}
+        className="flex items-center gap-2 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200 mb-4"
+      >
+        <ArrowLeft className="w-4 h-4" /> Back to Admin
+      </button>
+
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
+            <ClipboardList className="w-6 h-6 text-primary-500" /> Mock Tests
+          </h1>
+          <p className="text-surface-500 text-sm mt-1">
+            Create and manage full exams with MCQ, numerical, subjective and coding questions.
+          </p>
+        </div>
+        <button
+          onClick={() => createMut.mutate()}
+          disabled={createMut.isPending}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium shadow-sm disabled:opacity-60"
+        >
+          {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+          New Mock Test
+        </button>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-5">
+        <div className="relative flex-1">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-surface-400" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search mock tests…"
+            className="w-full pl-9 pr-3 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500/40"
+          />
+        </div>
+        <div className="flex gap-1 bg-surface-100 dark:bg-surface-800 rounded-xl p-1">
+          {['all', 'draft', 'published', 'archived'].map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-3 py-1.5 rounded-lg text-sm capitalize transition ${
+                statusFilter === s
+                  ? 'bg-white dark:bg-surface-700 shadow-sm text-surface-900 dark:text-white font-medium'
+                  : 'text-surface-500 hover:text-surface-800'
+              }`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-20"><Loader2 className="w-6 h-6 animate-spin text-primary-500" /></div>
+      ) : filtered.length === 0 ? (
+        <div className="text-center py-20 border-2 border-dashed border-surface-200 dark:border-surface-700 rounded-2xl">
+          <ClipboardList className="w-10 h-10 mx-auto text-surface-300 mb-3" />
+          <p className="text-surface-500">No mock tests yet. Create your first one.</p>
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {filtered.map((t) => {
+            const badge = STATUS_BADGE[t.status] || STATUS_BADGE.draft
+            const BadgeIcon = badge.icon
+            return (
+              <div
+                key={t.id}
+                className="group flex items-center gap-4 p-4 rounded-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 hover:shadow-md transition cursor-pointer"
+                onClick={() => navigate(`/admin/mock-tests/${t.id}`)}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h3 className="font-semibold text-surface-900 dark:text-white truncate">{t.title}</h3>
+                    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${badge.cls}`}>
+                      <BadgeIcon className="w-3 h-3" /> {badge.label}
+                    </span>
+                    {t.is_pyp && <span className="px-2 py-0.5 rounded-full text-xs bg-indigo-100 text-indigo-700">PYQ</span>}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-4 text-xs text-surface-500">
+                    <span className="flex items-center gap-1"><Clock className="w-3.5 h-3.5" /> {t.duration_minutes} min</span>
+                    <span>{(t.items_count || 0) + (t.bank_questions_count || 0)} questions</span>
+                    <span>{Number(t.computed_total_marks || t.total_marks || 0)} marks</span>
+                    <span className="flex items-center gap-1"><Users className="w-3.5 h-3.5" /> {t.total_attempts || 0} attempts</span>
+                  </div>
+                </div>
+                <button
+                  onClick={(e) => { e.stopPropagation(); navigate(`/admin/mock-tests/${t.id}`) }}
+                  className="p-2 rounded-lg text-surface-400 hover:text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-900/20"
+                  title="Edit"
+                >
+                  <Pencil className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    if (window.confirm(`Delete "${t.title}"? This cannot be undone.`)) deleteMut.mutate(t.id)
+                  }}
+                  className="p-2 rounded-lg text-surface-400 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20"
+                  title="Delete"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/exam-frontend/src/pages/RichMockAttempt.jsx
+++ b/frontend/exam-frontend/src/pages/RichMockAttempt.jsx
@@ -1,0 +1,416 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import toast from 'react-hot-toast'
+import {
+  Clock, ChevronLeft, ChevronRight, Flag, Maximize2, AlertTriangle,
+  Loader2, Play, CheckCircle2, XCircle, Send, ListChecks,
+} from 'lucide-react'
+import { mockTestBuilderService } from '../services/mockTestBuilderService'
+import CodeEditor from '../components/coding/CodeEditor'
+
+const MONACO_MODE = { python: 'python', cpp: 'cpp', java: 'java' }
+
+const qKey = (q) => `${q.kind}:${q.ref_id}`
+
+export default function RichMockAttempt() {
+  const { testId } = useParams()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [meta, setMeta] = useState(null)
+  const [questions, setQuestions] = useState([])
+  const [attemptId, setAttemptId] = useState(null)
+  const [current, setCurrent] = useState(0)
+  const [answers, setAnswers] = useState({})       // qKey -> answer payload
+  const [flagged, setFlagged] = useState({})       // qKey -> bool
+  const [remaining, setRemaining] = useState(0)    // seconds
+  const [submitting, setSubmitting] = useState(false)
+  const [result, setResult] = useState(null)
+  const [violations, setViolations] = useState(0)
+  const [showWarn, setShowWarn] = useState(false)
+  const containerRef = useRef(null)
+  const startedRef = useRef(Date.now())
+  const submittedRef = useRef(false)
+
+  /* ------------------------- start attempt ------------------------- */
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        const paper = await mockTestBuilderService.getPaper(testId)
+        const started = await mockTestBuilderService.startRich(testId)
+        if (!alive) return
+        const mtMeta = paper.mock_test
+        setMeta({ mock_test: mtMeta })
+        setQuestions(started.questions || paper.questions || [])
+        setAttemptId(started.attempt?.id)
+        setRemaining((mtMeta.duration_minutes || 60) * 60)
+      } catch (e) {
+        const msg = e?.response?.data?.error || 'Could not start this test.'
+        toast.error(msg)
+        navigate('/mock-test')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => { alive = false }
+  }, [testId, navigate])
+
+  const mt = meta?.mock_test
+
+  /* ------------------------- fullscreen ------------------------- */
+  const enterFullscreen = useCallback(() => {
+    const el = containerRef.current
+    if (el?.requestFullscreen) el.requestFullscreen().catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!mt?.fullscreen_required || loading || result) return
+    enterFullscreen()
+  }, [mt, loading, result, enterFullscreen])
+
+  /* ------------------------- timer ------------------------- */
+  useEffect(() => {
+    if (loading || result) return
+    const id = setInterval(() => {
+      setRemaining((r) => {
+        if (r <= 1) { clearInterval(id); handleSubmit(true); return 0 }
+        return r - 1
+      })
+    }, 1000)
+    return () => clearInterval(id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, result])
+
+  /* ------------------- proctoring: tab-switch / fullscreen exit ------------------- */
+  useEffect(() => {
+    if (loading || result) return
+    const onVisibility = () => {
+      if (document.hidden) bumpViolation()
+    }
+    const onFsChange = () => {
+      if (mt?.fullscreen_required && !document.fullscreenElement && !submittedRef.current) {
+        bumpViolation()
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    document.addEventListener('fullscreenchange', onFsChange)
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      document.removeEventListener('fullscreenchange', onFsChange)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, result, mt])
+
+  const bumpViolation = () => {
+    setViolations((v) => v + 1)
+    setShowWarn(true)
+  }
+
+  /* ------------------------- answer helpers ------------------------- */
+  const q = questions[current]
+  const setAns = (patch) => setAnswers((a) => ({ ...a, [qKey(q)]: { ...(a[qKey(q)] || {}), ...patch } }))
+  const cur = q ? (answers[qKey(q)] || {}) : {}
+
+  const isAnswered = (question) => {
+    const a = answers[qKey(question)]
+    if (!a) return false
+    if (['mcq', 'mcq_multi'].includes(question.item_type)) return (a.selected != null && a.selected.length > 0) || a.selected_option != null
+    if (question.item_type === 'numerical') return a.numerical_answer != null && a.numerical_answer !== ''
+    if (question.item_type === 'subjective') return !!(a.answer_text && a.answer_text.trim())
+    if (question.item_type === 'coding') return !!(a.code && a.code.trim())
+    return false
+  }
+
+  const toggleFlag = () => setFlagged((f) => ({ ...f, [qKey(q)]: !f[qKey(q)] }))
+
+  /* ------------------------- coding run ------------------------- */
+  const [running, setRunning] = useState(false)
+  const [runResult, setRunResult] = useState(null)
+  const runSamples = async () => {
+    if (!cur.code || !cur.language) { toast.error('Write some code and pick a language first.'); return }
+    setRunning(true); setRunResult(null)
+    try {
+      const r = await mockTestBuilderService.runCode(testId, { item_id: q.ref_id, code: cur.code, language: cur.language })
+      setRunResult(r)
+    } catch (e) {
+      toast.error(e?.response?.data?.error || 'Run failed')
+    } finally { setRunning(false) }
+  }
+
+  /* ------------------------- submit ------------------------- */
+  const buildPayload = () => {
+    const bank_answers = []
+    const item_answers = []
+    questions.forEach((question) => {
+      const a = answers[qKey(question)]
+      if (!a) return
+      const marked = !!flagged[qKey(question)]
+      if (question.kind === 'bank') {
+        const entry = { question_id: question.ref_id, is_marked_for_review: marked }
+        if (question.item_type === 'numerical') entry.numerical_answer = a.numerical_answer
+        else entry.selected_option = a.selected != null && a.selected.length ? String(a.selected[0]) : ''
+        bank_answers.push(entry)
+      } else {
+        const entry = { item_id: question.ref_id, is_marked_for_review: marked }
+        if (['mcq', 'mcq_multi'].includes(question.item_type)) entry.selected_options = a.selected || []
+        if (question.item_type === 'numerical') entry.numerical_answer = a.numerical_answer
+        if (question.item_type === 'subjective') entry.answer_text = a.answer_text || ''
+        if (question.item_type === 'coding') { entry.code = a.code || ''; entry.language = a.language || '' }
+        item_answers.push(entry)
+      }
+    })
+    return { time_taken_seconds: Math.round((Date.now() - startedRef.current) / 1000), bank_answers, item_answers }
+  }
+
+  const handleSubmit = async (auto = false) => {
+    if (submittedRef.current) return
+    if (!auto && !window.confirm('Submit your test? You cannot change answers afterwards.')) return
+    submittedRef.current = true
+    setSubmitting(true)
+    try {
+      const r = await mockTestBuilderService.submitRich(testId, buildPayload())
+      setResult(r)
+      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
+    } catch (e) {
+      submittedRef.current = false
+      toast.error(e?.response?.data?.error || 'Submission failed')
+    } finally { setSubmitting(false) }
+  }
+
+  const fmt = (s) => `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`
+
+  if (loading) return <div className="flex justify-center items-center h-screen"><Loader2 className="w-8 h-8 animate-spin text-primary-500" /></div>
+
+  /* ------------------------- result screen ------------------------- */
+  if (result) {
+    const visible = result.results_visible
+    const a = result.attempt
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4 bg-surface-50 dark:bg-surface-950">
+        <div className="max-w-md w-full bg-white dark:bg-surface-900 rounded-3xl shadow-xl p-8 text-center">
+          <CheckCircle2 className="w-14 h-14 text-emerald-500 mx-auto mb-4" />
+          <h2 className="text-2xl font-bold mb-2">Test submitted</h2>
+          {result.pending_manual ? (
+            <p className="text-surface-500 mb-6">Your test includes subjective questions. Results will be available after grading.</p>
+          ) : visible ? (
+            <div className="mb-6">
+              <p className="text-4xl font-bold text-primary-600">{Number(a.marks_obtained)}<span className="text-lg text-surface-400"> / {Number(a.total_marks || mt.total_marks)}</span></p>
+              <p className="text-surface-500 mt-1">{Number(a.percentage)}% · {a.correct_answers} correct</p>
+              {a.xp_earned > 0 && <p className="text-amber-500 font-medium mt-2">+{a.xp_earned} XP</p>}
+            </div>
+          ) : (
+            <p className="text-surface-500 mb-6">Your responses were recorded. Results will be released by your instructor.</p>
+          )}
+          <div className="flex gap-3">
+            <button onClick={() => navigate('/mock-test')} className="flex-1 px-4 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium">Back to Mock Tests</button>
+            {visible && !result.pending_manual && attemptId && (
+              <button onClick={() => navigate(`/mock-test/review/${attemptId}`)} className="flex-1 px-4 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 font-medium">Review</button>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const lowTime = remaining < 60
+
+  return (
+    <div ref={containerRef} className="min-h-screen bg-surface-50 dark:bg-surface-950 flex flex-col">
+      {/* top bar */}
+      <div className="flex items-center justify-between px-4 py-3 bg-white dark:bg-surface-900 border-b border-surface-200 dark:border-surface-700 sticky top-0 z-20">
+        <div className="min-w-0">
+          <h1 className="font-semibold text-surface-900 dark:text-white truncate">{mt?.title}</h1>
+          <p className="text-xs text-surface-400">Question {current + 1} of {questions.length}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className={`flex items-center gap-2 px-3 py-1.5 rounded-lg font-mono font-semibold ${lowTime ? 'bg-rose-100 text-rose-700 animate-pulse' : 'bg-surface-100 dark:bg-surface-800'}`}>
+            <Clock className="w-4 h-4" /> {fmt(remaining)}
+          </div>
+          {mt?.fullscreen_required && !document.fullscreenElement && (
+            <button onClick={enterFullscreen} className="p-2 rounded-lg bg-amber-100 text-amber-700" title="Re-enter fullscreen"><Maximize2 className="w-4 h-4" /></button>
+          )}
+          <button onClick={() => handleSubmit(false)} disabled={submitting}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium disabled:opacity-60">
+            {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />} Submit
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 flex flex-col lg:flex-row gap-4 p-4 max-w-6xl mx-auto w-full">
+        {/* question panel */}
+        <div className="flex-1 bg-white dark:bg-surface-900 rounded-2xl border border-surface-200 dark:border-surface-700 p-5 sm:p-6">
+          {q && (
+            <>
+              <div className="flex items-start justify-between gap-3 mb-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold px-2 py-1 rounded-full bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300 uppercase">{q.item_type.replace('_', ' ')}</span>
+                  <span className="text-xs text-surface-400">{q.marks} mark{q.marks !== 1 ? 's' : ''}{q.negative_marks ? ` · -${q.negative_marks}` : ''}</span>
+                </div>
+                <button onClick={toggleFlag} className={`inline-flex items-center gap-1 text-sm px-3 py-1.5 rounded-lg ${flagged[qKey(q)] ? 'bg-amber-100 text-amber-700' : 'text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'}`}>
+                  <Flag className="w-4 h-4" /> {flagged[qKey(q)] ? 'Flagged' : 'Flag'}
+                </button>
+              </div>
+
+              {q.question_html ? (
+                <div className="prose dark:prose-invert max-w-none mb-5" dangerouslySetInnerHTML={{ __html: q.question_html }} />
+              ) : (
+                <p className="text-surface-800 dark:text-surface-100 whitespace-pre-wrap mb-5 text-[15px] leading-relaxed">{q.question_text}</p>
+              )}
+              {q.question_image && <img src={q.question_image} alt="" className="max-h-72 rounded-lg mb-5" />}
+
+              <AnswerInput q={q} value={cur} onChange={setAns}
+                running={running} runResult={runResult} onRun={runSamples} />
+            </>
+          )}
+
+          {/* nav buttons */}
+          <div className="flex items-center justify-between mt-8 pt-4 border-t border-surface-200 dark:border-surface-700">
+            <button onClick={() => setCurrent((c) => Math.max(0, c - 1))} disabled={current === 0}
+              className="inline-flex items-center gap-1 px-4 py-2 rounded-xl border border-surface-200 dark:border-surface-700 text-sm disabled:opacity-40">
+              <ChevronLeft className="w-4 h-4" /> Previous
+            </button>
+            {current < questions.length - 1 ? (
+              <button onClick={() => setCurrent((c) => Math.min(questions.length - 1, c + 1))}
+                className="inline-flex items-center gap-1 px-4 py-2 rounded-xl bg-primary-600 hover:bg-primary-700 text-white text-sm">
+                Next <ChevronRight className="w-4 h-4" />
+              </button>
+            ) : (
+              <button onClick={() => handleSubmit(false)} disabled={submitting}
+                className="inline-flex items-center gap-1 px-4 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white text-sm">
+                Finish <Send className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* navigator */}
+        <div className="lg:w-64 bg-white dark:bg-surface-900 rounded-2xl border border-surface-200 dark:border-surface-700 p-4 h-fit">
+          <p className="text-sm font-semibold mb-3 flex items-center gap-2"><ListChecks className="w-4 h-4" /> Questions</p>
+          <div className="grid grid-cols-6 lg:grid-cols-5 gap-2">
+            {questions.map((question, i) => {
+              const answered = isAnswered(question)
+              const isFlag = flagged[qKey(question)]
+              return (
+                <button key={qKey(question)} onClick={() => setCurrent(i)}
+                  className={`relative w-9 h-9 rounded-lg text-sm font-medium transition ${
+                    i === current ? 'ring-2 ring-primary-500 ' : ''}${
+                    answered ? 'bg-emerald-500 text-white' : 'bg-surface-100 dark:bg-surface-800 text-surface-500'}`}>
+                  {i + 1}
+                  {isFlag && <Flag className="w-3 h-3 text-amber-500 absolute -top-1 -right-1" />}
+                </button>
+              )
+            })}
+          </div>
+          <div className="mt-4 space-y-1.5 text-xs text-surface-500">
+            <p className="flex items-center gap-2"><span className="w-3 h-3 rounded bg-emerald-500 inline-block" /> Answered</p>
+            <p className="flex items-center gap-2"><span className="w-3 h-3 rounded bg-surface-200 dark:bg-surface-700 inline-block" /> Not answered</p>
+            <p className="flex items-center gap-2"><Flag className="w-3 h-3 text-amber-500" /> Flagged for review</p>
+          </div>
+        </div>
+      </div>
+
+      {/* proctoring warning */}
+      {showWarn && (
+        <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center p-4">
+          <div className="bg-white dark:bg-surface-900 rounded-2xl max-w-sm w-full p-6 text-center">
+            <AlertTriangle className="w-12 h-12 text-amber-500 mx-auto mb-3" />
+            <h3 className="text-lg font-bold mb-2">Stay on the test</h3>
+            <p className="text-surface-500 text-sm mb-4">
+              Leaving the test window or fullscreen is recorded. Warning {violations} of 3. Repeated violations may be flagged to your instructor.
+            </p>
+            <button onClick={() => { setShowWarn(false); if (mt?.fullscreen_required) enterFullscreen() }}
+              className="w-full px-4 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium">
+              Resume test
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ------------------------- per-type answer input ------------------------- */
+function AnswerInput({ q, value, onChange, running, runResult, onRun }) {
+  if (['mcq', 'mcq_multi'].includes(q.item_type)) {
+    const selected = value.selected || []
+    const toggle = (idx) => {
+      if (q.item_type === 'mcq') onChange({ selected: [idx] })
+      else onChange({ selected: selected.includes(idx) ? selected.filter((x) => x !== idx) : [...selected, idx] })
+    }
+    return (
+      <div className="space-y-2">
+        {(q.options || []).map((o) => (
+          <button key={o.index} onClick={() => toggle(o.index)}
+            className={`w-full text-left px-4 py-3 rounded-xl border transition flex items-center gap-3 ${
+              selected.includes(o.index)
+                ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
+                : 'border-surface-200 dark:border-surface-700 hover:border-surface-300'}`}>
+            <span className={`w-5 h-5 rounded-${q.item_type === 'mcq' ? 'full' : 'md'} border flex items-center justify-center ${selected.includes(o.index) ? 'border-primary-500 bg-primary-500' : 'border-surface-300'}`}>
+              {selected.includes(o.index) && <CheckCircle2 className="w-4 h-4 text-white" />}
+            </span>
+            <span className="text-surface-800 dark:text-surface-100">{o.text}</span>
+            {o.image && <img src={o.image} alt="" className="h-12 rounded ml-auto" />}
+          </button>
+        ))}
+      </div>
+    )
+  }
+
+  if (q.item_type === 'numerical') {
+    return (
+      <input type="number" step="any" value={value.numerical_answer ?? ''}
+        onChange={(e) => onChange({ numerical_answer: e.target.value === '' ? null : Number(e.target.value) })}
+        placeholder="Enter your numerical answer"
+        className="w-full max-w-xs px-4 py-3 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-lg focus:outline-none focus:ring-2 focus:ring-primary-500/40" />
+    )
+  }
+
+  if (q.item_type === 'subjective') {
+    const words = (value.answer_text || '').trim().split(/\s+/).filter(Boolean).length
+    return (
+      <div>
+        <textarea value={value.answer_text || ''} onChange={(e) => onChange({ answer_text: e.target.value })}
+          rows={10} placeholder="Write your answer…"
+          className="w-full px-4 py-3 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 focus:outline-none focus:ring-2 focus:ring-primary-500/40" />
+        <p className="text-xs text-surface-400 mt-1">{words} words{q.max_words ? ` / ${q.max_words} max` : ''}</p>
+      </div>
+    )
+  }
+
+  if (q.item_type === 'coding') {
+    const langs = q.allowed_languages || []
+    const lang = value.language || langs[0] || 'python'
+    if (!value.language && langs[0] && !value.code) {
+      // lazy default starter code
+    }
+    return (
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <select value={lang} onChange={(e) => onChange({ language: e.target.value })}
+            className="px-3 py-1.5 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800 text-sm">
+            {langs.map((l) => <option key={l} value={l}>{l}</option>)}
+          </select>
+          <button onClick={onRun} disabled={running}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-surface-800 text-white text-sm disabled:opacity-60">
+            {running ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />} Run samples
+          </button>
+        </div>
+        <CodeEditor value={value.code || (q.starter_code?.[lang] ?? '')} onChange={(v) => onChange({ code: v, language: lang })} language={MONACO_MODE[lang] || 'python'} height={360} />
+        {runResult && (
+          <div className="mt-3 space-y-2">
+            <p className="text-sm font-medium">{runResult.passed_count}/{runResult.total_count} sample cases passed</p>
+            {(runResult.results || []).map((r, i) => (
+              <div key={i} className={`text-xs rounded-lg p-2 border ${r.verdict === 'passed' ? 'border-emerald-200 bg-emerald-50 dark:bg-emerald-900/10' : 'border-rose-200 bg-rose-50 dark:bg-rose-900/10'}`}>
+                <p className="flex items-center gap-1 font-medium">{r.verdict === 'passed' ? <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" /> : <XCircle className="w-3.5 h-3.5 text-rose-500" />} Case {i + 1}: {r.verdict}</p>
+                {r.stdin != null && <pre className="mt-1 whitespace-pre-wrap"><b>in:</b> {r.stdin}</pre>}
+                {r.expected_output != null && <pre className="whitespace-pre-wrap"><b>expected:</b> {r.expected_output}</pre>}
+                {r.stdout != null && <pre className="whitespace-pre-wrap"><b>got:</b> {r.stdout}</pre>}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+  return null
+}

--- a/frontend/exam-frontend/src/services/mockTestBuilderService.js
+++ b/frontend/exam-frontend/src/services/mockTestBuilderService.js
@@ -1,0 +1,59 @@
+import api from './api'
+
+const list = (res) => {
+  const d = res.data
+  return Array.isArray(d) ? d : (d?.results ?? [])
+}
+
+const PAGE = { page_size: 500 }
+
+/**
+ * Admin builder + student attempt API for the rich Mock Test system.
+ */
+export const mockTestBuilderService = {
+  // --- admin: mock tests ---
+  list: async (params = {}) =>
+    list(await api.get('/quiz/admin/mock-tests/', { params: { ...PAGE, ...params } })),
+  get: async (id) => (await api.get(`/quiz/admin/mock-tests/${id}/`)).data,
+  create: async (data) => (await api.post('/quiz/admin/mock-tests/', data)).data,
+  update: async (id, data) => (await api.patch(`/quiz/admin/mock-tests/${id}/`, data)).data,
+  remove: async (id) => api.delete(`/quiz/admin/mock-tests/${id}/`),
+  recomputeMarks: async (id) =>
+    (await api.post(`/quiz/admin/mock-tests/${id}/recompute_marks/`)).data,
+
+  // --- admin: inline items ---
+  listItems: async (mockTestId) =>
+    list(await api.get('/quiz/admin/mock-items/', { params: { mock_test: mockTestId, ...PAGE } })),
+  createItem: async (data) => (await api.post('/quiz/admin/mock-items/', data)).data,
+  updateItem: async (id, data) => (await api.patch(`/quiz/admin/mock-items/${id}/`, data)).data,
+  deleteItem: async (id) => api.delete(`/quiz/admin/mock-items/${id}/`),
+  reorderItems: async (order) =>
+    (await api.post('/quiz/admin/mock-items/reorder/', { order })).data,
+
+  // --- admin: bank question linking ---
+  getBankQuestions: async (mockTestId) =>
+    (await api.get(`/quiz/admin/mock-tests/${mockTestId}/bank_questions/`)).data,
+  addBankQuestions: async (mockTestId, payload) =>
+    (await api.post(`/quiz/admin/mock-tests/${mockTestId}/add_bank_questions/`, payload)).data,
+  removeBankQuestion: async (mockTestId, questionId) =>
+    (await api.post(`/quiz/admin/mock-tests/${mockTestId}/remove_bank_question/`, { question_id: questionId })).data,
+  searchBankQuestions: async (params = {}) =>
+    list(await api.get('/quiz/admin/questions/', { params: { ...PAGE, ...params } })),
+
+  // --- admin: helpers ---
+  getCourses: async () =>
+    list(await api.get('/courses/admin/courses/', { params: PAGE })),
+  getLanguages: async () => (await api.get('/coding/meta/')).data,
+
+  // --- student: rich attempt flow ---
+  getPaper: async (testId) =>
+    (await api.get(`/quiz/mock-tests/${testId}/paper/`)).data,
+  startRich: async (testId) =>
+    (await api.post(`/quiz/mock-tests/${testId}/start_rich/`)).data,
+  submitRich: async (testId, data) =>
+    (await api.post(`/quiz/mock-tests/${testId}/submit_rich/`, data)).data,
+  runCode: async (testId, payload) =>
+    (await api.post(`/quiz/mock-tests/${testId}/run_item/`, payload)).data,
+}
+
+export default mockTestBuilderService


### PR DESCRIPTION
## Phase 4 — Frontend for the rich Mock Test system

Builds on the Phase 1–3 backend (PRs #48/#49/#50). Adds the admin builder UI and the student attempt experience, plus a small backend endpoint to run coding samples.

### Admin
- **MockTestManager** (`/admin/mock-tests`) — list with search + status filter, create, delete.
- **MockTestBuilder** (`/admin/mock-tests/:testId`) — Settings tab (description, duration, start deadline, result visibility, fullscreen/negative-marking/release/free toggles, linked-courses multi-select) + Questions tab with an inline item editor for all 5 types (MCQ, MCQ-multi, numerical, subjective, coding) and bank-question import.
- Entry point button added to the AdminDashboard header.

### Student
- **RichMockAttempt** (`/mock-test/live/:testId`) — fullscreen proctored attempt: countdown timer (auto-submit at 0), question navigator with answered/flagged state, per-type answer UI, Monaco editor + "Run samples" for coding, tab-switch / fullscreen-exit warnings, and a results-or-pending screen based on `results_visible` / `pending_manual`.
- "Start Test" now routes through the unified rich attempt flow (the rich paper includes bank questions, so it is a superset of the legacy flow).

### Backend
- `run_item` action on `MockTestViewSet` runs a coding item's **sample** cases against submitted code (`reveal_io=True`), access-guarded and `CODING_ENABLED`-gated.

### Service layer
- New `mockTestBuilderService` covering admin CRUD, bank linking, recompute, course/language lookups, and student rich actions (paper/start/submit/run).

### Deploy notes
Requires **both** a VM `web` restart (for `run_item`) and Netlify frontend deploy.

Frontend builds clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>