### PR TITLE
Mock test: pre-start instructions, resumable server timer, autosave & re-attempt limit

### DIFF
--- a/backend/quiz/admin_serializers.py
+++ b/backend/quiz/admin_serializers.py
@@ -309,7 +309,7 @@ class AdminMockTestSerializer(serializers.ModelSerializer):
             'id', 'title', 'description', 'course', 'course_name', 'courses',
             'sections', 'duration_minutes', 'total_marks', 'negative_marking',
             'status', 'is_free', 'result_visibility', 'results_released',
-            'start_deadline', 'fullscreen_required',
+            'start_deadline', 'fullscreen_required', 'max_attempts',
             'available_from', 'available_until',
             'is_pyp', 'pyp_year', 'pyp_shift', 'pyp_session', 'pyp_date',
             'items', 'items_count', 'bank_questions_count', 'computed_total_marks',

--- a/backend/quiz/migrations/0011_mocktest_max_attempts.py
+++ b/backend/quiz/migrations/0011_mocktest_max_attempts.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('quiz', '0010_mocktest_courses_mocktest_fullscreen_required_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mocktest',
+            name='max_attempts',
+            field=models.PositiveIntegerField(
+                default=1,
+                help_text='Total attempts allowed per student. 1 = no re-attempts (default).',
+            ),
+        ),
+    ]

--- a/backend/quiz/models.py
+++ b/backend/quiz/models.py
@@ -254,6 +254,11 @@ class MockTest(TimeStampedModel):
     start_deadline = models.DateTimeField(null=True, blank=True)
     # Force fullscreen during the attempt for a distraction-free experience.
     fullscreen_required = models.BooleanField(default=True)
+    # Maximum number of attempts a student may make. Default 1 (no re-attempts).
+    max_attempts = models.PositiveIntegerField(
+        default=1,
+        help_text='Total attempts allowed per student. 1 = no re-attempts (default).',
+    )
     
     # Previous Year Paper fields
     is_pyp = models.BooleanField(default=False, help_text='Is this a Previous Year Paper?')

--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -160,7 +160,7 @@ class MockTestSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'title', 'description', 'course', 'course_name',
             'duration_minutes', 'total_marks', 'negative_marking',
-            'status', 'is_free', 'sections', 'questions_count',
+            'status', 'is_free', 'sections', 'questions_count', 'max_attempts',
             'total_attempts', 'average_score', 'highest_score',
             'available_from', 'available_until', 'created_at',
             'user_attempt_info'
@@ -179,26 +179,46 @@ class MockTestSerializer(serializers.ModelSerializer):
         
         try:
             profile = request.user.profile
-            attempts = MockTestAttempt.objects.filter(
-                student=profile,
-                mock_test=obj,
-                status='completed'
+            # Attempts that count toward the per-test limit.
+            finished = MockTestAttempt.objects.filter(
+                student=profile, mock_test=obj,
+                status__in=['completed', 'timed_out'],
             ).order_by('-completed_at')
-            
-            if not attempts.exists():
-                return None
-            
-            best_attempt = attempts.order_by('-percentage').first()
-            latest_attempt = attempts.first()
-            
+            active = MockTestAttempt.objects.filter(
+                student=profile, mock_test=obj, status='in_progress',
+            ).order_by('-started_at').first()
+
+            attempts_used = finished.count()
+            max_attempts = obj.max_attempts or 1
+            # A resume doesn't consume a new attempt; a fresh start is allowed
+            # only while used attempts are below the cap.
+            can_reattempt = attempts_used < max_attempts
+
+            completed = finished.filter(status='completed')
+            best_attempt = completed.order_by('-percentage').first()
+            latest_attempt = finished.first()
+
+            if not finished.exists() and not active:
+                return {
+                    'attempted': False,
+                    'attempts_used': 0,
+                    'max_attempts': max_attempts,
+                    'can_reattempt': can_reattempt,
+                    'active_attempt_id': None,
+                }
+
             return {
-                'attempted': True,
-                'attempts_count': attempts.count(),
+                'attempted': completed.exists(),
+                'attempts_count': attempts_used,
+                'attempts_used': attempts_used,
+                'max_attempts': max_attempts,
+                'can_reattempt': can_reattempt,
+                'active_attempt_id': str(active.id) if active else None,
                 'best_score': float(best_attempt.percentage) if best_attempt else 0,
                 'best_attempt_id': str(best_attempt.id) if best_attempt else None,
                 'latest_attempt_id': str(latest_attempt.id) if latest_attempt else None,
                 'latest_score': float(latest_attempt.percentage) if latest_attempt else 0,
-                'latest_date': latest_attempt.completed_at.isoformat() if latest_attempt else None,
+                'latest_date': latest_attempt.completed_at.isoformat() if latest_attempt and latest_attempt.completed_at else None,
                 'rank': best_attempt.rank if best_attempt else None,
                 'percentile': float(best_attempt.percentile) if best_attempt and best_attempt.percentile else None,
             }

--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -935,6 +935,195 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
             )
         return None
 
+    # -- timing / persistence helpers for the server-authoritative timer -----
+
+    def _attempt_timing(self, mock_test, attempt):
+        """Server-authoritative timing for an in-progress attempt.
+
+        The clock is anchored to ``attempt.started_at`` (stored in the DB), so
+        closing the tab never pauses it. Returns server ``now``, the absolute
+        ``expires_at``, whole ``seconds_remaining`` and whether it has expired.
+        """
+        now = timezone.now()
+        expires_at = attempt.started_at + timezone.timedelta(
+            minutes=mock_test.duration_minutes or 0)
+        remaining = int((expires_at - now).total_seconds())
+        return {
+            'server_now': now.isoformat(),
+            'started_at': attempt.started_at.isoformat(),
+            'expires_at': expires_at.isoformat(),
+            'seconds_remaining': max(0, remaining),
+            'expired': remaining <= 0,
+        }
+
+    def _saved_answers(self, attempt):
+        """Previously-saved answers, keyed to match the attempt UI (`kind:ref`).
+
+        Lets a resumed attempt restore what the student had entered before the
+        tab was closed.
+        """
+        out = {}
+        for a in attempt.answers.select_related('question').all():
+            key = f'bank:{a.question_id}'
+            entry = {'is_marked_for_review': a.is_marked_for_review}
+            if a.numerical_answer is not None:
+                entry['numerical_answer'] = float(a.numerical_answer)
+            if a.selected_option:
+                entry['selected'] = [a.selected_option]
+            out[key] = entry
+        for a in attempt.item_answers.select_related('item').all():
+            key = f'item:{a.item_id}'
+            entry = {'is_marked_for_review': a.is_marked_for_review}
+            if a.selected_options:
+                entry['selected'] = list(a.selected_options)
+            if a.numerical_answer is not None:
+                entry['numerical_answer'] = float(a.numerical_answer)
+            if a.answer_text:
+                entry['answer_text'] = a.answer_text
+            if a.code:
+                entry['code'] = a.code
+            if a.language:
+                entry['language'] = a.language
+            out[key] = entry
+        return out
+
+    def _upsert_rich_answers(self, attempt, mock_test, tenant,
+                             bank_answers, item_answers, grade):
+        """Persist submitted answers. When ``grade`` is False (autosave) the
+        answers are stored raw without any grading (never runs code)."""
+        from .mock_grading import grade_item_answer
+        mtq_map = {
+            str(mtq.question_id): mtq
+            for mtq in MockTestQuestion.objects.filter(mock_test=mock_test).select_related('question')
+        }
+        for a in bank_answers or []:
+            mtq = mtq_map.get(str(a.get('question_id')))
+            if not mtq:
+                continue
+            answer, _ = Answer.objects.get_or_create(
+                mock_test_attempt=attempt, question=mtq.question,
+                defaults={'tenant': tenant},
+            )
+            answer.selected_option = a.get('selected_option', '') or ''
+            answer.numerical_answer = a.get('numerical_answer')
+            answer.answer_text = a.get('answer_text', '') or ''
+            answer.time_taken_seconds = int(a.get('time_taken_seconds', 0) or 0)
+            answer.is_marked_for_review = bool(a.get('is_marked_for_review', False))
+            if grade:
+                answer.check_answer(
+                    marks_override=mtq.marks_override,
+                    negative_marks_override=mtq.negative_marks_override,
+                )
+            else:
+                answer.save()
+
+        item_map = {
+            str(it.id): it
+            for it in MockTestItem.objects.filter(mock_test=mock_test)
+        }
+        for a in item_answers or []:
+            item = item_map.get(str(a.get('item_id')))
+            if not item:
+                continue
+            ans, _ = MockTestAnswer.objects.get_or_create(
+                attempt=attempt, item=item, defaults={'tenant': tenant},
+            )
+            ans.selected_options = a.get('selected_options', []) or []
+            ans.numerical_answer = a.get('numerical_answer')
+            ans.answer_text = a.get('answer_text', '') or ''
+            ans.code = a.get('code', '') or ''
+            ans.language = a.get('language', '') or ''
+            ans.time_taken_seconds = int(a.get('time_taken_seconds', 0) or 0)
+            ans.is_marked_for_review = bool(a.get('is_marked_for_review', False))
+            if grade:
+                grade_item_answer(item, ans)
+            ans.save()
+
+    def _finalize_rich_attempt(self, attempt, mock_test, student, timed_out=False):
+        """Grade every saved answer, aggregate results and complete the attempt.
+
+        Used by both explicit submission and server-side auto-submit when the
+        timer expires (e.g. the student never returned to the tab). Idempotent
+        via the attempt's ``in_progress`` guard at the call sites.
+        """
+        from decimal import Decimal
+        from .mock_grading import grade_item_answer
+
+        # (Re)grade any answers that were only autosaved (stored ungraded).
+        mtq_map = {
+            str(mtq.question_id): mtq
+            for mtq in MockTestQuestion.objects.filter(mock_test=mock_test).select_related('question')
+        }
+        for answer in attempt.answers.select_related('question').all():
+            mtq = mtq_map.get(str(answer.question_id))
+            if mtq:
+                answer.check_answer(
+                    marks_override=mtq.marks_override,
+                    negative_marks_override=mtq.negative_marks_override,
+                )
+        for ans in attempt.item_answers.select_related('item').all():
+            grade_item_answer(ans.item, ans)
+            ans.save()
+
+        bank_qs = attempt.answers.all()
+        item_qs = attempt.item_answers.all()
+        bank_marks = sum((x.marks_obtained for x in bank_qs), Decimal('0'))
+        item_marks = sum((x.marks_obtained for x in item_qs), Decimal('0'))
+        attempt.marks_obtained = bank_marks + item_marks
+        attempt.attempted_questions = bank_qs.count() + item_qs.count()
+        attempt.correct_answers = (
+            bank_qs.filter(is_correct=True).count() + item_qs.filter(is_correct=True).count()
+        )
+        attempt.wrong_answers = (
+            bank_qs.filter(is_correct=False).count()
+            + item_qs.filter(is_correct=False, needs_manual_grading=False).count()
+        )
+        total = float(mock_test.total_marks) or 0
+        attempt.percentage = max(0, (float(attempt.marks_obtained) / total) * 100) if total > 0 else 0
+
+        pending_manual = item_qs.filter(needs_manual_grading=True).exists()
+        attempt.grading_status = 'pending_manual' if pending_manual else 'auto_graded'
+        attempt.status = 'timed_out' if timed_out else 'completed'
+        attempt.completed_at = timezone.now()
+        elapsed = int((attempt.completed_at - attempt.started_at).total_seconds())
+        cap = (mock_test.duration_minutes or 0) * 60
+        attempt.time_taken_seconds = min(elapsed, cap) if cap else elapsed
+        attempt.save()
+
+        awarded_xp = 0
+        if not pending_manual:
+            already = MockTestAttempt.objects.filter(
+                student=student, mock_test=mock_test,
+                status__in=['completed', 'timed_out'],
+            ).exclude(id=attempt.id).exists()
+            if not already:
+                awarded_xp = calculate_xp_for_quiz(
+                    attempt.percentage, attempt.total_questions, is_daily_challenge=False
+                ) * 2
+                attempt.xp_earned = awarded_xp
+                attempt.save(update_fields=['xp_earned'])
+                GamificationService.award_xp(
+                    student, awarded_xp, 'mock_complete',
+                    f'Completed mock test: {mock_test.title}', str(attempt.id),
+                )
+
+        mock_test.total_attempts += 1
+        if attempt.marks_obtained > mock_test.highest_score:
+            mock_test.highest_score = attempt.marks_obtained
+        mock_test.save(update_fields=['total_attempts', 'highest_score'])
+
+        results_visible = (
+            mock_test.result_visibility == 'immediate' and not pending_manual
+        ) or mock_test.results_released
+
+        return {
+            'attempt': MockTestAttemptSerializer(attempt).data,
+            'grading_status': attempt.grading_status,
+            'results_visible': results_visible,
+            'pending_manual': pending_manual,
+            'timed_out': timed_out,
+        }
+
     @action(detail=True, methods=['get'])
     def paper(self, request, pk=None):
         """Merged, ordered question paper for the rich attempt UI (no answers)."""
@@ -947,6 +1136,12 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
         active = MockTestAttempt.objects.filter(
             student=student, mock_test=mock_test, status='in_progress'
         ).first()
+        attempts_used = MockTestAttempt.objects.filter(
+            student=student, mock_test=mock_test,
+            status__in=['completed', 'timed_out'],
+        ).count()
+        max_attempts = mock_test.max_attempts or 1
+        timing = self._attempt_timing(mock_test, active) if active else None
         return Response({
             'mock_test': {
                 'id': str(mock_test.id),
@@ -958,10 +1153,16 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
                 'fullscreen_required': mock_test.fullscreen_required,
                 'result_visibility': mock_test.result_visibility,
                 'start_deadline': mock_test.start_deadline.isoformat() if mock_test.start_deadline else None,
+                'max_attempts': max_attempts,
                 'sections': mock_test.sections,
             },
             'questions': build_paper(mock_test),
             'active_attempt_id': str(active.id) if active else None,
+            'server_now': timezone.now().isoformat(),
+            'attempts_used': attempts_used,
+            'attempts_remaining': max(0, max_attempts - attempts_used),
+            'can_start': attempts_used < max_attempts,
+            'timing': timing,
         })
 
     @action(detail=True, methods=['post'])
@@ -978,11 +1179,37 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
             student=student, mock_test=mock_test, status='in_progress'
         ).first()
         if existing:
+            timing = self._attempt_timing(mock_test, existing)
+            # Timer runs on the server clock, so a tab left closed past the
+            # deadline is auto-submitted here on return rather than resumed.
+            if timing['expired']:
+                result = self._finalize_rich_attempt(
+                    existing, mock_test, student, timed_out=True)
+                return Response({
+                    'expired': True,
+                    'attempt_id': str(existing.id),
+                    **result,
+                })
             return Response({
                 'attempt': MockTestAttemptSerializer(existing).data,
                 'questions': build_paper(mock_test),
+                'saved_answers': self._saved_answers(existing),
+                'timing': timing,
                 'resumed': True,
             })
+
+        # Fresh start: enforce the per-student attempt cap.
+        attempts_used = MockTestAttempt.objects.filter(
+            student=student, mock_test=mock_test,
+            status__in=['completed', 'timed_out'],
+        ).count()
+        max_attempts = mock_test.max_attempts or 1
+        if attempts_used >= max_attempts:
+            return Response(
+                {'error': 'You have used all allowed attempts for this test.',
+                 'attempts_used': attempts_used, 'max_attempts': max_attempts},
+                status=status.HTTP_403_FORBIDDEN,
+            )
 
         if mock_test.start_deadline and timezone.now() > mock_test.start_deadline:
             return Response(
@@ -1002,14 +1229,41 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
         return Response({
             'attempt': MockTestAttemptSerializer(attempt).data,
             'questions': build_paper(mock_test),
+            'saved_answers': {},
+            'timing': self._attempt_timing(mock_test, attempt),
             'resumed': False,
         }, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=['post'])
+    def save_rich(self, request, pk=None):
+        """Autosave in-progress answers (no grading) so a resume can restore them."""
+        mock_test = self.get_object()
+        denied = self._rich_access_or_403(mock_test, request)
+        if denied:
+            return denied
+        student = request.user.profile
+        attempt = MockTestAttempt.objects.filter(
+            student=student, mock_test=mock_test, status='in_progress'
+        ).first()
+        if not attempt:
+            return Response({'error': 'No active attempt found'},
+                            status=status.HTTP_400_BAD_REQUEST)
+        timing = self._attempt_timing(mock_test, attempt)
+        if timing['expired']:
+            result = self._finalize_rich_attempt(
+                attempt, mock_test, student, timed_out=True)
+            return Response({'expired': True, 'attempt_id': str(attempt.id), **result})
+        self._upsert_rich_answers(
+            attempt, mock_test, getattr(request, 'tenant', None),
+            request.data.get('bank_answers', []),
+            request.data.get('item_answers', []),
+            grade=False,
+        )
+        return Response({'saved': True, 'timing': timing})
 
     @action(detail=True, methods=['post'], throttle_classes=[QuizSubmitThrottle])
     def submit_rich(self, request, pk=None):
         """Submit a rich attempt: grade bank + inline answers; flag subjective."""
-        from decimal import Decimal
-        from .mock_grading import grade_item_answer, has_subjective_items
         mock_test = self.get_object()
         denied = self._rich_access_or_403(mock_test, request)
         if denied:
@@ -1024,114 +1278,18 @@ class MockTestViewSet(TenantAwareReadOnlyViewSet):
                             status=status.HTTP_400_BAD_REQUEST)
 
         tenant = getattr(request, 'tenant', None)
-        bank_answers = request.data.get('bank_answers', []) or []
-        item_answers = request.data.get('item_answers', []) or []
-        time_taken = int(request.data.get('time_taken_seconds', 0) or 0)
-
-        # --- bank questions (shared Answer model, existing autograde) ---
-        mtq_map = {
-            str(mtq.question_id): mtq
-            for mtq in MockTestQuestion.objects.filter(mock_test=mock_test).select_related('question')
-        }
-        for a in bank_answers:
-            qid = str(a.get('question_id'))
-            mtq = mtq_map.get(qid)
-            if not mtq:
-                continue
-            answer, _ = Answer.objects.get_or_create(
-                mock_test_attempt=attempt, question=mtq.question,
-                defaults={'tenant': tenant},
-            )
-            answer.selected_option = a.get('selected_option', '') or ''
-            answer.numerical_answer = a.get('numerical_answer')
-            answer.answer_text = a.get('answer_text', '') or ''
-            answer.time_taken_seconds = int(a.get('time_taken_seconds', 0) or 0)
-            answer.is_marked_for_review = bool(a.get('is_marked_for_review', False))
-            answer.check_answer(
-                marks_override=mtq.marks_override,
-                negative_marks_override=mtq.negative_marks_override,
-            )
-
-        # --- inline items (MockTestAnswer, autograde or manual) ---
-        item_map = {
-            str(it.id): it
-            for it in MockTestItem.objects.filter(mock_test=mock_test)
-        }
-        for a in item_answers:
-            item = item_map.get(str(a.get('item_id')))
-            if not item:
-                continue
-            ans, _ = MockTestAnswer.objects.get_or_create(
-                attempt=attempt, item=item, defaults={'tenant': tenant},
-            )
-            ans.selected_options = a.get('selected_options', []) or []
-            ans.numerical_answer = a.get('numerical_answer')
-            ans.answer_text = a.get('answer_text', '') or ''
-            ans.code = a.get('code', '') or ''
-            ans.language = a.get('language', '') or ''
-            ans.time_taken_seconds = int(a.get('time_taken_seconds', 0) or 0)
-            ans.is_marked_for_review = bool(a.get('is_marked_for_review', False))
-            grade_item_answer(item, ans)
-            ans.save()
-
-        # --- aggregate results ---
-        bank_qs = attempt.answers.all()
-        item_qs = attempt.item_answers.all()
-        bank_marks = sum((x.marks_obtained for x in bank_qs), Decimal('0'))
-        item_marks = sum((x.marks_obtained for x in item_qs), Decimal('0'))
-        attempt.marks_obtained = bank_marks + item_marks
-        attempt.attempted_questions = bank_qs.count() + item_qs.count()
-        attempt.correct_answers = (
-            bank_qs.filter(is_correct=True).count() + item_qs.filter(is_correct=True).count()
+        # Persist and grade the final answers, then finalize. Time is computed
+        # server-side from started_at (never trusts the client clock).
+        self._upsert_rich_answers(
+            attempt, mock_test, tenant,
+            request.data.get('bank_answers', []),
+            request.data.get('item_answers', []),
+            grade=True,
         )
-        attempt.wrong_answers = (
-            bank_qs.filter(is_correct=False).count()
-            + item_qs.filter(is_correct=False, needs_manual_grading=False).count()
-        )
-        total = float(mock_test.total_marks) or 0
-        attempt.percentage = max(0, (float(attempt.marks_obtained) / total) * 100) if total > 0 else 0
-
-        pending_manual = item_qs.filter(needs_manual_grading=True).exists()
-        attempt.grading_status = 'pending_manual' if pending_manual else 'auto_graded'
-        attempt.status = 'completed'
-        attempt.completed_at = timezone.now()
-        attempt.time_taken_seconds = time_taken
-        attempt.save()
-
-        # XP only when fully auto-graded and first completion. Manual-grading
-        # attempts get XP finalized after admin grading (later phase).
-        awarded_xp = 0
-        if not pending_manual:
-            already = MockTestAttempt.objects.filter(
-                student=student, mock_test=mock_test, status='completed'
-            ).exclude(id=attempt.id).exists()
-            if not already:
-                awarded_xp = calculate_xp_for_quiz(
-                    attempt.percentage, attempt.total_questions, is_daily_challenge=False
-                ) * 2
-                attempt.xp_earned = awarded_xp
-                attempt.save(update_fields=['xp_earned'])
-                GamificationService.award_xp(
-                    student, awarded_xp, 'mock_complete',
-                    f'Completed mock test: {mock_test.title}', str(attempt.id),
-                )
-
-        # Stats
-        mock_test.total_attempts += 1
-        if attempt.marks_obtained > mock_test.highest_score:
-            mock_test.highest_score = attempt.marks_obtained
-        mock_test.save(update_fields=['total_attempts', 'highest_score'])
-
-        results_visible = (
-            mock_test.result_visibility == 'immediate' and not pending_manual
-        ) or mock_test.results_released
-
-        return Response({
-            'attempt': MockTestAttemptSerializer(attempt).data,
-            'grading_status': attempt.grading_status,
-            'results_visible': results_visible,
-            'pending_manual': pending_manual,
-        })
+        timing = self._attempt_timing(mock_test, attempt)
+        result = self._finalize_rich_attempt(
+            attempt, mock_test, student, timed_out=timing['expired'])
+        return Response(result)
 
     @action(detail=True, methods=['post'], throttle_classes=[QuizSubmitThrottle])
     def run_item(self, request, pk=None):

--- a/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
+++ b/frontend/exam-frontend/src/pages/MockTestBuilder.jsx
@@ -147,6 +147,11 @@ export default function MockTestBuilder() {
             </Field>
           </div>
 
+          <Field label="Attempts allowed" hint="1 = no re-attempts (default)">
+            <input type="number" min={1} value={form.max_attempts || 1}
+              onChange={(e) => set('max_attempts')(Math.max(1, Number(e.target.value) || 1))} className={inputCls} />
+          </Field>
+
           <Field label="Result visibility">
             <select value={form.result_visibility} onChange={(e) => set('result_visibility')(e.target.value)} className={inputCls}>
               <option value="immediate">Show results on submission</option>

--- a/frontend/exam-frontend/src/pages/RichMockAttempt.jsx
+++ b/frontend/exam-frontend/src/pages/RichMockAttempt.jsx
@@ -17,7 +17,10 @@ export default function RichMockAttempt() {
   const { testId } = useParams()
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
+  const [phase, setPhase] = useState('instructions') // 'instructions' | 'attempt'
+  const [starting, setStarting] = useState(false)
   const [meta, setMeta] = useState(null)
+  const [paperInfo, setPaperInfo] = useState(null)  // attempts/limits/active id
   const [questions, setQuestions] = useState([])
   const [attemptId, setAttemptId] = useState(null)
   const [current, setCurrent] = useState(0)
@@ -31,22 +34,25 @@ export default function RichMockAttempt() {
   const containerRef = useRef(null)
   const startedRef = useRef(Date.now())
   const submittedRef = useRef(false)
+  const expiryRef = useRef(null)   // absolute deadline in client-clock ms
 
-  /* ------------------------- start attempt ------------------------- */
+  /* ------------------- load paper (no attempt created yet) ------------------- */
   useEffect(() => {
     let alive = true
     ;(async () => {
       try {
         const paper = await mockTestBuilderService.getPaper(testId)
-        const started = await mockTestBuilderService.startRich(testId)
         if (!alive) return
-        const mtMeta = paper.mock_test
-        setMeta({ mock_test: mtMeta })
-        setQuestions(started.questions || paper.questions || [])
-        setAttemptId(started.attempt?.id)
-        setRemaining((mtMeta.duration_minutes || 60) * 60)
+        setMeta({ mock_test: paper.mock_test })
+        setQuestions(paper.questions || [])
+        setPaperInfo({
+          active_attempt_id: paper.active_attempt_id || null,
+          attempts_used: paper.attempts_used ?? 0,
+          attempts_remaining: paper.attempts_remaining ?? null,
+          can_start: paper.can_start !== false,
+        })
       } catch (e) {
-        const msg = e?.response?.data?.error || 'Could not start this test.'
+        const msg = e?.response?.data?.error || 'Could not load this test.'
         toast.error(msg)
         navigate('/mock-test')
       } finally {
@@ -58,6 +64,56 @@ export default function RichMockAttempt() {
 
   const mt = meta?.mock_test
 
+  /* --------------- convert server saved answers into UI state --------------- */
+  const restoreAnswers = useCallback((saved) => {
+    if (!saved || typeof saved !== 'object') return
+    const next = {}
+    const nextFlags = {}
+    Object.entries(saved).forEach(([key, v]) => {
+      const entry = {}
+      if (Array.isArray(v.selected)) entry.selected = v.selected
+      if (v.numerical_answer != null) entry.numerical_answer = v.numerical_answer
+      if (v.answer_text != null) entry.answer_text = v.answer_text
+      if (v.code != null) entry.code = v.code
+      if (v.language != null) entry.language = v.language
+      next[key] = entry
+      if (v.is_marked_for_review) nextFlags[key] = true
+    })
+    setAnswers(next)
+    setFlagged(nextFlags)
+  }, [])
+
+  /* --------------- start (or resume) the attempt on user action --------------- */
+  const beginAttempt = useCallback(async () => {
+    setStarting(true)
+    try {
+      const started = await mockTestBuilderService.startRich(testId)
+      if (started.expired) {
+        toast('Your previous attempt timed out and was submitted.', { icon: '⏰' })
+        navigate(`/mock-test/live-review/${started.attempt_id}`)
+        return
+      }
+      setQuestions(started.questions || questions)
+      setAttemptId(started.attempt?.id)
+      if (started.resumed) restoreAnswers(started.saved_answers)
+      // Anchor the timer to the server clock so a closed tab never pauses it.
+      const t = started.timing
+      if (t) {
+        const offset = Date.now() - Date.parse(t.server_now)
+        expiryRef.current = Date.parse(t.expires_at) + offset
+      } else {
+        expiryRef.current = Date.now() + (mt?.duration_minutes || 60) * 60000
+      }
+      startedRef.current = Date.now()
+      setRemaining(Math.max(0, Math.round((expiryRef.current - Date.now()) / 1000)))
+      setPhase('attempt')
+    } catch (e) {
+      toast.error(e?.response?.data?.error || 'Could not start this test.')
+    } finally {
+      setStarting(false)
+    }
+  }, [testId, navigate, questions, restoreAnswers, mt])
+
   /* ------------------------- fullscreen ------------------------- */
   const enterFullscreen = useCallback(() => {
     const el = containerRef.current
@@ -65,28 +121,30 @@ export default function RichMockAttempt() {
   }, [])
 
   useEffect(() => {
-    if (!mt?.fullscreen_required || loading || result) return
+    if (!mt?.fullscreen_required || phase !== 'attempt' || result) return
     enterFullscreen()
-  }, [mt, loading, result, enterFullscreen])
+  }, [mt, phase, result, enterFullscreen])
 
-  /* ------------------------- timer ------------------------- */
+  /* ------------------------- timer (server-anchored) ------------------------- */
   useEffect(() => {
-    if (loading || result) return
-    const id = setInterval(() => {
-      setRemaining((r) => {
-        if (r <= 1) { clearInterval(id); handleSubmit(true); return 0 }
-        return r - 1
-      })
-    }, 1000)
+    if (phase !== 'attempt' || result) return
+    const tick = () => {
+      const secs = expiryRef.current
+        ? Math.max(0, Math.round((expiryRef.current - Date.now()) / 1000))
+        : 0
+      setRemaining(secs)
+      if (secs <= 0) { clearInterval(id); handleSubmit(true) }
+    }
+    const id = setInterval(tick, 1000)
     return () => clearInterval(id)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, result])
+  }, [phase, result])
 
   /* ------------------- proctoring: tab-switch / fullscreen exit ------------------- */
   useEffect(() => {
-    if (loading || result) return
+    if (phase !== 'attempt' || result) return
     const onVisibility = () => {
-      if (document.hidden) bumpViolation()
+      if (document.hidden) { bumpViolation(); autosave() }
     }
     const onFsChange = () => {
       if (mt?.fullscreen_required && !document.fullscreenElement && !submittedRef.current) {
@@ -100,7 +158,28 @@ export default function RichMockAttempt() {
       document.removeEventListener('fullscreenchange', onFsChange)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, result, mt])
+  }, [phase, result, mt])
+
+  /* ------------------------- autosave (survives tab close) ------------------------- */
+  const savingRef = useRef(false)
+  const autosave = useCallback(async () => {
+    if (phase !== 'attempt' || result || submittedRef.current || savingRef.current) return
+    savingRef.current = true
+    try {
+      const p = buildPayload()
+      const r = await mockTestBuilderService.saveRich(testId, {
+        bank_answers: p.bank_answers, item_answers: p.item_answers,
+      })
+      if (r?.expired) { submittedRef.current = true; setResult(r) }
+    } catch { /* best-effort */ } finally { savingRef.current = false }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, result, testId])
+
+  useEffect(() => {
+    if (phase !== 'attempt' || result) return
+    const id = setInterval(() => { autosave() }, 15000)
+    return () => clearInterval(id)
+  }, [phase, result, autosave])
 
   const bumpViolation = () => {
     setViolations((v) => v + 1)
@@ -217,6 +296,65 @@ export default function RichMockAttempt() {
 
   const lowTime = remaining < 60
 
+  /* ------------------------- instructions screen ------------------------- */
+  if (phase === 'instructions') {
+    const hasResume = !!paperInfo?.active_attempt_id
+    const remainingAttempts = paperInfo?.attempts_remaining
+    const blocked = !hasResume && paperInfo?.can_start === false
+    const deadlinePassed = mt?.start_deadline && new Date(mt.start_deadline) < new Date()
+    const startBlocked = !hasResume && (blocked || deadlinePassed)
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4 bg-surface-50 dark:bg-surface-950">
+        <div className="max-w-lg w-full bg-white dark:bg-surface-900 rounded-3xl shadow-xl p-8">
+          <h1 className="text-2xl font-bold mb-1 text-surface-900 dark:text-white">{mt?.title}</h1>
+          <p className="text-surface-500 mb-6">Please read the instructions carefully before you begin.</p>
+
+          <div className="grid grid-cols-2 gap-3 mb-6 text-sm">
+            <Info label="Duration" value={`${mt?.duration_minutes || 0} min`} />
+            <Info label="Total marks" value={Number(mt?.total_marks || 0)} />
+            <Info label="Questions" value={questions.length} />
+            <Info label="Negative marking" value={mt?.negative_marking ? 'Yes' : 'No'} />
+            {typeof remainingAttempts === 'number' && (
+              <Info label="Attempts left" value={`${remainingAttempts} of ${mt?.max_attempts ?? 1}`} />
+            )}
+            {mt?.start_deadline && (
+              <Info label="Start before" value={new Date(mt.start_deadline).toLocaleString()} />
+            )}
+          </div>
+
+          <ul className="space-y-2 text-sm text-surface-600 dark:text-surface-300 mb-6 list-disc pl-5">
+            <li>The timer starts as soon as you begin and <strong>keeps running even if you close the tab</strong>.</li>
+            <li>If you leave, you can return and <strong>resume</strong> — but the clock will not pause.</li>
+            <li>When the time is up, your test is submitted automatically.</li>
+            {mt?.fullscreen_required && <li>The test runs in <strong>fullscreen</strong>. Leaving fullscreen or switching tabs is recorded.</li>}
+            <li>Your answers are saved automatically as you go.</li>
+            {(mt?.max_attempts ?? 1) <= 1
+              ? <li>Only <strong>one attempt</strong> is allowed — you cannot re-take this test.</li>
+              : <li>You are allowed <strong>{mt?.max_attempts} attempts</strong> in total.</li>}
+          </ul>
+
+          {startBlocked ? (
+            <div className="rounded-xl bg-rose-50 dark:bg-rose-900/20 text-rose-700 dark:text-rose-300 px-4 py-3 text-sm mb-4">
+              {deadlinePassed ? 'The window to start this test has closed.' : 'You have used all your allowed attempts for this test.'}
+            </div>
+          ) : null}
+
+          <div className="flex gap-3">
+            <button onClick={() => navigate('/mock-test')}
+              className="flex-1 px-4 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 font-medium">
+              Cancel
+            </button>
+            <button onClick={beginAttempt} disabled={starting || (startBlocked && !hasResume)}
+              className="flex-1 px-4 py-2.5 rounded-xl bg-primary-600 hover:bg-primary-700 disabled:opacity-50 text-white font-medium flex items-center justify-center gap-2">
+              {starting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+              {hasResume ? 'Resume test' : 'Start test'}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div ref={containerRef} className="min-h-screen bg-surface-50 dark:bg-surface-950 flex flex-col">
       {/* top bar */}
@@ -328,6 +466,16 @@ export default function RichMockAttempt() {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+/* ------------------------- small info tile ------------------------- */
+function Info({ label, value }) {
+  return (
+    <div className="rounded-xl bg-surface-50 dark:bg-surface-800/60 px-3 py-2">
+      <p className="text-[11px] uppercase tracking-wide text-surface-400">{label}</p>
+      <p className="font-semibold text-surface-800 dark:text-surface-100">{value}</p>
     </div>
   )
 }

--- a/frontend/exam-frontend/src/services/mockTestBuilderService.js
+++ b/frontend/exam-frontend/src/services/mockTestBuilderService.js
@@ -64,6 +64,8 @@ export const mockTestBuilderService = {
     (await api.post(`/quiz/mock-tests/${testId}/start_rich/`)).data,
   submitRich: async (testId, data) =>
     (await api.post(`/quiz/mock-tests/${testId}/submit_rich/`, data)).data,
+  saveRich: async (testId, data) =>
+    (await api.post(`/quiz/mock-tests/${testId}/save_rich/`, data)).data,
   runCode: async (testId, payload) =>
     (await api.post(`/quiz/mock-tests/${testId}/run_item/`, payload)).data,
   richReview: async (attemptId) =>


### PR DESCRIPTION
## What & why

Adds a professional pre-test flow to the rich Mock Test system so students don't start accidentally, can't cheat the clock by closing the tab, and are governed by an admin-set attempt limit.

### Admin
- **New per-test setting "Attempts allowed"** (`MockTest.max_attempts`, default **1** = no re-attempts). Editable in the Mock Test builder settings.

### Student attempt flow
- **Instructions screen before the test starts** — shows duration, marks, #questions, negative marking, attempts remaining, start deadline, and the rules. The attempt is only created when the student clicks **Start** (no more accidental starts on page load).
- **Server-authoritative timer** anchored to `started_at` in the DB — it keeps running even if the tab is closed. Returning shows **Resume**; the clock never pauses.
- **Auto-submit on expiry**: if a student never returns before time runs out, the attempt is finalized server-side (graded, marked `timed_out`) and they're routed to the review.
- **Autosave** every 15s and when the tab is hidden (new `save_rich` action, stores answers ungraded). Saved answers are **restored on resume**.
- **Attempt-limit enforcement**: a fresh start is blocked with a clear message once `max_attempts` completed/timed-out attempts are used (resuming an in-progress attempt is always allowed).

## Backend
- `MockTest.max_attempts` field + migration `0011_mocktest_max_attempts`.
- `views.py`: extracted `_finalize_rich_attempt` (reused by submit + expiry), added `_upsert_rich_answers`, `_saved_answers`, `_attempt_timing` helpers; new `save_rich` action; `start_rich` now enforces the cap, resumes with `server_now`/`expires_at`/saved answers, and finalizes expired attempts; `submit_rich` computes `time_taken_seconds` server-side; `paper` exposes timing + attempt counts.
- Serializers expose `max_attempts` (admin writable) and attempt-status (used/remaining/can_start/active id) to students.

## Verification
- `npm run build` passes.
- VM `manage.py check` clean; `makemigrations quiz --check --dry-run` reports no missing migrations.

Requires a backend deploy + migrate after merge.