### PR TITLE
Manual/subjective grading for rich Mock Tests (Phase 5)

### DIFF
--- a/backend/quiz/admin_views.py
+++ b/backend/quiz/admin_views.py
@@ -61,6 +61,8 @@ class AdminQuestionViewSet(TenantAdminModelViewSet):
 # ---------------------------------------------------------------------------
 from decimal import Decimal
 
+from django.utils import timezone
+
 from rest_framework import viewsets, filters, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -69,7 +71,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from core.permissions import IsTenantAdmin
 from exams.admin_views import BuilderPagination
-from .models import MockTest, MockTestItem, MockTestQuestion, Question
+from .models import MockTest, MockTestItem, MockTestQuestion, Question, MockTestAttempt, MockTestAnswer
 from .admin_serializers import (
     AdminMockTestSerializer, AdminMockTestItemSerializer,
     AdminMockTestQuestionSerializer,
@@ -173,6 +175,177 @@ class AdminMockTestViewSet(viewsets.ModelViewSet):
         mock_test = self.get_object()
         total = recompute_mock_total(mock_test)
         return Response({'total_marks': float(total)})
+
+    # --- manual grading (Phase 5) ----------------------------------------
+
+    def _attempt_grading_payload(self, attempt):
+        """Serialize an attempt with its inline answers for the grading UI."""
+        u = getattr(attempt.student, 'user', None)
+        answers = []
+        for ans in (attempt.item_answers.select_related('item')
+                    .order_by('item__section', 'item__order')):
+            item = ans.item
+            answers.append({
+                'answer_id': str(ans.id),
+                'item_id': str(item.id),
+                'item_type': item.item_type,
+                'question_text': item.question_text,
+                'question_html': item.question_html or '',
+                'max_marks': float(ans.max_marks or item.marks),
+                'max_words': item.max_words,
+                'answer_text': ans.answer_text,
+                'code': ans.code,
+                'language': ans.language,
+                'coding_results': ans.coding_results,
+                'passed_count': ans.passed_count,
+                'total_count': ans.total_count,
+                'marks_obtained': float(ans.marks_obtained),
+                'feedback': ans.feedback,
+                'needs_manual_grading': ans.needs_manual_grading,
+                'is_auto_graded': ans.is_auto_graded,
+                'graded_at': ans.graded_at.isoformat() if ans.graded_at else None,
+            })
+        return {
+            'attempt_id': str(attempt.id),
+            'student_name': (getattr(u, 'full_name', '') or (u.email if u else '')).strip() if u else '',
+            'student_email': u.email if u else '',
+            'mock_test_id': str(attempt.mock_test_id),
+            'mock_test_title': attempt.mock_test.title,
+            'total_marks': float(attempt.mock_test.total_marks),
+            'marks_obtained': float(attempt.marks_obtained),
+            'percentage': float(attempt.percentage),
+            'grading_status': attempt.grading_status,
+            'completed_at': attempt.completed_at.isoformat() if attempt.completed_at else None,
+            'pending_count': attempt.item_answers.filter(needs_manual_grading=True).count(),
+            'answers': answers,
+        }
+
+    @action(detail=False, methods=['get'], url_path='pending-grading')
+    def pending_grading(self, request):
+        """List completed attempts (this tenant) awaiting manual grading."""
+        tenant = self._tenant()
+        qs = (MockTestAttempt.objects.filter(
+                mock_test__tenant=tenant, status='completed',
+                grading_status='pending_manual')
+              .select_related('student__user', 'mock_test')
+              .order_by('completed_at'))
+        mock_id = request.query_params.get('mock_test')
+        if mock_id:
+            qs = qs.filter(mock_test_id=mock_id)
+        out = []
+        for a in qs:
+            u = getattr(a.student, 'user', None)
+            out.append({
+                'attempt_id': str(a.id),
+                'student_name': (getattr(u, 'full_name', '') or (u.email if u else '')).strip() if u else '',
+                'student_email': u.email if u else '',
+                'mock_test_id': str(a.mock_test_id),
+                'mock_test_title': a.mock_test.title,
+                'completed_at': a.completed_at.isoformat() if a.completed_at else None,
+                'pending_count': a.item_answers.filter(needs_manual_grading=True).count(),
+            })
+        return Response(out)
+
+    @action(detail=False, methods=['get'], url_path='attempts/(?P<attempt_id>[^/.]+)')
+    def attempt_detail(self, request, attempt_id=None):
+        """Full grading view for a single attempt."""
+        tenant = self._tenant()
+        attempt = (MockTestAttempt.objects.filter(id=attempt_id, mock_test__tenant=tenant)
+                   .select_related('student__user', 'mock_test').first())
+        if not attempt:
+            raise NotFound('Attempt not found.')
+        return Response(self._attempt_grading_payload(attempt))
+
+    @action(detail=False, methods=['post'], url_path='grade-answer')
+    def grade_answer(self, request):
+        """Set marks + feedback on one inline answer (marks it manually graded)."""
+        tenant = self._tenant()
+        answer_id = request.data.get('answer_id')
+        ans = (MockTestAnswer.objects.filter(id=answer_id, attempt__mock_test__tenant=tenant)
+               .select_related('item', 'attempt__mock_test').first())
+        if not ans:
+            raise NotFound('Answer not found.')
+        try:
+            marks = Decimal(str(request.data.get('marks')))
+        except (TypeError, ValueError):
+            raise ValidationError({'marks': 'A numeric marks value is required.'})
+        max_marks = Decimal(str(ans.max_marks or ans.item.marks))
+        if marks < 0 or marks > max_marks:
+            raise ValidationError({'marks': f'Marks must be between 0 and {max_marks}.'})
+        ans.marks_obtained = marks
+        ans.feedback = request.data.get('feedback', '') or ''
+        ans.is_correct = marks >= max_marks and max_marks > 0
+        ans.needs_manual_grading = False
+        ans.is_auto_graded = False
+        ans.graded_by = request.user
+        ans.graded_at = timezone.now()
+        ans.save(update_fields=[
+            'marks_obtained', 'feedback', 'is_correct', 'needs_manual_grading',
+            'is_auto_graded', 'graded_by', 'graded_at', 'updated_at',
+        ])
+        from .mock_grading import recompute_attempt
+        attempt = ans.attempt
+        recompute_attempt(attempt)
+        attempt.save(update_fields=[
+            'marks_obtained', 'attempted_questions', 'correct_answers',
+            'wrong_answers', 'percentage', 'updated_at',
+        ])
+        return Response({
+            'answer_id': str(ans.id),
+            'marks_obtained': float(ans.marks_obtained),
+            'attempt_marks': float(attempt.marks_obtained),
+            'attempt_percentage': float(attempt.percentage),
+            'pending_count': attempt.item_answers.filter(needs_manual_grading=True).count(),
+        })
+
+    @action(detail=False, methods=['post'], url_path='finalize-attempt')
+    def finalize_attempt(self, request):
+        """Finalize a fully-graded attempt: mark graded + award deferred XP."""
+        tenant = self._tenant()
+        attempt = (MockTestAttempt.objects.filter(
+                    id=request.data.get('attempt_id'), mock_test__tenant=tenant)
+                   .select_related('student__user', 'mock_test').first())
+        if not attempt:
+            raise NotFound('Attempt not found.')
+        remaining = attempt.item_answers.filter(needs_manual_grading=True).count()
+        if remaining:
+            raise ValidationError(
+                {'error': f'{remaining} answer(s) still need grading before finalizing.'})
+
+        from .mock_grading import recompute_attempt
+        recompute_attempt(attempt)
+        attempt.grading_status = 'graded'
+        attempt.save(update_fields=[
+            'marks_obtained', 'attempted_questions', 'correct_answers',
+            'wrong_answers', 'percentage', 'grading_status', 'updated_at',
+        ])
+
+        # Award XP once (deferred from submit for manual-grading attempts).
+        awarded = 0
+        from gamification.models import XPTransaction
+        already = XPTransaction.objects.filter(
+            student=attempt.student, transaction_type='mock_complete',
+            reference_id=attempt.id,
+        ).exists()
+        if not already and attempt.xp_earned == 0:
+            from gamification.services import GamificationService
+            from core.utils import calculate_xp_for_quiz
+            awarded = calculate_xp_for_quiz(
+                float(attempt.percentage), attempt.total_questions, is_daily_challenge=False
+            ) * 2
+            attempt.xp_earned = awarded
+            attempt.save(update_fields=['xp_earned'])
+            GamificationService.award_xp(
+                attempt.student, awarded, 'mock_complete',
+                f'Completed mock test: {attempt.mock_test.title}', str(attempt.id),
+            )
+        return Response({
+            'attempt_id': str(attempt.id),
+            'grading_status': attempt.grading_status,
+            'marks_obtained': float(attempt.marks_obtained),
+            'percentage': float(attempt.percentage),
+            'xp_awarded': awarded,
+        })
 
 
 class AdminMockTestItemViewSet(viewsets.ModelViewSet):

--- a/backend/quiz/mock_grading.py
+++ b/backend/quiz/mock_grading.py
@@ -216,3 +216,37 @@ def _grade_coding(item, ans, marks):
         fraction = Decimal(result['passed_points']) / Decimal(total_points)
         ans.marks_obtained = (marks * fraction).quantize(Decimal('0.01'))
     ans.is_correct = total_points > 0 and result['passed_points'] == total_points
+
+
+# ---------------------------------------------------------------------------
+# Attempt aggregation + manual-grading finalization (Phase 5)
+# ---------------------------------------------------------------------------
+
+def recompute_attempt(attempt):
+    """Recompute an attempt's aggregate score fields from its answers.
+
+    Covers both bank answers (shared ``Answer``) and inline ``MockTestAnswer``.
+    Answers still flagged ``needs_manual_grading`` contribute 0 and are not
+    counted as wrong. Does not save.
+    """
+    bank_qs = attempt.answers.all()
+    item_qs = attempt.item_answers.all()
+    bank_marks = sum((x.marks_obtained for x in bank_qs), Decimal('0'))
+    item_marks = sum((x.marks_obtained for x in item_qs), Decimal('0'))
+    attempt.marks_obtained = bank_marks + item_marks
+    attempt.attempted_questions = bank_qs.count() + item_qs.count()
+    attempt.correct_answers = (
+        bank_qs.filter(is_correct=True).count() + item_qs.filter(is_correct=True).count()
+    )
+    attempt.wrong_answers = (
+        bank_qs.filter(is_correct=False).count()
+        + item_qs.filter(is_correct=False, needs_manual_grading=False).count()
+    )
+    total = float(attempt.mock_test.total_marks) or 0
+    attempt.percentage = max(0, (float(attempt.marks_obtained) / total) * 100) if total > 0 else 0
+    return attempt
+
+
+def pending_manual_count(attempt):
+    """Number of inline answers still awaiting manual grading."""
+    return attempt.item_answers.filter(needs_manual_grading=True).count()

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -49,6 +49,7 @@ import CodingSubmissionReview from './pages/CodingSubmissionReview'
 import MockTestManager from './pages/MockTestManager'
 import MockTestBuilder from './pages/MockTestBuilder'
 import RichMockAttempt from './pages/RichMockAttempt'
+import MockTestGrading from './pages/MockTestGrading'
 
 
 // Protected Route Component
@@ -183,6 +184,7 @@ function App() {
           {/* Admin Dashboard */}
           <Route path="/admin-dashboard" element={<AdminDashboard />} />
           <Route path="/admin/mock-tests" element={<AdminRoute><MockTestManager /></AdminRoute>} />
+          <Route path="/admin/mock-tests/grading" element={<AdminRoute><MockTestGrading /></AdminRoute>} />
           <Route path="/admin/mock-tests/:testId" element={<AdminRoute><MockTestBuilder /></AdminRoute>} />
         </Route>
 

--- a/frontend/exam-frontend/src/pages/MockTestGrading.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestGrading.jsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import {
+  ChevronLeft, Loader2, ClipboardCheck, User, Clock, FileText, Code2,
+  CheckCircle2, AlertCircle, Award,
+} from 'lucide-react'
+import { mockTestBuilderService } from '../services/mockTestBuilderService'
+
+export default function MockTestGrading() {
+  const navigate = useNavigate()
+  const [activeAttempt, setActiveAttempt] = useState(null)
+
+  const { data: pending, isLoading } = useQuery({
+    queryKey: ['mockPendingGrading'],
+    queryFn: () => mockTestBuilderService.pendingGrading(),
+  })
+
+  if (activeAttempt) {
+    return <AttemptGrader attemptId={activeAttempt} onBack={() => setActiveAttempt(null)} />
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <button onClick={() => navigate('/admin/mock-tests')} className="inline-flex items-center gap-1 text-sm text-surface-500 hover:text-surface-700">
+        <ChevronLeft className="w-4 h-4" /> Mock Tests
+      </button>
+
+      <div className="flex items-center gap-3">
+        <div className="p-2.5 rounded-xl bg-amber-100 text-amber-600"><ClipboardCheck className="w-6 h-6" /></div>
+        <div>
+          <h1 className="text-2xl font-bold text-surface-900 dark:text-white">Manual Grading</h1>
+          <p className="text-surface-500 text-sm">Attempts with subjective answers awaiting your review.</p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-16"><Loader2 className="w-7 h-7 animate-spin text-primary-500" /></div>
+      ) : !pending?.length ? (
+        <div className="card p-12 text-center text-surface-500">
+          <CheckCircle2 className="w-12 h-12 mx-auto mb-3 text-emerald-400" />
+          <p className="font-medium">Nothing to grade</p>
+          <p className="text-sm">All submitted attempts are fully graded.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {pending.map((a) => (
+            <button key={a.attempt_id} onClick={() => setActiveAttempt(a.attempt_id)}
+              className="w-full card p-4 flex items-center justify-between hover:border-primary-300 transition text-left">
+              <div className="min-w-0">
+                <p className="font-semibold text-surface-900 dark:text-white truncate flex items-center gap-2">
+                  <User className="w-4 h-4 text-surface-400" /> {a.student_name || a.student_email}
+                </p>
+                <p className="text-sm text-surface-500 truncate">{a.mock_test_title}</p>
+                {a.completed_at && (
+                  <p className="text-xs text-surface-400 flex items-center gap-1 mt-1">
+                    <Clock className="w-3 h-3" /> {new Date(a.completed_at).toLocaleString()}
+                  </p>
+                )}
+              </div>
+              <span className="shrink-0 inline-flex items-center gap-1 px-3 py-1 rounded-full bg-amber-100 text-amber-700 text-sm font-medium">
+                <AlertCircle className="w-4 h-4" /> {a.pending_count} to grade
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AttemptGrader({ attemptId, onBack }) {
+  const qc = useQueryClient()
+  const { data, isLoading } = useQuery({
+    queryKey: ['mockAttemptGrading', attemptId],
+    queryFn: () => mockTestBuilderService.attemptDetail(attemptId),
+  })
+
+  const gradeMut = useMutation({
+    mutationFn: (payload) => mockTestBuilderService.gradeAnswer(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['mockAttemptGrading', attemptId] })
+      qc.invalidateQueries({ queryKey: ['mockPendingGrading'] })
+      toast.success('Saved')
+    },
+    onError: (e) => toast.error(e?.response?.data?.marks || e?.response?.data?.error || 'Failed to save'),
+  })
+
+  const finalizeMut = useMutation({
+    mutationFn: () => mockTestBuilderService.finalizeAttempt(attemptId),
+    onSuccess: (r) => {
+      qc.invalidateQueries({ queryKey: ['mockPendingGrading'] })
+      toast.success(r.xp_awarded ? `Finalized · ${r.xp_awarded} XP awarded` : 'Finalized')
+      onBack()
+    },
+    onError: (e) => toast.error(e?.response?.data?.error || 'Cannot finalize yet'),
+  })
+
+  if (isLoading || !data) {
+    return <div className="flex justify-center py-16"><Loader2 className="w-7 h-7 animate-spin text-primary-500" /></div>
+  }
+
+  const manualAnswers = data.answers.filter((a) => a.item_type === 'subjective' || a.needs_manual_grading)
+  const canFinalize = data.pending_count === 0
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <button onClick={onBack} className="inline-flex items-center gap-1 text-sm text-surface-500 hover:text-surface-700">
+        <ChevronLeft className="w-4 h-4" /> Back to queue
+      </button>
+
+      <div className="card p-5">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-xl font-bold text-surface-900 dark:text-white">{data.student_name || data.student_email}</h1>
+            <p className="text-surface-500 text-sm">{data.mock_test_title}</p>
+          </div>
+          <div className="text-right">
+            <p className="text-2xl font-bold text-primary-600">{data.marks_obtained}<span className="text-base text-surface-400"> / {data.total_marks}</span></p>
+            <p className="text-xs text-surface-400">{data.pending_count} pending · {data.grading_status.replace('_', ' ')}</p>
+          </div>
+        </div>
+      </div>
+
+      {manualAnswers.map((a, i) => (
+        <GradeCard key={a.answer_id} answer={a} index={i} onSave={(marks, feedback) =>
+          gradeMut.mutate({ answer_id: a.answer_id, marks, feedback })} saving={gradeMut.isPending} />
+      ))}
+
+      <div className="card p-5 flex items-center justify-between gap-4 flex-wrap">
+        <p className="text-sm text-surface-500">
+          {canFinalize ? 'All answers graded. Finalize to release results and award XP.' : 'Grade every pending answer before finalizing.'}
+        </p>
+        <button onClick={() => finalizeMut.mutate()} disabled={!canFinalize || finalizeMut.isPending}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-medium disabled:opacity-50">
+          {finalizeMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Award className="w-4 h-4" />} Finalize & release
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function GradeCard({ answer, index, onSave, saving }) {
+  const [marks, setMarks] = useState(answer.needs_manual_grading ? '' : String(answer.marks_obtained))
+  const [feedback, setFeedback] = useState(answer.feedback || '')
+  const graded = !answer.needs_manual_grading
+
+  return (
+    <div className={`card p-5 ${graded ? 'border-emerald-200 dark:border-emerald-900/40' : ''}`}>
+      <div className="flex items-center gap-2 mb-3">
+        {answer.item_type === 'coding'
+          ? <Code2 className="w-4 h-4 text-primary-500" />
+          : <FileText className="w-4 h-4 text-primary-500" />}
+        <span className="text-xs font-semibold uppercase text-surface-400">{answer.item_type.replace('_', ' ')}</span>
+        <span className="text-xs text-surface-400">· max {answer.max_marks}</span>
+        {graded && <span className="ml-auto inline-flex items-center gap-1 text-xs text-emerald-600"><CheckCircle2 className="w-3.5 h-3.5" /> graded</span>}
+      </div>
+
+      {answer.question_html
+        ? <div className="prose dark:prose-invert max-w-none text-sm mb-3" dangerouslySetInnerHTML={{ __html: answer.question_html }} />
+        : <p className="text-surface-800 dark:text-surface-100 text-sm mb-3 whitespace-pre-wrap">{answer.question_text}</p>}
+
+      <div className="rounded-xl bg-surface-50 dark:bg-surface-800/50 border border-surface-200 dark:border-surface-700 p-4 mb-4">
+        {answer.item_type === 'coding' ? (
+          <>
+            <p className="text-xs text-surface-400 mb-1">Submission ({answer.language || 'n/a'}) · auto {answer.passed_count}/{answer.total_count} cases</p>
+            <pre className="text-xs overflow-x-auto whitespace-pre-wrap font-mono">{answer.code || '(no code submitted)'}</pre>
+          </>
+        ) : (
+          <p className="text-surface-800 dark:text-surface-100 text-sm whitespace-pre-wrap">{answer.answer_text || <span className="text-surface-400 italic">(no answer)</span>}</p>
+        )}
+      </div>
+
+      <div className="flex items-end gap-3 flex-wrap">
+        <div>
+          <label className="block text-xs font-medium text-surface-500 mb-1">Marks (0–{answer.max_marks})</label>
+          <input type="number" step="0.5" min={0} max={answer.max_marks} value={marks}
+            onChange={(e) => setMarks(e.target.value)}
+            className="w-28 px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800" />
+        </div>
+        <div className="flex-1 min-w-[200px]">
+          <label className="block text-xs font-medium text-surface-500 mb-1">Feedback (optional)</label>
+          <input value={feedback} onChange={(e) => setFeedback(e.target.value)} placeholder="Note for the student…"
+            className="w-full px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800" />
+        </div>
+        <button onClick={() => onSave(Number(marks), feedback)} disabled={saving || marks === ''}
+          className="px-4 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium disabled:opacity-50">
+          {graded ? 'Update' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/exam-frontend/src/pages/MockTestManager.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestManager.jsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import {
   Plus, ClipboardList, Clock, Users, Trash2, Pencil, Search,
-  CheckCircle2, FileEdit, Archive, Loader2, ArrowLeft,
+  CheckCircle2, FileEdit, Archive, Loader2, ArrowLeft, ClipboardCheck,
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
 
@@ -69,14 +69,22 @@ export default function MockTestManager() {
             Create and manage full exams with MCQ, numerical, subjective and coding questions.
           </p>
         </div>
-        <button
-          onClick={() => createMut.mutate()}
-          disabled={createMut.isPending}
-          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium shadow-sm disabled:opacity-60"
-        >
-          {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-          New Mock Test
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigate('/admin/mock-tests/grading')}
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 hover:bg-surface-50 dark:hover:bg-surface-800 font-medium"
+          >
+            <ClipboardCheck className="w-4 h-4" /> Grading
+          </button>
+          <button
+            onClick={() => createMut.mutate()}
+            disabled={createMut.isPending}
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 text-white font-medium shadow-sm disabled:opacity-60"
+          >
+            {createMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+            New Mock Test
+          </button>
+        </div>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-3 mb-5">

--- a/frontend/exam-frontend/src/services/mockTestBuilderService.js
+++ b/frontend/exam-frontend/src/services/mockTestBuilderService.js
@@ -45,6 +45,16 @@ export const mockTestBuilderService = {
     list(await api.get('/courses/admin/courses/', { params: PAGE })),
   getLanguages: async () => (await api.get('/coding/meta/')).data,
 
+  // --- admin: manual grading (Phase 5) ---
+  pendingGrading: async (params = {}) =>
+    (await api.get('/quiz/admin/mock-tests/pending-grading/', { params })).data,
+  attemptDetail: async (attemptId) =>
+    (await api.get(`/quiz/admin/mock-tests/attempts/${attemptId}/`)).data,
+  gradeAnswer: async (payload) =>
+    (await api.post('/quiz/admin/mock-tests/grade-answer/', payload)).data,
+  finalizeAttempt: async (attemptId) =>
+    (await api.post('/quiz/admin/mock-tests/finalize-attempt/', { attempt_id: attemptId })).data,
+
   // --- student: rich attempt flow ---
   getPaper: async (testId) =>
     (await api.get(`/quiz/mock-tests/${testId}/paper/`)).data,


### PR DESCRIPTION
## Phase 5 — Manual (subjective) grading for rich Mock Tests

Adds the admin workflow to grade subjective (and any deferred) inline answers and finalize attempts that were left `pending_manual` at submit time.

### Backend (admin-only actions on `AdminMockTestViewSet`)
- `GET pending-grading/` — completed attempts in the tenant awaiting manual grading (student, mock, pending count).
- `GET attempts/<id>/` — full grading view: every inline answer with the item text, the student's response (text or code + auto case results), max marks, and current marks/feedback.
- `POST grade-answer/` — set marks (bounded 0…max) + feedback on one answer; clears `needs_manual_grading`, stamps grader/time, and recomputes the attempt's aggregate score.
- `POST finalize-attempt/` — refuses while any answer is still pending; otherwise recomputes, sets `grading_status='graded'`, and awards the **deferred** mock-completion XP once.
- `mock_grading.recompute_attempt` / `pending_manual_count` helpers (shared aggregation).

### Frontend
- **MockTestGrading** page: a pending-attempts queue and a per-attempt grader with per-answer marks + feedback and a "Finalize & release" action.
- **Grading** button added to the MockTestManager header.
- Route `/admin/mock-tests/grading`.

### Deploy
Code-only (no migration): VM pull + `docker compose restart web`; Netlify auto-deploys frontend.

Django `check` clean; frontend builds clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>