### PR TITLE
Fix: mock tests hidden unless matching last-used course

### DIFF
--- a/frontend/exam-frontend/src/pages/MockTest.jsx
+++ b/frontend/exam-frontend/src/pages/MockTest.jsx
@@ -26,9 +26,11 @@ const MockTest = () => {
   const isAdmin = (user?.role || profile?.user?.role) === 'admin'
   const [showFilters, setShowFilters] = useState(false)
 
-  // Filter state
+  // Filter state. Course defaults to '' (All courses) so mock tests from every
+  // enrolled course are visible by default — otherwise a test created in a
+  // course other than the last-used one stays hidden until manually selected.
   const [filters, setFilters] = useState({
-    course: localStorage.getItem('study:lastCourseId') || '',
+    course: '',
     attempted: '', // '', 'true', 'false'
     is_free: '',
     search: '',
@@ -59,16 +61,8 @@ const MockTest = () => {
     queryFn: () => quizService.getMockAttempts(),
   })
 
-  // Default the exam to the shared selection (or first available) and persist it.
-  useEffect(() => {
-    const exams = filterOptions?.courses
-    if (!exams?.length) return
-    const isValid = (id) => id && exams.some((e) => e.id === id)
-    if (isValid(filters.course)) return
-    const stored = localStorage.getItem('study:lastCourseId')
-    setFilters((prev) => ({ ...prev, course: (isValid(stored) && stored) || exams[0].id }))
-  }, [filterOptions?.courses, filters.course])
-
+  // Persist a specific course selection for cross-page context, but never force
+  // one — an empty selection ("All courses") is a valid, respected state.
   useEffect(() => {
     if (filters.course) localStorage.setItem('study:lastCourseId', filters.course)
   }, [filters.course])
@@ -220,6 +214,15 @@ const MockTest = () => {
               <div>
                 <label className="block text-sm font-medium mb-2">Course</label>
                 <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={() => updateFilter('course', '')}
+                    className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${filters.course === ''
+                      ? 'bg-primary-500 text-white'
+                      : 'bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700'
+                      }`}
+                  >
+                    All courses
+                  </button>
                   {filterOptions?.courses?.map((course) => (
                     <button
                       key={course.id}


### PR DESCRIPTION
## Problem
A newly created mock test (e.g. **Mathematics — Class XI PCM Mock Test 1**) did not appear on the student Mock Tests page, even though the viewer is enrolled in that course and the test is published.

## Root cause
`MockTest.jsx` **always** applied a course filter:
- `filters.course` defaulted to `localStorage['study:lastCourseId']` (the last course used elsewhere, e.g. Python), and
- an effect force-selected the first course whenever the selection was empty, and
- there was **no "All courses" option**.

So the list only ever showed one course's tests at a time. A test created in any other enrolled course was invisible until the user manually switched — which isn't discoverable.

## Fix (frontend only)
- Default the course filter to `''` (**All courses**) so tests from every enrolled course show by default.
- Add an **"All courses"** chip to the course filter.
- Remove the effect that force-selected a course; `''` is now a valid, respected state. An explicit course choice is still persisted to `study:lastCourseId` for cross-page context.

## Verification
- API confirmed: unscoped list returns both the Math and Python mocks; `?course=<Class XI PCM>` returns just the Math one.
- `npm run build` passes.

Frontend-only → Netlify auto-deploy. No backend change (access scoping already correct).