### PR TITLE
Add rich text + inline images to mock test questions

### DIFF
--- a/frontend/exam-frontend/src/components/common/RichMarkdownEditor.jsx
+++ b/frontend/exam-frontend/src/components/common/RichMarkdownEditor.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { Eye, Pencil } from 'lucide-react'
+import { NotesTextarea } from '../admin/builderShared'
+import MathRenderer from '../chat/MathRenderer'
+
+/**
+ * Rich content editor for mock-test authoring.
+ *
+ * Wraps the shared {@link NotesTextarea} (Markdown + inline image paste / drop /
+ * upload to blob storage) with a Write / Preview toggle so admins see exactly
+ * what students will see. Content is stored as Markdown and rendered everywhere
+ * through {@link MathRenderer} (Markdown + GFM + KaTeX math + inline images).
+ */
+export default function RichMarkdownEditor({ value, onChange, rows = 4 }) {
+  const [tab, setTab] = useState('write')
+  const has = !!(value && value.trim())
+
+  const TabBtn = ({ id, icon: Icon, children }) => (
+    <button
+      type="button"
+      onClick={() => setTab(id)}
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-colors ${
+        tab === id
+          ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300'
+          : 'text-surface-500 hover:text-surface-800 dark:hover:text-surface-200'
+      }`}
+    >
+      <Icon className="w-3.5 h-3.5" /> {children}
+    </button>
+  )
+
+  return (
+    <div className="rounded-xl border border-surface-200 dark:border-surface-700 overflow-hidden">
+      <div className="flex items-center gap-1 px-2 pt-2 pb-1 border-b border-surface-100 dark:border-surface-800">
+        <TabBtn id="write" icon={Pencil}>Write</TabBtn>
+        <TabBtn id="preview" icon={Eye}>Preview</TabBtn>
+        <span className="ml-auto text-[11px] text-surface-400 pr-1 hidden sm:inline">
+          Markdown · math with $…$ · paste images inline
+        </span>
+      </div>
+      <div className="p-2">
+        {tab === 'write' ? (
+          <NotesTextarea value={value ?? ''} onChange={onChange} rows={rows} />
+        ) : (
+          <div className="min-h-[80px] px-1 py-1">
+            {has ? (
+              <MathRenderer content={value} />
+            ) : (
+              <p className="text-sm italic text-surface-400">Nothing to preview yet.</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
@@ -7,6 +7,7 @@ import {
   ListChecks, Calculator, FileText, Code2, CheckSquare, Library, X, Search,
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
+import RichMarkdownEditor from '../components/common/RichMarkdownEditor'
 
 const ITEM_TYPES = [
   { value: 'mcq', label: 'MCQ (single)', icon: ListChecks, color: 'text-blue-500' },
@@ -308,7 +309,7 @@ function ItemEditor({ testId, item, onClose }) {
   const saveMut = useMutation({
     mutationFn: () => {
       const payload = {
-        item_type: f.item_type, question_text: f.question_text || '', question_html: f.question_html || '',
+        item_type: f.item_type, question_text: f.question_text || '', question_html: '',
         explanation: f.explanation || '', marks: f.marks, negative_marks: f.negative_marks || 0, section: f.section || 0,
       }
       if (['mcq', 'mcq_multi'].includes(f.item_type)) payload.options = f.options
@@ -341,7 +342,7 @@ function ItemEditor({ testId, item, onClose }) {
           <button onClick={onClose} className="p-1.5 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800"><X className="w-5 h-5" /></button>
         </div>
         <div className="p-5 space-y-4 max-h-[70vh] overflow-auto">
-          <Field label="Question"><textarea value={f.question_text || ''} onChange={(e) => set('question_text')(e.target.value)} rows={3} className={inputCls} /></Field>
+          <Field label="Question"><RichMarkdownEditor value={f.question_text} onChange={set('question_text')} rows={4} /></Field>
           <div className="grid grid-cols-3 gap-3">
             <Field label="Marks"><input type="number" step="0.5" value={f.marks} onChange={(e) => set('marks')(Number(e.target.value))} className={inputCls} /></Field>
             <Field label="Negative"><input type="number" step="0.5" value={f.negative_marks || 0} onChange={(e) => set('negative_marks')(Number(e.target.value))} className={inputCls} /></Field>
@@ -353,10 +354,12 @@ function ItemEditor({ testId, item, onClose }) {
               <p className="text-sm font-medium mb-2">Options <span className="text-xs text-surface-400">(check the correct one{f.item_type === 'mcq_multi' ? 's' : ''})</span></p>
               <div className="space-y-2">
                 {f.options.map((o, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <input type={f.item_type === 'mcq' ? 'radio' : 'checkbox'} checked={!!o.is_correct} name="correct" onChange={(e) => setOpt(i, { is_correct: e.target.checked })} />
-                    <input value={o.text || ''} onChange={(e) => setF((s) => ({ ...s, options: s.options.map((x, idx) => idx === i ? { ...x, text: e.target.value } : x) }))} placeholder={`Option ${i + 1}`} className={inputCls} />
-                    <button onClick={() => setF((s) => ({ ...s, options: s.options.filter((_, idx) => idx !== i) }))} className="p-1.5 text-surface-400 hover:text-rose-600"><Trash2 className="w-4 h-4" /></button>
+                  <div key={i} className="flex items-start gap-2">
+                    <input type={f.item_type === 'mcq' ? 'radio' : 'checkbox'} checked={!!o.is_correct} name="correct" onChange={(e) => setOpt(i, { is_correct: e.target.checked })} className="mt-3.5" />
+                    <div className="flex-1">
+                      <RichMarkdownEditor value={o.text} onChange={(v) => setF((s) => ({ ...s, options: s.options.map((x, idx) => idx === i ? { ...x, text: v } : x) }))} rows={2} />
+                    </div>
+                    <button onClick={() => setF((s) => ({ ...s, options: s.options.filter((_, idx) => idx !== i) }))} className="mt-3 p-1.5 text-surface-400 hover:text-rose-600"><Trash2 className="w-4 h-4" /></button>
                   </div>
                 ))}
               </div>
@@ -374,8 +377,8 @@ function ItemEditor({ testId, item, onClose }) {
           {f.item_type === 'subjective' && (
             <>
               <Field label="Max words" hint="optional"><input type="number" value={f.max_words ?? ''} onChange={(e) => set('max_words')(e.target.value === '' ? null : Number(e.target.value))} className={inputCls} /></Field>
-              <Field label="Grading rubric" hint="admins only"><textarea value={f.rubric || ''} onChange={(e) => set('rubric')(e.target.value)} rows={2} className={inputCls} /></Field>
-              <Field label="Model answer" hint="admins only"><textarea value={f.model_answer || ''} onChange={(e) => set('model_answer')(e.target.value)} rows={2} className={inputCls} /></Field>
+              <Field label="Grading rubric" hint="admins only"><RichMarkdownEditor value={f.rubric} onChange={set('rubric')} rows={2} /></Field>
+              <Field label="Model answer" hint="admins only"><RichMarkdownEditor value={f.model_answer} onChange={set('model_answer')} rows={2} /></Field>
             </>
           )}
 
@@ -419,7 +422,7 @@ function ItemEditor({ testId, item, onClose }) {
             </div>
           )}
 
-          <Field label="Explanation" hint="shown after submission"><textarea value={f.explanation || ''} onChange={(e) => set('explanation')(e.target.value)} rows={2} className={inputCls} /></Field>
+          <Field label="Explanation" hint="shown after submission"><RichMarkdownEditor value={f.explanation} onChange={set('explanation')} rows={2} /></Field>
         </div>
         <div className="flex justify-end gap-2 p-4 border-t border-surface-200 dark:border-surface-700">
           <button onClick={onClose} className="px-4 py-2 rounded-xl border border-surface-200 dark:border-surface-700 text-sm">Cancel</button>

--- a/frontend/exam-frontend/src/pages/MockTestGrading.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestGrading.jsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2, AlertCircle, Award,
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
+import MathRenderer from '../components/chat/MathRenderer'
 
 export default function MockTestGrading() {
   const navigate = useNavigate()
@@ -159,7 +160,7 @@ function GradeCard({ answer, index, onSave, saving }) {
 
       {answer.question_html
         ? <div className="prose dark:prose-invert max-w-none text-sm mb-3" dangerouslySetInnerHTML={{ __html: answer.question_html }} />
-        : <p className="text-surface-800 dark:text-surface-100 text-sm mb-3 whitespace-pre-wrap">{answer.question_text}</p>}
+        : <div className="mb-3"><MathRenderer content={answer.question_text} className="prose-sm" /></div>}
 
       <div className="rounded-xl bg-surface-50 dark:bg-surface-800/50 border border-surface-200 dark:border-surface-700 p-4 mb-4">
         {answer.item_type === 'coding' ? (

--- a/frontend/exam-frontend/src/pages/MockTestSubmissionReview.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestSubmissionReview.jsx
@@ -7,6 +7,7 @@ import {
   Award, Hash, ListChecks, User, Clock, ChevronDown, ChevronUp,
 } from 'lucide-react'
 import { mockTestBuilderService as svc } from '../services/mockTestBuilderService'
+import MathRenderer from '../components/chat/MathRenderer'
 
 const TYPE_META = {
   mcq: { label: 'Multiple Choice', icon: ListChecks },
@@ -162,7 +163,7 @@ function ReviewCard({ answer, index, onSave, saving }) {
 
       {answer.question_html
         ? <div className="prose dark:prose-invert max-w-none text-sm mb-3" dangerouslySetInnerHTML={{ __html: answer.question_html }} />
-        : <p className="text-surface-800 dark:text-surface-100 text-sm mb-3 whitespace-pre-wrap">{answer.question_text}</p>}
+        : <div className="mb-3"><MathRenderer content={answer.question_text} className="prose-sm" /></div>}
 
       {(answer.item_type === 'mcq' || answer.item_type === 'mcq_multi') && (
         <McqReview answer={answer} />
@@ -173,7 +174,8 @@ function ReviewCard({ answer, index, onSave, saving }) {
 
       {answer.explanation && (
         <div className="mt-3 text-xs text-surface-500 bg-surface-50 dark:bg-surface-800/50 rounded-lg p-3">
-          <span className="font-semibold">Explanation: </span>{answer.explanation}
+          <span className="font-semibold">Explanation: </span>
+          <MathRenderer content={answer.explanation} className="prose-sm inline" />
         </div>
       )}
 
@@ -208,7 +210,7 @@ function McqReview({ answer }) {
             {isCorrect ? <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
               : isSelected ? <XCircle className="w-4 h-4 text-rose-500 shrink-0" />
               : <span className="w-4 h-4 shrink-0" />}
-            <span className="flex-1">{opt.text}</span>
+            <div className="flex-1 min-w-0"><MathRenderer content={opt.text} className="prose-sm prose-p:my-0" /></div>
             {isSelected && <span className="text-xs font-medium text-surface-500">student</span>}
           </div>
         )
@@ -266,7 +268,7 @@ function SubjectiveReview({ answer }) {
           {answer.model_answer && (
             <div className="bg-surface-100 dark:bg-surface-800 rounded-lg p-3">
               <span className="font-semibold">Model answer: </span>
-              <span className="whitespace-pre-wrap">{answer.model_answer}</span>
+              <MathRenderer content={answer.model_answer} className="prose-sm" />
             </div>
           )}
         </div>

--- a/frontend/exam-frontend/src/pages/RichMockAttempt.jsx
+++ b/frontend/exam-frontend/src/pages/RichMockAttempt.jsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
 import CodeEditor from '../components/coding/CodeEditor'
+import MathRenderer from '../components/chat/MathRenderer'
 
 const MONACO_MODE = { python: 'python', cpp: 'cpp', java: 'java' }
 
@@ -256,7 +257,7 @@ export default function RichMockAttempt() {
               {q.question_html ? (
                 <div className="prose dark:prose-invert max-w-none mb-5" dangerouslySetInnerHTML={{ __html: q.question_html }} />
               ) : (
-                <p className="text-surface-800 dark:text-surface-100 whitespace-pre-wrap mb-5 text-[15px] leading-relaxed">{q.question_text}</p>
+                <div className="mb-5"><MathRenderer content={q.question_text} className="prose-base" /></div>
               )}
               {q.question_image && <img src={q.question_image} alt="" className="max-h-72 rounded-lg mb-5" />}
 
@@ -342,17 +343,19 @@ function AnswerInput({ q, value, onChange, running, runResult, onRun }) {
     return (
       <div className="space-y-2">
         {(q.options || []).map((o) => (
-          <button key={o.index} onClick={() => toggle(o.index)}
-            className={`w-full text-left px-4 py-3 rounded-xl border transition flex items-center gap-3 ${
+          <div key={o.index} role="button" tabIndex={0}
+            onClick={() => toggle(o.index)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(o.index) } }}
+            className={`w-full cursor-pointer text-left px-4 py-3 rounded-xl border transition flex items-center gap-3 ${
               selected.includes(o.index)
                 ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
                 : 'border-surface-200 dark:border-surface-700 hover:border-surface-300'}`}>
-            <span className={`w-5 h-5 rounded-${q.item_type === 'mcq' ? 'full' : 'md'} border flex items-center justify-center ${selected.includes(o.index) ? 'border-primary-500 bg-primary-500' : 'border-surface-300'}`}>
+            <span className={`shrink-0 w-5 h-5 rounded-${q.item_type === 'mcq' ? 'full' : 'md'} border flex items-center justify-center ${selected.includes(o.index) ? 'border-primary-500 bg-primary-500' : 'border-surface-300'}`}>
               {selected.includes(o.index) && <CheckCircle2 className="w-4 h-4 text-white" />}
             </span>
-            <span className="text-surface-800 dark:text-surface-100">{o.text}</span>
+            <div className="text-surface-800 dark:text-surface-100 flex-1 min-w-0"><MathRenderer content={o.text} className="prose-sm prose-p:my-0" /></div>
             {o.image && <img src={o.image} alt="" className="h-12 rounded ml-auto" />}
-          </button>
+          </div>
         ))}
       </div>
     )

--- a/frontend/exam-frontend/src/pages/RichMockReview.jsx
+++ b/frontend/exam-frontend/src/pages/RichMockReview.jsx
@@ -6,6 +6,7 @@ import {
   FileText, Code2, HelpCircle, Medal,
 } from 'lucide-react'
 import { mockTestBuilderService } from '../services/mockTestBuilderService'
+import MathRenderer from '../components/chat/MathRenderer'
 
 export default function RichMockReview() {
   const { attemptId } = useParams()
@@ -117,7 +118,7 @@ function ReviewCard({ q, index }) {
 
       {q.question_html
         ? <div className="prose dark:prose-invert max-w-none text-sm mb-3" dangerouslySetInnerHTML={{ __html: q.question_html }} />
-        : <p className="text-surface-800 dark:text-surface-100 text-sm mb-3 whitespace-pre-wrap">{q.question_text}</p>}
+        : <div className="mb-3"><MathRenderer content={q.question_text} className="prose-sm" /></div>}
 
       {/* options for MCQ types */}
       {q.options && (
@@ -130,7 +131,7 @@ function ReviewCard({ q, index }) {
               {o.is_correct ? <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
                 : o.is_selected ? <XCircle className="w-4 h-4 text-rose-500 shrink-0" />
                 : <span className="w-4 h-4 shrink-0" />}
-              <span>{o.text}</span>
+              <div className="flex-1 min-w-0"><MathRenderer content={o.text} className="prose-sm prose-p:my-0" /></div>
               {o.is_selected && <span className="ml-auto text-xs text-surface-400">your answer</span>}
             </div>
           ))}
@@ -168,7 +169,7 @@ function ReviewCard({ q, index }) {
       {q.explanation && (
         <details className="mt-2 text-sm">
           <summary className="cursor-pointer text-surface-500 font-medium">Explanation</summary>
-          <div className="mt-1 text-surface-600 dark:text-surface-300 whitespace-pre-wrap">{q.explanation}</div>
+          <div className="mt-1 text-surface-600 dark:text-surface-300"><MathRenderer content={q.explanation} className="prose-sm" /></div>
         </details>
       )}
     </div>


### PR DESCRIPTION
## Summary
Adds **rich text authoring + inline images** to every mock test question type, with **identical rendering for students**. This reuses the app's established content pattern (Markdown source + inline image upload to Azure blob + `MathRenderer` rendering with KaTeX math), so it's consistent with the Course Builder's notes editor.

## What changed

### New component
- `components/common/RichMarkdownEditor.jsx` — a **Write / Preview** editor that wraps the existing `NotesTextarea` (Markdown + paste/drop/upload images to blob via `/content/admin/upload-image/`) and previews with `MathRenderer` so admins see exactly what students will see.

### Admin builder (`MockTestBuilder.jsx`)
- Question body, **MCQ/multi options**, explanation, grading rubric, and model answer all use the rich editor now (was plain textareas / inputs).
- On save, stale `question_html` is cleared so the authored Markdown is authoritative.

### Student-facing (`RichMockAttempt.jsx`, `RichMockReview.jsx`)
- Question, options, and explanation render via `MathRenderer` (Markdown + GFM + KaTeX + inline images). Legacy raw `question_html` is still honored for old items.
- MCQ option rows converted from `<button>` to `<div role="button">` so they can contain rich block content (images/math) without invalid HTML nesting; keyboard (Enter/Space) support preserved.

### Admin review/grading (`MockTestSubmissionReview.jsx`, `MockTestGrading.jsx`)
- Question, options, explanation, and model answer render via `MathRenderer`.

## Notes
- **No backend changes** — the paper/review payloads already carry `question_text`, per-option `text`, `explanation`, `model_answer`. Frontend-only; Netlify auto-deploys.
- **Backward compatible**: existing plain-text questions render fine as Markdown paragraphs.
- **Safe**: Markdown is rendered by `react-markdown` without raw-HTML injection (no `rehype-raw`), so no new XSS surface; images are inserted as Markdown pointing at uploaded blob URLs.

## Verification
- `npm run build` passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>