### PR TITLE
Fix laggy community Create Post modal (remove viewport backdrop-blur)

### DIFF
--- a/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
+++ b/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
@@ -183,13 +183,15 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+                transition={{ duration: 0.15 }}
+                className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
                 onClick={onClose}
             >
                 <motion.div
-                    initial={{ scale: 0.9, opacity: 0 }}
+                    initial={{ scale: 0.98, opacity: 0 }}
                     animate={{ scale: 1, opacity: 1 }}
-                    exit={{ scale: 0.9, opacity: 0 }}
+                    exit={{ scale: 0.98, opacity: 0 }}
+                    transition={{ duration: 0.15 }}
                     onClick={(e) => e.stopPropagation()}
                     className="bg-white dark:bg-surface-900 rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-2xl"
                 >


### PR DESCRIPTION
## Problem
The "Create New Post" modal on the Community page was very slow to open and to type in.

## Cause
The overlay used a full-viewport `backdrop-blur-sm`. The Community page keeps a DOM-heavy, animated post list (plus leaderboard) mounted behind the modal, so the browser had to **re-rasterize the entire blurred backdrop on every repaint** — including on each keystroke in the form. `backdrop-filter: blur()` over a large, busy page is a well-known input-lag source.

## Fix
- Replace `bg-black/50 backdrop-blur-sm` with a plain `bg-black/60` dim (no blur → no viewport re-rasterization).
- Use short, snappy `0.15s` open/close transitions and a smaller scale delta so the modal appears instantly.

Frontend-only; no backend/migration. Deploys via Netlify on merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>