### PR TITLE
Count rich mock-test items in questions_count

### DIFF
--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -167,7 +167,9 @@ class MockTestSerializer(serializers.ModelSerializer):
         ]
     
     def get_questions_count(self, obj):
-        return obj.questions.count()
+        # Count both legacy bank questions and rich inline items so the card
+        # reflects the true question count for either mock-test style.
+        return obj.questions.count() + obj.items.count()
     
     def get_user_attempt_info(self, obj):
         """Get user's attempt info for this mock test."""


### PR DESCRIPTION
The Mock Tests list card showed **"0 Questions"** for rich mock tests. `MockTestSerializer.get_questions_count` counted only the legacy `questions` M2M (bank questions). Rich mock tests store their questions as inline `MockTestItem` rows, so the count now includes `obj.items` as well.

Verified with Django `check` on the VM. No migration or frontend change needed.