### PR TITLE
Don't show mock-test score until fully graded

### DIFF
--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -195,8 +195,21 @@ class MockTestSerializer(serializers.ModelSerializer):
             can_reattempt = attempts_used < max_attempts
 
             completed = finished.filter(status='completed')
-            best_attempt = completed.order_by('-percentage').first()
+
+            # A score should only surface once an attempt is fully graded AND its
+            # results are visible — otherwise a partial (auto-only) percentage
+            # would misrepresent an attempt still awaiting manual grading.
+            results_visible = (obj.result_visibility == 'immediate') or obj.results_released
+            def scorable(a):
+                return a.grading_status in ('auto_graded', 'graded') and results_visible
+
+            scored = [a for a in completed if scorable(a)]
+            best_attempt = max(scored, key=lambda a: a.percentage) if scored else None
+            latest_completed = completed.first()  # ordered by -completed_at
             latest_attempt = finished.first()
+            # Review target: prefer the best scored attempt, else the latest one.
+            review_attempt = best_attempt or latest_completed or latest_attempt
+            has_score = best_attempt is not None
 
             if not finished.exists() and not active:
                 return {
@@ -214,10 +227,15 @@ class MockTestSerializer(serializers.ModelSerializer):
                 'max_attempts': max_attempts,
                 'can_reattempt': can_reattempt,
                 'active_attempt_id': str(active.id) if active else None,
-                'best_score': float(best_attempt.percentage) if best_attempt else 0,
-                'best_attempt_id': str(best_attempt.id) if best_attempt else None,
+                # Score fields are populated only when a fully-graded, visible
+                # result exists. `results_pending` lets the UI show an
+                # "awaiting grading" state instead of a misleading percentage.
+                'has_score': has_score,
+                'results_pending': completed.exists() and not has_score,
+                'best_score': float(best_attempt.percentage) if has_score else None,
+                'best_attempt_id': str(review_attempt.id) if review_attempt else None,
                 'latest_attempt_id': str(latest_attempt.id) if latest_attempt else None,
-                'latest_score': float(latest_attempt.percentage) if latest_attempt else 0,
+                'latest_score': float(latest_completed.percentage) if has_score and latest_completed else None,
                 'latest_date': latest_attempt.completed_at.isoformat() if latest_attempt and latest_attempt.completed_at else None,
                 'rank': best_attempt.rank if best_attempt else None,
                 'percentile': float(best_attempt.percentile) if best_attempt and best_attempt.percentile else None,

--- a/frontend/exam-frontend/src/pages/MockTest.jsx
+++ b/frontend/exam-frontend/src/pages/MockTest.jsx
@@ -356,12 +356,15 @@ const MockTest = () => {
                   <div>
                     <div className="flex items-center gap-2 mb-2">
                       <span className="badge-primary">{test.course_name}</span>
-                      {hasAttempted && (
+                      {hasAttempted && attemptInfo.has_score && (
                         <span className={`badge ${attemptInfo.best_score >= 70 ? 'badge-success' :
                           attemptInfo.best_score >= 40 ? 'badge-warning' : 'badge-error'
                           }`}>
                           Best: {Math.round(attemptInfo.best_score)}%
                         </span>
+                      )}
+                      {hasAttempted && !attemptInfo.has_score && attemptInfo.results_pending && (
+                        <span className="badge badge-warning">Awaiting grading</span>
                       )}
                     </div>
                     <h3 className="text-lg font-semibold">{test.title}</h3>


### PR DESCRIPTION
## Problem
The Mock Tests card showed **"Best: 55%"** for an attempt that was still **awaiting manual grading** (it has a subjective question). That 55% is only the auto-graded portion, so it misrepresents the real result — the review screen correctly says "Your attempt is awaiting grading."

## Fix
**Backend (`serializers.py`, `get_user_attempt_info`):** a score is now only surfaced when an attempt is **fully graded** (`grading_status` in `auto_graded`/`graded`) **and** its results are visible (`immediate` or released). New fields:
- `has_score` — a final, visible score exists
- `results_pending` — attempted but score not yet available
- score/rank/percentile are `null` while pending; the review target (`best_attempt_id`) falls back to the latest attempt so **View Result** still works.

**Frontend (`MockTest.jsx`):** the "Best: X%" badge renders only when `has_score`; otherwise an **"Awaiting grading"** pill is shown.

## Verification
- `npm run build` passes; serializer compiles; VM `manage.py check` clean.

Requires a backend deploy (git pull + restart web; **no migration**).