### PR TITLE
Add course-scoped community forum posts

### DIFF
--- a/backend/community/migrations/0007_post_courses.py
+++ b/backend/community/migrations/0007_post_courses.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+def backfill_courses(apps, schema_editor):
+    """Copy each post's legacy single ``course`` into the new ``courses`` M2M."""
+    Post = apps.get_model('community', 'Post')
+    for post in Post.objects.exclude(course__isnull=True).iterator():
+        post.courses.add(post.course_id)
+
+
+def unbackfill_courses(apps, schema_editor):
+    Post = apps.get_model('community', 'Post')
+    for post in Post.objects.iterator():
+        post.courses.clear()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exams', '0007_rename_exam_to_course'),
+        ('community', '0006_alter_post_course_metadata'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='post',
+            name='courses',
+            field=models.ManyToManyField(
+                blank=True,
+                related_name='linked_community_posts',
+                to='exams.course',
+            ),
+        ),
+        migrations.RunPython(backfill_courses, unbackfill_courses),
+    ]

--- a/backend/community/models.py
+++ b/backend/community/models.py
@@ -36,11 +36,23 @@ class Post(TimeStampedModel):
     )
     
     # Categorization
+    # Legacy single-course link (kept for backward compatibility). New posts use
+    # the ``courses`` M2M below; a post may belong to one or more courses.
     course = models.ForeignKey(
         Course,
         on_delete=models.SET_NULL,
         null=True, blank=True,
         related_name='community_posts'
+    )
+    # A post can be scoped to one or more courses. If no course is linked (this
+    # M2M is empty AND the legacy ``course`` FK is null) the post is global and
+    # visible to every user in the tenant. When course(s) are linked, only users
+    # enrolled in at least one of those courses (plus the author and
+    # admins/instructors) may see the post.
+    courses = models.ManyToManyField(
+        Course,
+        blank=True,
+        related_name='linked_community_posts'
     )
     subject = models.ForeignKey(
         Subject,

--- a/backend/community/serializers.py
+++ b/backend/community/serializers.py
@@ -8,6 +8,7 @@ from .models import (
 )
 from .services import ContentModerationService
 from users.serializers import UserSerializer
+from exams.models import Course
 
 
 class AuthorSerializer(serializers.Serializer):
@@ -151,12 +152,13 @@ class PostSerializer(serializers.ModelSerializer):
     is_liked = serializers.SerializerMethodField()
     user_poll_vote = serializers.SerializerMethodField()
     top_comments = serializers.SerializerMethodField()
-    
+    courses = serializers.SerializerMethodField()
+
     class Meta:
         model = Post
         fields = [
             'id', 'post_type', 'title', 'content', 'image', 'author',
-            'course', 'subject', 'tags',
+            'course', 'courses', 'subject', 'tags',
             'likes_count', 'comments_count', 'views_count',
             'is_solved', 'best_answer', 'status',
             'poll_options', 'quiz', 'is_liked', 'user_poll_vote',
@@ -166,7 +168,17 @@ class PostSerializer(serializers.ModelSerializer):
             'id', 'author', 'likes_count', 'comments_count', 'views_count',
             'is_solved', 'best_answer', 'created_at', 'updated_at'
         ]
-    
+
+    def get_courses(self, obj):
+        """Linked courses (M2M), falling back to the legacy single course FK."""
+        linked = list(obj.courses.all())
+        if not linked and obj.course_id:
+            linked = [obj.course]
+        return [
+            {'id': str(c.id), 'name': c.name, 'code': c.code}
+            for c in linked
+        ]
+
     def get_is_liked(self, obj):
         request = self.context.get('request')
         if not request or not request.user.is_authenticated:
@@ -198,15 +210,50 @@ class PostCreateSerializer(serializers.ModelSerializer):
         write_only=True
     )
     quiz_data = serializers.JSONField(required=False, write_only=True)
-    
+    courses = serializers.PrimaryKeyRelatedField(
+        many=True,
+        required=False,
+        queryset=Course.objects.all(),
+    )
+
     class Meta:
         model = Post
         fields = [
-            'post_type', 'title', 'content', 'image', 'course', 'subject', 'tags',
-            'poll_options', 'quiz_data'
+            'post_type', 'title', 'content', 'image', 'course', 'courses',
+            'subject', 'tags', 'poll_options', 'quiz_data'
         ]
 
-    
+    def validate_courses(self, value):
+        """Students may only link courses they are actively enrolled in.
+
+        Admins/instructors can link any course in their tenant.
+        """
+        request = self.context.get('request')
+        user = getattr(request, 'user', None)
+        if not value or user is None:
+            return value
+
+        role = getattr(user, 'role', None)
+        is_staff = role in ('admin', 'instructor') or getattr(user, 'is_staff', False)
+        if is_staff:
+            return value
+
+        try:
+            enrolled_ids = set(
+                user.profile.enrollments.filter(
+                    status='approved', is_active=True
+                ).values_list('course_id', flat=True)
+            )
+        except Exception:
+            enrolled_ids = set()
+
+        invalid = [c for c in value if c.id not in enrolled_ids]
+        if invalid:
+            raise serializers.ValidationError(
+                'You can only post to courses you are enrolled in.'
+            )
+        return value
+
     def validate(self, data):
         # Validate content for profanity
         result = ContentModerationService.validate_content(
@@ -249,10 +296,14 @@ class PostCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         poll_options = validated_data.pop('poll_options', [])
         quiz_data = validated_data.pop('quiz_data', None)
-        
+        courses = validated_data.pop('courses', [])
+
         validated_data['author'] = self.context['request'].user.profile
         post = super().create(validated_data)
-        
+
+        # Link course(s) for course-scoped visibility. Empty => global post.
+        if courses:
+            post.courses.set(courses)
         # Create poll options
         if poll_options:
             for i, option_text in enumerate(poll_options):

--- a/backend/community/views.py
+++ b/backend/community/views.py
@@ -5,7 +5,7 @@ from rest_framework import viewsets, status, mixins
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-from django.db.models import F
+from django.db.models import F, Q
 from django.shortcuts import get_object_or_404
 
 from .models import (
@@ -22,6 +22,47 @@ from .services import CommunityXPService, CommunityLeaderboardService
 from core.views import TenantAwareViewSet
 
 
+def _is_staff_user(user):
+    """Admins and instructors moderate/see every post in the tenant."""
+    role = getattr(user, 'role', None)
+    return role in ('admin', 'instructor') or getattr(user, 'is_staff', False)
+
+
+def _student_course_ids(user):
+    """IDs of every course the user is actively (approved) enrolled in."""
+    try:
+        profile = user.profile
+    except Exception:
+        return []
+    return list(
+        profile.enrollments.filter(
+            status='approved', is_active=True
+        ).values_list('course_id', flat=True)
+    )
+
+
+def accessible_posts_q(user):
+    """Q filtering the posts a user is allowed to see.
+
+    - Post has no course links (legacy ``course`` null AND ``courses`` empty)
+      -> global, visible to everyone in the tenant.
+    - Post is linked to one or more courses -> visible only if the user is
+      enrolled in at least one of them.
+    - The author always sees their own posts.
+    Admins/instructors bypass this entirely (handled by the caller).
+    """
+    global_q = Q(course__isnull=True) & Q(courses__isnull=True)
+    course_ids = _student_course_ids(user)
+    q = global_q
+    if course_ids:
+        q = q | Q(course__in=course_ids) | Q(courses__in=course_ids)
+    try:
+        q = q | Q(author=user.profile)
+    except Exception:
+        pass
+    return q
+
+
 class PostViewSet(TenantAwareViewSet):
     """
     ViewSet for community posts (questions, polls, quizzes).
@@ -31,21 +72,33 @@ class PostViewSet(TenantAwareViewSet):
     def get_queryset(self):
         queryset = Post.objects.filter(status='active').select_related(
             'author__user', 'course', 'subject'
-        ).prefetch_related('poll_options', 'quiz')
-        
+        ).prefetch_related('poll_options', 'quiz', 'courses')
+
+        # Course-scoped visibility: global posts are visible to all, but posts
+        # linked to course(s) are only visible to enrolled students (the author
+        # and admins/instructors always see them).
+        if not _is_staff_user(self.request.user):
+            queryset = queryset.filter(accessible_posts_q(self.request.user)).distinct()
+
         # Filters
         post_type = self.request.query_params.get('type')
         if post_type:
             queryset = queryset.filter(post_type=post_type)
-        
+
         course = self.request.query_params.get('course')
-        if course:
-            queryset = queryset.filter(course_id=course)
-        
+        if course == 'global':
+            # Only globally-visible posts (no course link at all).
+            queryset = queryset.filter(course__isnull=True, courses__isnull=True)
+        elif course:
+            # Posts linked to this course via either the M2M or the legacy FK.
+            queryset = queryset.filter(
+                Q(courses=course) | Q(course_id=course)
+            ).distinct()
+
         subject = self.request.query_params.get('subject')
         if subject:
             queryset = queryset.filter(subject_id=subject)
-        
+
         is_solved = self.request.query_params.get('is_solved')
         if is_solved is not None:
             queryset = queryset.filter(is_solved=is_solved.lower() == 'true')
@@ -69,7 +122,32 @@ class PostViewSet(TenantAwareViewSet):
         if self.action in ['create', 'update', 'partial_update']:
             return PostCreateSerializer
         return PostSerializer
-    
+
+    @action(detail=False, methods=['get'])
+    def filter_options(self, request):
+        """Courses the user can filter by / post into.
+
+        Students get their approved enrollments; admins/instructors get every
+        course in the tenant so they can moderate and post to any course.
+        """
+        from exams.models import Course
+
+        if _is_staff_user(request.user):
+            courses_qs = Course.objects.all()
+            if getattr(request, 'tenant', None):
+                courses_qs = courses_qs.filter(tenant=request.tenant)
+        else:
+            course_ids = _student_course_ids(request.user)
+            courses_qs = Course.objects.filter(id__in=course_ids)
+
+        courses = list(
+            courses_qs.values('id', 'name', 'code').order_by('name')
+        )
+        return Response({
+            'courses': courses,
+            'is_staff': _is_staff_user(request.user),
+        })
+
     def retrieve(self, request, *args, **kwargs):
         """Increment view count on retrieve."""
         instance = self.get_object()

--- a/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
+++ b/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { X, Plus, Trash2, HelpCircle, BarChart3, Zap, Image as ImageIcon, Camera } from 'lucide-react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { X, Plus, Trash2, HelpCircle, BarChart3, Zap, Image as ImageIcon, Camera, Users, BookOpen } from 'lucide-react'
 
 import { communityService } from '../../services/communityService'
 import toast from 'react-hot-toast'
@@ -15,6 +15,16 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
     const [tagInput, setTagInput] = useState('')
     const [imageFile, setImageFile] = useState(null)
     const [imagePreview, setImagePreview] = useState(null)
+    const [selectedCourses, setSelectedCourses] = useState([])
+
+    // Courses the current user can post into (enrolled courses for students;
+    // all tenant courses for admins/instructors).
+    const { data: filterOptions } = useQuery({
+        queryKey: ['communityFilterOptions'],
+        queryFn: () => communityService.getFilterOptions(),
+        enabled: isOpen,
+    })
+    const availableCourses = filterOptions?.courses || []
 
 
     // Poll state
@@ -58,6 +68,15 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
         setExplanation('')
         setImageFile(null)
         setImagePreview(null)
+        setSelectedCourses([])
+    }
+
+    const toggleCourse = (courseId) => {
+        setSelectedCourses((prev) =>
+            prev.includes(courseId)
+                ? prev.filter((id) => id !== courseId)
+                : [...prev, courseId]
+        )
     }
 
     const handleImageChange = (e) => {
@@ -117,6 +136,7 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
             submitData.append('image', imageFile)
         }
         tags.forEach(tag => submitData.append('tags', tag))
+        selectedCourses.forEach(courseId => submitData.append('courses', courseId))
 
         if (type === 'poll') {
             const validOptions = pollOptions.filter(o => o.trim())
@@ -270,6 +290,46 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
                             </div>
                         </div>
 
+
+                        {/* Course Visibility */}
+                        <div>
+                            <label className="block text-sm font-medium mb-2 flex items-center gap-2">
+                                <BookOpen size={16} />
+                                Post to Course(s)
+                            </label>
+                            {availableCourses.length > 0 ? (
+                                <>
+                                    <div className="flex flex-wrap gap-2">
+                                        {availableCourses.map((course) => {
+                                            const active = selectedCourses.includes(course.id)
+                                            return (
+                                                <button
+                                                    key={course.id}
+                                                    type="button"
+                                                    onClick={() => toggleCourse(course.id)}
+                                                    className={`px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all ${active
+                                                        ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20 text-primary-600'
+                                                        : 'border-surface-200 dark:border-surface-700 text-surface-600 hover:border-surface-300'
+                                                        }`}
+                                                >
+                                                    {course.name}
+                                                </button>
+                                            )
+                                        })}
+                                    </div>
+                                    <p className="text-xs text-surface-500 mt-2 flex items-center gap-1">
+                                        <Users size={12} />
+                                        {selectedCourses.length === 0
+                                            ? 'No course selected — visible to everyone in the community.'
+                                            : 'Only students enrolled in the selected course(s) will see this post.'}
+                                    </p>
+                                </>
+                            ) : (
+                                <p className="text-xs text-surface-500">
+                                    You are not enrolled in any course yet. This post will be visible to everyone.
+                                </p>
+                            )}
+                        </div>
 
                         {/* Poll Options */}
                         {type === 'poll' && (

--- a/frontend/exam-frontend/src/components/community/PostCard.jsx
+++ b/frontend/exam-frontend/src/components/community/PostCard.jsx
@@ -1,7 +1,7 @@
 import { motion } from 'framer-motion'
 import {
     MessageCircle, ThumbsUp, Eye, CheckCircle,
-    BarChart3, Zap, Clock, User, BadgeCheck
+    BarChart3, Zap, Clock, User, BadgeCheck, BookOpen, Globe
 } from 'lucide-react'
 
 const PostCard = ({ post, onLike, onClick }) => {
@@ -79,10 +79,36 @@ const PostCard = ({ post, onLike, onClick }) => {
                     </div>
                 </div>
 
-                {/* Type Badge */}
-                <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${config.color}`}>
-                    <TypeIcon size={12} />
-                    {config.label}
+                {/* Type + Course Badges */}
+                <div className="flex flex-col items-end gap-1.5">
+                    <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${config.color}`}>
+                        <TypeIcon size={12} />
+                        {config.label}
+                    </div>
+                    {post.courses && post.courses.length > 0 ? (
+                        <div className="flex flex-wrap justify-end gap-1">
+                            {post.courses.slice(0, 2).map((c) => (
+                                <span
+                                    key={c.id}
+                                    className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary-50 dark:bg-primary-900/20 text-primary-600 border border-primary-200 dark:border-primary-800"
+                                    title={c.name}
+                                >
+                                    <BookOpen size={11} />
+                                    <span className="max-w-[120px] truncate">{c.name}</span>
+                                </span>
+                            ))}
+                            {post.courses.length > 2 && (
+                                <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-surface-100 dark:bg-surface-700 text-surface-500">
+                                    +{post.courses.length - 2}
+                                </span>
+                            )}
+                        </div>
+                    ) : (
+                        <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-surface-100 dark:bg-surface-700 text-surface-500">
+                            <Globe size={11} />
+                            Everyone
+                        </span>
+                    )}
                 </div>
             </div>
 

--- a/frontend/exam-frontend/src/pages/Community.jsx
+++ b/frontend/exam-frontend/src/pages/Community.jsx
@@ -5,7 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
     MessageCircle, MessageSquare, ThumbsUp, Eye, CheckCircle,
     Plus, Filter, TrendingUp, Clock, HelpCircle,
-    BarChart3, Zap, Trophy, Users
+    BarChart3, Zap, Trophy, Users, BookOpen, Globe
 } from 'lucide-react'
 import { communityService } from '../services/communityService'
 import Loading from '../components/common/Loading'
@@ -19,16 +19,25 @@ const Community = () => {
     const queryClient = useQueryClient()
     const [activeTab, setActiveTab] = useState('all')
     const [sortBy, setSortBy] = useState('recent')
+    const [courseFilter, setCourseFilter] = useState('all')
     const [showCreateModal, setShowCreateModal] = useState(false)
     const [createType, setCreateType] = useState('question')
 
+    // Courses the user belongs to (for scoping the forum by course).
+    const { data: filterOptions } = useQuery({
+        queryKey: ['communityFilterOptions'],
+        queryFn: () => communityService.getFilterOptions()
+    })
+    const courses = filterOptions?.courses || []
+
     // Fetch posts
     const { data: postsData, isLoading: postsLoading } = useQuery({
-        queryKey: ['communityPosts', activeTab, sortBy],
+        queryKey: ['communityPosts', activeTab, sortBy, courseFilter],
         queryFn: () => communityService.getPosts({
             type: activeTab === 'all' ? undefined : activeTab,
             sort: sortBy,
-            my_posts: activeTab === 'my_posts' ? 'true' : undefined
+            my_posts: activeTab === 'my_posts' ? 'true' : undefined,
+            course: courseFilter === 'all' ? undefined : courseFilter
         })
     })
 
@@ -176,6 +185,44 @@ const Community = () => {
                                 </button>
                             ))}
                         </div>
+                    </div>
+
+                    {/* Course Filter */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <BookOpen size={16} className="text-surface-500" />
+                        <span className="text-sm text-surface-500">Course:</span>
+                        <button
+                            onClick={() => setCourseFilter('all')}
+                            className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-all ${courseFilter === 'all'
+                                ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600'
+                                : 'text-surface-500 hover:bg-surface-100 dark:hover:bg-surface-800'
+                                }`}
+                        >
+                            <Users size={14} />
+                            All
+                        </button>
+                        <button
+                            onClick={() => setCourseFilter('global')}
+                            className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-all ${courseFilter === 'global'
+                                ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600'
+                                : 'text-surface-500 hover:bg-surface-100 dark:hover:bg-surface-800'
+                                }`}
+                        >
+                            <Globe size={14} />
+                            Everyone
+                        </button>
+                        {courses.map((course) => (
+                            <button
+                                key={course.id}
+                                onClick={() => setCourseFilter(course.id)}
+                                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-all ${courseFilter === course.id
+                                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600'
+                                    : 'text-surface-500 hover:bg-surface-100 dark:hover:bg-surface-800'
+                                    }`}
+                            >
+                                {course.name}
+                            </button>
+                        ))}
                     </div>
 
                     {/* Sort Options */}

--- a/frontend/exam-frontend/src/pages/CommunityPost.jsx
+++ b/frontend/exam-frontend/src/pages/CommunityPost.jsx
@@ -5,7 +5,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
     ArrowLeft, ThumbsUp, MessageCircle, Eye, Share2,
     CheckCircle, Clock, BarChart3, Zap, Trophy, Send,
-    BadgeCheck, Camera, Image as ImageIcon, X
+    BadgeCheck, Camera, Image as ImageIcon, X, BookOpen, Globe
 } from 'lucide-react'
 
 import { communityService } from '../services/communityService'
@@ -241,6 +241,26 @@ const CommunityPost = () => {
 
                 {/* Title */}
                 <h1 className="text-2xl font-bold mb-4">{post.title}</h1>
+
+                {/* Course Visibility */}
+                <div className="flex flex-wrap items-center gap-2 mb-4">
+                    {post.courses && post.courses.length > 0 ? (
+                        post.courses.map((c) => (
+                            <span
+                                key={c.id}
+                                className="flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-primary-50 dark:bg-primary-900/20 text-primary-600 border border-primary-200 dark:border-primary-800"
+                            >
+                                <BookOpen size={12} />
+                                {c.name}
+                            </span>
+                        ))
+                    ) : (
+                        <span className="flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium bg-surface-100 dark:bg-surface-700 text-surface-500">
+                            <Globe size={12} />
+                            Visible to everyone
+                        </span>
+                    )}
+                </div>
 
                 {/* Content */}
                 <div className="prose dark:prose-invert max-w-none mb-6">

--- a/frontend/exam-frontend/src/services/communityService.js
+++ b/frontend/exam-frontend/src/services/communityService.js
@@ -10,6 +10,11 @@ export const communityService = {
         return response.data
     },
 
+    getFilterOptions: async () => {
+        const response = await api.get('/community/posts/filter_options/')
+        return response.data
+    },
+
     getPost: async (id) => {
         const response = await api.get(`/community/posts/${id}/`)
         return response.data


### PR DESCRIPTION
## What & why

Extends the community forum so posts can be scoped to one or more courses, while keeping global (open-to-everyone) posts working.

### Behavior
- A post can be linked to **one or more courses** (new `courses` M2M on `Post`; legacy single-`course` FK kept and backfilled).
- **Course-linked posts** are visible only to students **enrolled** in at least one of those courses. The author and admins/instructors always see them.
- **Posts with no course link** are **global** — visible to everyone in the tenant.
- **Admins/instructors** get a blue **verified tick** beside their name (already present) and can post to / see any course.

### Backend
- `Post.courses` M2M + migration `0007_post_courses` (backfills from legacy `course`).
- `PostViewSet.get_queryset` now enforces course-scoped visibility via `accessible_posts_q`.
- New `GET /community/posts/filter_options/` returns the courses a user can post into / filter by (enrolled courses for students, all tenant courses for staff).
- `PostSerializer` exposes a `courses` list; `PostCreateSerializer` accepts `courses` IDs and validates that students only link courses they're enrolled in.

### Frontend
- **CreatePostModal**: multi-select of course chips ("no course selected → visible to everyone").
- **PostCard** & **CommunityPost**: course badge(s) at top right, or an "Everyone / Visible to everyone" badge for global posts.
- **Community** page: course filter row (All / Everyone / per-course).

### Verification
- `npm run build` ✅
- `py_compile` ✅
- VM `manage.py check` clean, `makemigrations --check` reports no missing migrations ✅

Deploy note: this PR includes migration `0007` — VM needs `migrate` + `restart web`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>