### PR TITLE
Add admin mock test submissions views

### DIFF
--- a/backend/quiz/admin_views.py
+++ b/backend/quiz/admin_views.py
@@ -189,17 +189,31 @@ class AdminMockTestViewSet(viewsets.ModelViewSet):
                 'answer_id': str(ans.id),
                 'item_id': str(item.id),
                 'item_type': item.item_type,
+                'section': item.section,
+                'order': item.order,
                 'question_text': item.question_text,
                 'question_html': item.question_html or '',
+                'explanation': item.explanation or '',
                 'max_marks': float(ans.max_marks or item.marks),
                 'max_words': item.max_words,
+                # Student response (only the field relevant to item_type is used).
+                'selected_options': ans.selected_options or [],
+                'numerical_answer': float(ans.numerical_answer) if ans.numerical_answer is not None else None,
                 'answer_text': ans.answer_text,
                 'code': ans.code,
                 'language': ans.language,
                 'coding_results': ans.coding_results,
                 'passed_count': ans.passed_count,
                 'total_count': ans.total_count,
+                # Correct-answer reference (admin-only) for review display.
+                'options': item.options or [],
+                'correct_option_indices': list(item.correct_option_indices or []),
+                'numerical_correct': float(item.numerical_answer) if item.numerical_answer is not None else None,
+                'numerical_tolerance': float(item.numerical_tolerance) if item.numerical_tolerance is not None else None,
+                'model_answer': item.model_answer or '',
+                'rubric': item.rubric or '',
                 'marks_obtained': float(ans.marks_obtained),
+                'is_correct': ans.is_correct,
                 'feedback': ans.feedback,
                 'needs_manual_grading': ans.needs_manual_grading,
                 'is_auto_graded': ans.is_auto_graded,
@@ -245,6 +259,82 @@ class AdminMockTestViewSet(viewsets.ModelViewSet):
                 'pending_count': a.item_answers.filter(needs_manual_grading=True).count(),
             })
         return Response(out)
+
+    @action(detail=True, methods=['get'], url_path='submissions')
+    def submissions(self, request, pk=None):
+        """All completed attempts for one mock test, plus summary counts.
+
+        Mirrors the assignment/coding submissions views: eligible-student count,
+        submitted/graded/pending breakdown, average score, and a per-attempt
+        list the admin can drill into for review + grading.
+        """
+        mock_test = self.get_object()
+        attempts = (MockTestAttempt.objects.filter(
+                        mock_test=mock_test, status='completed')
+                    .select_related('student__user')
+                    .prefetch_related('item_answers')
+                    .order_by('-completed_at'))
+
+        rows, graded, pending, score_sum = [], 0, 0, 0.0
+        for a in attempts:
+            u = getattr(a.student, 'user', None)
+            pending_count = a.item_answers.filter(needs_manual_grading=True).count()
+            is_graded = a.grading_status == 'graded' or (
+                a.grading_status == 'auto_graded' and pending_count == 0)
+            if pending_count > 0:
+                pending += 1
+            else:
+                graded += 1
+            score_sum += float(a.percentage)
+            rows.append({
+                'attempt_id': str(a.id),
+                'student_name': (getattr(u, 'full_name', '') or (u.email if u else '')).strip() if u else '',
+                'student_email': u.email if u else '',
+                'marks_obtained': float(a.marks_obtained),
+                'total_marks': float(mock_test.total_marks),
+                'percentage': float(a.percentage),
+                'grading_status': a.grading_status,
+                'pending_count': pending_count,
+                'is_fully_graded': pending_count == 0,
+                'completed_at': a.completed_at.isoformat() if a.completed_at else None,
+                'time_taken_seconds': a.time_taken_seconds,
+            })
+
+        # Eligible students: enrolled (approved+active) in any linked/legacy
+        # course, or every student in the tenant when the test is open to all.
+        from users.models import StudentProfile, CourseEnrollment
+        course_ids = list(mock_test.courses.values_list('id', flat=True))
+        if mock_test.course_id:
+            course_ids.append(mock_test.course_id)
+        if course_ids:
+            eligible = (CourseEnrollment.objects.filter(
+                            course_id__in=course_ids, status='approved', is_active=True)
+                        .values('student_id').distinct().count())
+        else:
+            eligible = StudentProfile.objects.filter(
+                user__tenant=mock_test.tenant_id, user__role='student').count()
+
+        submitted = len(rows)
+        avg_score = round(score_sum / submitted, 2) if submitted else 0.0
+        return Response({
+            'mock_test': {
+                'id': str(mock_test.id),
+                'title': mock_test.title,
+                'status': mock_test.status,
+                'total_marks': float(mock_test.total_marks),
+                'duration_minutes': mock_test.duration_minutes,
+                'result_visibility': mock_test.result_visibility,
+                'results_released': mock_test.results_released,
+            },
+            'counts': {
+                'eligible': eligible,
+                'submitted': submitted,
+                'graded': graded,
+                'pending': pending,
+            },
+            'average_score': avg_score,
+            'attempts': rows,
+        })
 
     @action(detail=False, methods=['get'], url_path='attempts/(?P<attempt_id>[^/.]+)')
     def attempt_detail(self, request, attempt_id=None):

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -50,6 +50,8 @@ import MockTestManager from './pages/MockTestManager'
 import MockTestBuilder from './pages/MockTestBuilder'
 import RichMockAttempt from './pages/RichMockAttempt'
 import MockTestGrading from './pages/MockTestGrading'
+import MockTestSubmissions from './pages/MockTestSubmissions'
+import MockTestSubmissionReview from './pages/MockTestSubmissionReview'
 import RichMockReview from './pages/RichMockReview'
 
 
@@ -187,6 +189,8 @@ function App() {
           <Route path="/admin-dashboard" element={<AdminDashboard />} />
           <Route path="/admin/mock-tests" element={<AdminRoute><MockTestManager /></AdminRoute>} />
           <Route path="/admin/mock-tests/grading" element={<AdminRoute><MockTestGrading /></AdminRoute>} />
+          <Route path="/admin/mock-tests/:testId/submissions" element={<AdminRoute><MockTestSubmissions /></AdminRoute>} />
+          <Route path="/admin/mock-tests/:testId/submissions/:attemptId" element={<AdminRoute><MockTestSubmissionReview /></AdminRoute>} />
           <Route path="/admin/mock-tests/:testId" element={<AdminRoute><MockTestBuilder /></AdminRoute>} />
         </Route>
 

--- a/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import {
-  ArrowLeft, Save, Plus, Trash2, GripVertical, Loader2, Settings2,
+  ArrowLeft, Save, Plus, Trash2, GripVertical, Loader2, Settings2, Inbox,
   ListChecks, Calculator, FileText, Code2, CheckSquare, Library, X, Search,
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
@@ -104,6 +104,10 @@ export default function MockTestBuilder() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <button onClick={() => navigate(`/admin/mock-tests/${testId}/submissions`)}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-xl border border-surface-200 dark:border-surface-700 hover:bg-surface-50 dark:hover:bg-surface-800 font-medium text-sm">
+            <Inbox className="w-4 h-4" /> Submissions
+          </button>
           <select value={form.status} onChange={(e) => { set('status')(e.target.value); saveMut.mutate({ status: e.target.value }) }}
             className={`${inputCls} w-auto`}>
             <option value="draft">Draft</option>

--- a/frontend/exam-frontend/src/pages/MockTestManager.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestManager.jsx
@@ -5,6 +5,7 @@ import toast from 'react-hot-toast'
 import {
   Plus, ClipboardList, Clock, Users, Trash2, Pencil, Search,
   CheckCircle2, FileEdit, Archive, Loader2, ArrowLeft, ClipboardCheck,
+  Inbox,
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
 
@@ -147,6 +148,13 @@ export default function MockTestManager() {
                     <span className="flex items-center gap-1"><Users className="w-3.5 h-3.5" /> {t.total_attempts || 0} attempts</span>
                   </div>
                 </div>
+                <button
+                  onClick={(e) => { e.stopPropagation(); navigate(`/admin/mock-tests/${t.id}/submissions`) }}
+                  className="p-2 rounded-lg text-surface-400 hover:text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-900/20"
+                  title="View submissions"
+                >
+                  <Inbox className="w-4 h-4" />
+                </button>
                 <button
                   onClick={(e) => { e.stopPropagation(); navigate(`/admin/mock-tests/${t.id}`) }}
                   className="p-2 rounded-lg text-surface-400 hover:text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-900/20"

--- a/frontend/exam-frontend/src/pages/MockTestSubmissionReview.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestSubmissionReview.jsx
@@ -1,0 +1,338 @@
+import { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import {
+  ArrowLeft, Loader2, FileText, Code2, CheckCircle2, XCircle,
+  Award, Hash, ListChecks, User, Clock, ChevronDown, ChevronUp,
+} from 'lucide-react'
+import { mockTestBuilderService as svc } from '../services/mockTestBuilderService'
+
+const TYPE_META = {
+  mcq: { label: 'Multiple Choice', icon: ListChecks },
+  mcq_multi: { label: 'Multiple Choice (Multi)', icon: ListChecks },
+  numerical: { label: 'Numerical', icon: Hash },
+  subjective: { label: 'Subjective', icon: FileText },
+  coding: { label: 'Coding', icon: Code2 },
+}
+
+/**
+ * Admin per-attempt review + grading page for a mock test submission.
+ * Renders every answer (all five question types) with the student's response,
+ * the correct reference, and auto-grade status; subjective answers get an
+ * inline grading control, and the attempt can be finalized to release results.
+ */
+export default function MockTestSubmissionReview() {
+  const { testId, attemptId } = useParams()
+  const navigate = useNavigate()
+  const qc = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mockAttemptGrading', attemptId],
+    queryFn: () => svc.attemptDetail(attemptId),
+    enabled: !!attemptId,
+  })
+
+  const gradeMut = useMutation({
+    mutationFn: (payload) => svc.gradeAnswer(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['mockAttemptGrading', attemptId] })
+      qc.invalidateQueries({ queryKey: ['mock-submissions', testId] })
+      qc.invalidateQueries({ queryKey: ['mockPendingGrading'] })
+      toast.success('Saved')
+    },
+    onError: (e) => toast.error(e?.response?.data?.marks || e?.response?.data?.error || 'Failed to save'),
+  })
+
+  const finalizeMut = useMutation({
+    mutationFn: () => svc.finalizeAttempt(attemptId),
+    onSuccess: (r) => {
+      qc.invalidateQueries({ queryKey: ['mockAttemptGrading', attemptId] })
+      qc.invalidateQueries({ queryKey: ['mock-submissions', testId] })
+      qc.invalidateQueries({ queryKey: ['mockPendingGrading'] })
+      toast.success(r.xp_awarded ? `Finalized · ${r.xp_awarded} XP awarded` : 'Finalized & released')
+    },
+    onError: (e) => toast.error(e?.response?.data?.error || 'Cannot finalize yet'),
+  })
+
+  if (isLoading || !data) {
+    return <div className="flex justify-center py-24"><Loader2 className="w-7 h-7 animate-spin text-primary-500" /></div>
+  }
+
+  const canFinalize = data.pending_count === 0
+  const finalized = data.grading_status === 'graded'
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-5">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm flex-wrap">
+        <button
+          onClick={() => navigate(`/admin/mock-tests/${testId}/submissions`)}
+          className="text-surface-500 hover:text-primary-600 flex items-center gap-1"
+        >
+          <ArrowLeft size={16} /> Submissions
+        </button>
+      </div>
+
+      {/* Header */}
+      <div className="card p-5">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="min-w-0">
+            <h1 className="text-xl font-bold text-surface-900 dark:text-white flex items-center gap-2">
+              <User className="w-5 h-5 text-surface-400" /> {data.student_name || data.student_email}
+            </h1>
+            <p className="text-surface-500 text-sm mt-0.5">{data.mock_test_title}</p>
+            {data.completed_at && (
+              <p className="text-xs text-surface-400 flex items-center gap-1 mt-1">
+                <Clock className="w-3 h-3" /> {new Date(data.completed_at).toLocaleString()}
+              </p>
+            )}
+          </div>
+          <div className="text-right">
+            <p className="text-3xl font-bold text-primary-600">
+              {data.marks_obtained}<span className="text-base text-surface-400"> / {data.total_marks}</span>
+            </p>
+            <p className="text-xs text-surface-400 mt-1">
+              {Math.round(data.percentage)}% ·{' '}
+              {data.pending_count > 0
+                ? `${data.pending_count} pending`
+                : (finalized ? 'graded' : 'auto-graded')}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Answers */}
+      <div className="space-y-4">
+        {data.answers.map((a, i) => (
+          <ReviewCard
+            key={a.answer_id}
+            answer={a}
+            index={i}
+            saving={gradeMut.isPending}
+            onSave={(marks, feedback) => gradeMut.mutate({ answer_id: a.answer_id, marks, feedback })}
+          />
+        ))}
+      </div>
+
+      {/* Finalize */}
+      <div className="card p-5 flex items-center justify-between gap-4 flex-wrap sticky bottom-4">
+        <p className="text-sm text-surface-500">
+          {finalized
+            ? 'This attempt is finalized. Results are released to the student.'
+            : canFinalize
+              ? 'All answers graded. Finalize to release results and award XP.'
+              : 'Grade every pending answer before finalizing.'}
+        </p>
+        <button
+          onClick={() => finalizeMut.mutate()}
+          disabled={!canFinalize || finalizeMut.isPending}
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-medium disabled:opacity-50"
+        >
+          {finalizeMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Award className="w-4 h-4" />}
+          {finalized ? 'Re-finalize' : 'Finalize & release'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ReviewCard({ answer, index, onSave, saving }) {
+  const meta = TYPE_META[answer.item_type] || TYPE_META.mcq
+  const Icon = meta.icon
+  const isManual = answer.item_type === 'subjective' || answer.needs_manual_grading
+  const scoredCls = answer.needs_manual_grading
+    ? 'border-amber-200 dark:border-amber-900/40'
+    : answer.marks_obtained > 0
+      ? 'border-emerald-200 dark:border-emerald-900/40'
+      : 'border-surface-200 dark:border-surface-700'
+
+  return (
+    <div className={`card p-5 border ${scoredCls}`}>
+      <div className="flex items-center gap-2 mb-3">
+        <Icon className="w-4 h-4 text-primary-500" />
+        <span className="text-xs font-semibold uppercase text-surface-400">Q{index + 1} · {meta.label}</span>
+        <span className="text-xs text-surface-400">· max {answer.max_marks}</span>
+        <span className="ml-auto text-sm font-semibold">
+          {answer.needs_manual_grading
+            ? <span className="text-amber-600">Needs grading</span>
+            : <span className={answer.marks_obtained > 0 ? 'text-emerald-600' : 'text-surface-500'}>{answer.marks_obtained}/{answer.max_marks}</span>}
+        </span>
+      </div>
+
+      {answer.question_html
+        ? <div className="prose dark:prose-invert max-w-none text-sm mb-3" dangerouslySetInnerHTML={{ __html: answer.question_html }} />
+        : <p className="text-surface-800 dark:text-surface-100 text-sm mb-3 whitespace-pre-wrap">{answer.question_text}</p>}
+
+      {(answer.item_type === 'mcq' || answer.item_type === 'mcq_multi') && (
+        <McqReview answer={answer} />
+      )}
+      {answer.item_type === 'numerical' && <NumericalReview answer={answer} />}
+      {answer.item_type === 'subjective' && <SubjectiveReview answer={answer} />}
+      {answer.item_type === 'coding' && <CodingReview answer={answer} />}
+
+      {answer.explanation && (
+        <div className="mt-3 text-xs text-surface-500 bg-surface-50 dark:bg-surface-800/50 rounded-lg p-3">
+          <span className="font-semibold">Explanation: </span>{answer.explanation}
+        </div>
+      )}
+
+      {isManual && <GradeControl answer={answer} onSave={onSave} saving={saving} />}
+
+      {!isManual && answer.feedback && (
+        <p className="mt-3 text-xs text-surface-500"><span className="font-semibold">Feedback:</span> {answer.feedback}</p>
+      )}
+    </div>
+  )
+}
+
+function McqReview({ answer }) {
+  const selected = new Set((answer.selected_options || []).map(Number))
+  const correct = new Set((answer.correct_option_indices || []).map(Number))
+  return (
+    <div className="space-y-2">
+      {(answer.options || []).map((opt, idx) => {
+        const isCorrect = correct.has(idx)
+        const isSelected = selected.has(idx)
+        return (
+          <div
+            key={idx}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm border ${
+              isCorrect
+                ? 'border-emerald-300 bg-emerald-50 dark:bg-emerald-900/20'
+                : isSelected
+                  ? 'border-rose-300 bg-rose-50 dark:bg-rose-900/20'
+                  : 'border-surface-200 dark:border-surface-700'
+            }`}
+          >
+            {isCorrect ? <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
+              : isSelected ? <XCircle className="w-4 h-4 text-rose-500 shrink-0" />
+              : <span className="w-4 h-4 shrink-0" />}
+            <span className="flex-1">{opt.text}</span>
+            {isSelected && <span className="text-xs font-medium text-surface-500">student</span>}
+          </div>
+        )
+      })}
+      {selected.size === 0 && <p className="text-xs text-surface-400 italic">No option selected.</p>}
+    </div>
+  )
+}
+
+function NumericalReview({ answer }) {
+  const correct = answer.marks_obtained > 0
+  return (
+    <div className="flex flex-wrap gap-3 text-sm">
+      <div className={`px-3 py-2 rounded-lg border ${correct ? 'border-emerald-300 bg-emerald-50 dark:bg-emerald-900/20' : 'border-rose-300 bg-rose-50 dark:bg-rose-900/20'}`}>
+        <span className="text-xs text-surface-400 block">Student answer</span>
+        <span className="font-mono font-semibold">{answer.numerical_answer ?? '(blank)'}</span>
+      </div>
+      <div className="px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700">
+        <span className="text-xs text-surface-400 block">Correct answer</span>
+        <span className="font-mono font-semibold">
+          {answer.numerical_correct}
+          {answer.numerical_tolerance ? ` ± ${answer.numerical_tolerance}` : ''}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function SubjectiveReview({ answer }) {
+  const [showRef, setShowRef] = useState(false)
+  return (
+    <div>
+      <div className="rounded-xl bg-surface-50 dark:bg-surface-800/50 border border-surface-200 dark:border-surface-700 p-4">
+        <p className="text-surface-800 dark:text-surface-100 text-sm whitespace-pre-wrap">
+          {answer.answer_text || <span className="text-surface-400 italic">(no answer)</span>}
+        </p>
+      </div>
+      {(answer.rubric || answer.model_answer) && (
+        <button
+          onClick={() => setShowRef((v) => !v)}
+          className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary-600 hover:underline"
+        >
+          {showRef ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+          Grading reference (admin only)
+        </button>
+      )}
+      {showRef && (
+        <div className="mt-2 space-y-2 text-xs">
+          {answer.rubric && (
+            <div className="bg-indigo-50 dark:bg-indigo-900/20 rounded-lg p-3">
+              <span className="font-semibold text-indigo-700 dark:text-indigo-300">Rubric: </span>
+              <span className="whitespace-pre-wrap">{answer.rubric}</span>
+            </div>
+          )}
+          {answer.model_answer && (
+            <div className="bg-surface-100 dark:bg-surface-800 rounded-lg p-3">
+              <span className="font-semibold">Model answer: </span>
+              <span className="whitespace-pre-wrap">{answer.model_answer}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CodingReview({ answer }) {
+  const results = answer.coding_results || []
+  return (
+    <div className="space-y-3">
+      <div className="rounded-xl bg-surface-900 text-surface-100 p-4 overflow-x-auto">
+        <p className="text-xs text-surface-400 mb-1">Submission ({answer.language || 'n/a'}) · {answer.passed_count}/{answer.total_count} cases passed</p>
+        <pre className="text-xs whitespace-pre-wrap font-mono">{answer.code || '(no code submitted)'}</pre>
+      </div>
+      {results.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {results.map((r, i) => (
+            <span
+              key={i}
+              className={`inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium ${
+                r.verdict === 'passed' || r.passed
+                  ? 'bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400'
+                  : 'bg-rose-50 dark:bg-rose-900/20 text-rose-700 dark:text-rose-400'
+              }`}
+            >
+              {(r.verdict === 'passed' || r.passed) ? <CheckCircle2 className="w-3.5 h-3.5" /> : <XCircle className="w-3.5 h-3.5" />}
+              Case {i + 1}{r.verdict ? ` · ${r.verdict}` : ''}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GradeControl({ answer, onSave, saving }) {
+  const [marks, setMarks] = useState(answer.needs_manual_grading ? '' : String(answer.marks_obtained))
+  const [feedback, setFeedback] = useState(answer.feedback || '')
+  const graded = !answer.needs_manual_grading
+
+  return (
+    <div className="mt-4 pt-4 border-t border-surface-200 dark:border-surface-700 flex items-end gap-3 flex-wrap">
+      <div>
+        <label className="block text-xs font-medium text-surface-500 mb-1">Marks (0–{answer.max_marks})</label>
+        <input
+          type="number" step="0.5" min={0} max={answer.max_marks} value={marks}
+          onChange={(e) => setMarks(e.target.value)}
+          className="w-28 px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800"
+        />
+      </div>
+      <div className="flex-1 min-w-[200px]">
+        <label className="block text-xs font-medium text-surface-500 mb-1">Feedback (optional)</label>
+        <input
+          value={feedback} onChange={(e) => setFeedback(e.target.value)} placeholder="Note for the student…"
+          className="w-full px-3 py-2 rounded-lg border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-800"
+        />
+      </div>
+      <button
+        onClick={() => onSave(Number(marks), feedback)}
+        disabled={saving || marks === ''}
+        className="px-4 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium disabled:opacity-50"
+      >
+        {graded ? 'Update' : 'Save'}
+      </button>
+    </div>
+  )
+}

--- a/frontend/exam-frontend/src/pages/MockTestSubmissions.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestSubmissions.jsx
@@ -1,0 +1,159 @@
+import { useParams, useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { motion } from 'framer-motion'
+import {
+  ArrowLeft, Users, CheckCircle2, Clock, Trophy, FileText,
+  ChevronRight, ClipboardList, AlertCircle, BarChart3,
+} from 'lucide-react'
+import { mockTestBuilderService as svc } from '../services/mockTestBuilderService'
+import Loading from '../components/common/Loading'
+
+/**
+ * Admin submissions view for a single mock test — mirrors the assignment /
+ * coding grading pages. Shows counts, average score, and the list of student
+ * attempts; click one to open the focused per-attempt review + grading page.
+ */
+export default function MockTestSubmissions() {
+  const { testId } = useParams()
+  const navigate = useNavigate()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['mock-submissions', testId],
+    queryFn: () => svc.submissions(testId),
+    enabled: !!testId,
+  })
+
+  if (isLoading) return <Loading fullScreen />
+
+  const test = data?.mock_test || {}
+  const counts = data?.counts || { eligible: 0, submitted: 0, pending: 0, graded: 0 }
+  const attempts = data?.attempts || []
+  const avg = data?.average_score ?? 0
+
+  const stats = [
+    { label: 'Eligible', value: counts.eligible, icon: Users, tint: 'text-surface-500 bg-surface-100 dark:bg-surface-800' },
+    { label: 'Submitted', value: counts.submitted, icon: CheckCircle2, tint: 'text-blue-600 bg-blue-50 dark:bg-blue-900/20' },
+    { label: 'Pending grading', value: counts.pending, icon: Clock, tint: 'text-amber-600 bg-amber-50 dark:bg-amber-900/20' },
+    { label: 'Avg score', value: `${avg}%`, icon: BarChart3, tint: 'text-success-600 bg-success-50 dark:bg-success-900/20' },
+  ]
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm flex-wrap">
+        <button
+          onClick={() => navigate('/admin/mock-tests')}
+          className="text-surface-500 hover:text-primary-600 flex items-center gap-1"
+        >
+          <ArrowLeft size={16} /> Mock Tests
+        </button>
+        <span className="text-surface-400">/</span>
+        <button
+          onClick={() => navigate(`/admin/mock-tests/${testId}`)}
+          className="text-surface-500 hover:text-primary-600"
+        >
+          Edit
+        </button>
+        <span className="text-surface-400">/</span>
+        <span className="text-surface-500">Submissions</span>
+      </div>
+
+      {/* Header */}
+      <div className="card p-6">
+        <div className="flex items-start gap-3">
+          <div className="w-11 h-11 rounded-xl bg-primary-50 dark:bg-primary-900/20 text-primary-600 dark:text-primary-400 flex items-center justify-center shrink-0">
+            <ClipboardList className="w-5 h-5" />
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-2xl font-display font-bold">{test.title || 'Mock Test'}</h1>
+            <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-surface-500">
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800 capitalize">{test.status}</span>
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800">Total {test.total_marks} marks</span>
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800 inline-flex items-center gap-1">
+                <Clock className="w-3 h-3" /> {test.duration_minutes} min
+              </span>
+              <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800">
+                {test.result_visibility === 'immediate' ? 'Results: immediate' : (test.results_released ? 'Results: released' : 'Results: held')}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {stats.map((s) => (
+          <div key={s.label} className="card p-4 flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${s.tint}`}>
+              <s.icon className="w-5 h-5" />
+            </div>
+            <div>
+              <div className="text-2xl font-bold leading-none">{s.value}</div>
+              <div className="text-xs text-surface-500 mt-1">{s.label}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Attempts list */}
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold flex items-center gap-2">
+          <CheckCircle2 className="w-5 h-5 text-success-500" /> Submissions ({attempts.length})
+        </h2>
+        {attempts.length === 0 ? (
+          <div className="card p-8 text-center text-surface-500">
+            <FileText className="w-10 h-10 mx-auto mb-2 text-surface-300" />
+            <p>No submissions yet.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {attempts.map((a, i) => (
+              <motion.button
+                key={a.attempt_id}
+                type="button"
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: i * 0.03 }}
+                onClick={() => navigate(`/admin/mock-tests/${testId}/submissions/${a.attempt_id}`)}
+                className="w-full text-left card p-4 flex items-center gap-4 hover:border-primary-200 dark:hover:border-primary-800 hover:shadow-md transition-all group"
+              >
+                <div className="w-10 h-10 rounded-full bg-primary-50 dark:bg-primary-900/20 text-primary-600 dark:text-primary-400 flex items-center justify-center font-semibold text-sm shrink-0">
+                  {(a.student_name || a.student_email || '?').charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold truncate">{a.student_name || a.student_email}</p>
+                  <p className="text-xs text-surface-400 flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
+                    {a.completed_at && <span>{new Date(a.completed_at).toLocaleString()}</span>}
+                    {a.time_taken_seconds > 0 && (
+                      <span className="text-surface-500">· {Math.round(a.time_taken_seconds / 60)} min taken</span>
+                    )}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <span className="text-sm font-semibold text-surface-700 dark:text-surface-200">
+                    {a.marks_obtained}/{a.total_marks}
+                    <span className="text-surface-400 font-normal"> ({Math.round(a.percentage)}%)</span>
+                  </span>
+                  {a.pending_count > 0 ? (
+                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400">
+                      <AlertCircle className="w-3.5 h-3.5" /> {a.pending_count} to grade
+                    </span>
+                  ) : a.grading_status === 'graded' ? (
+                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-success-50 dark:bg-success-900/20 text-success-700 dark:text-success-400">
+                      <Trophy className="w-3.5 h-3.5" /> Graded
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400">
+                      <CheckCircle2 className="w-3.5 h-3.5" /> Auto-graded
+                    </span>
+                  )}
+                  <ChevronRight className="w-5 h-5 text-surface-300 group-hover:text-primary-500 transition-colors" />
+                </div>
+              </motion.button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/exam-frontend/src/services/mockTestBuilderService.js
+++ b/frontend/exam-frontend/src/services/mockTestBuilderService.js
@@ -54,6 +54,8 @@ export const mockTestBuilderService = {
     (await api.post('/quiz/admin/mock-tests/grade-answer/', payload)).data,
   finalizeAttempt: async (attemptId) =>
     (await api.post('/quiz/admin/mock-tests/finalize-attempt/', { attempt_id: attemptId })).data,
+  submissions: async (testId) =>
+    (await api.get(`/quiz/admin/mock-tests/${testId}/submissions/`)).data,
 
   // --- student: rich attempt flow ---
   getPaper: async (testId) =>


### PR DESCRIPTION
## Summary
Adds an admin **submissions viewing/grading** experience for rich mock tests, mirroring the course assignment/coding grading pages. Admins can now open a test's submissions, see participation/grading stats, and drill into any attempt to review all five question types and grade subjective answers.

## Backend (`backend/quiz/admin_views.py`)
- New `submissions` detail action (`GET /quiz/admin/mock-tests/<pk>/submissions/`): returns `mock_test` meta, `counts` (eligible/submitted/graded/pending), `average_score`, and a per-attempt list. Eligible = distinct approved+active enrollments in linked/legacy courses, or all tenant students when the test is open to all.
- Enriched `_attempt_grading_payload` with correct-answer references (`options`, `correct_option_indices`, `numerical_correct`/`numerical_tolerance`, `model_answer`, `rubric`, `selected_options`, `coding_results`, etc.) so the review view can render every question type.

## Frontend
- New `MockTestSubmissions.jsx` (list) + `MockTestSubmissionReview.jsx` (per-attempt review + grade + finalize).
- Wired routes in `App.jsx`; added a per-card **View submissions** button in `MockTestManager.jsx` and a **Submissions** link in the builder header.
- `mockTestBuilderService.submissions(testId)` API method.

## Verification
- Frontend `npm run build` passes.
- VM Django `manage.py check` clean on this branch.
- Confirmed coding result verdict shape (`verdict`/`points`/`max_points`) matches the review component.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>