### PR TITLE
Make community course filter/selector scalable (searchable dropdown)

### DIFF
--- a/frontend/exam-frontend/src/components/common/SearchableSelect.jsx
+++ b/frontend/exam-frontend/src/components/common/SearchableSelect.jsx
@@ -1,0 +1,138 @@
+import { useState, useRef, useEffect, useMemo } from 'react'
+import { Search, Check, ChevronDown } from 'lucide-react'
+
+/**
+ * A lightweight, dependency-free searchable dropdown that scales to hundreds of
+ * options (search + virtualised-height scroll list) instead of rendering every
+ * option inline.
+ *
+ * Props:
+ *  - options: [{ value, label }]
+ *  - value: string (single) | string[] (multiple)
+ *  - onChange: (value) => void
+ *  - multiple: boolean
+ *  - placeholder / searchPlaceholder / emptyText
+ *  - buttonClassName: classes for the trigger button
+ *  - align: 'left' | 'right' (popover alignment)
+ */
+const SearchableSelect = ({
+    options = [],
+    value,
+    onChange,
+    multiple = false,
+    placeholder = 'Select...',
+    searchPlaceholder = 'Search...',
+    emptyText = 'No matches found',
+    buttonClassName = '',
+    align = 'left',
+    renderTriggerLabel,
+}) => {
+    const [open, setOpen] = useState(false)
+    const [query, setQuery] = useState('')
+    const containerRef = useRef(null)
+    const inputRef = useRef(null)
+
+    useEffect(() => {
+        if (!open) return undefined
+        const handleClickOutside = (e) => {
+            if (containerRef.current && !containerRef.current.contains(e.target)) {
+                setOpen(false)
+            }
+        }
+        const handleEsc = (e) => e.key === 'Escape' && setOpen(false)
+        document.addEventListener('mousedown', handleClickOutside)
+        document.addEventListener('keydown', handleEsc)
+        // Focus the search box when opening.
+        const t = setTimeout(() => inputRef.current?.focus(), 10)
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+            document.removeEventListener('keydown', handleEsc)
+            clearTimeout(t)
+        }
+    }, [open])
+
+    const filtered = useMemo(() => {
+        const q = query.trim().toLowerCase()
+        if (!q) return options
+        return options.filter((o) => o.label.toLowerCase().includes(q))
+    }, [options, query])
+
+    const selectedValues = multiple ? (value || []) : (value ? [value] : [])
+    const isSelected = (v) => selectedValues.includes(v)
+
+    const handleSelect = (v) => {
+        if (multiple) {
+            const set = new Set(value || [])
+            if (set.has(v)) set.delete(v)
+            else set.add(v)
+            onChange([...set])
+        } else {
+            onChange(v)
+            setOpen(false)
+            setQuery('')
+        }
+    }
+
+    const triggerLabel = () => {
+        if (renderTriggerLabel) return renderTriggerLabel(selectedValues)
+        if (multiple) {
+            if (!selectedValues.length) return placeholder
+            return `${selectedValues.length} selected`
+        }
+        const match = options.find((o) => o.value === value)
+        return match ? match.label : placeholder
+    }
+
+    return (
+        <div className="relative" ref={containerRef}>
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className={buttonClassName || 'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm border border-surface-200 dark:border-surface-700 text-surface-600 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors'}
+            >
+                <span className="truncate max-w-[180px]">{triggerLabel()}</span>
+                <ChevronDown size={14} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+            </button>
+
+            {open && (
+                <div
+                    className={`absolute z-40 mt-1 w-64 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 shadow-xl ${align === 'right' ? 'right-0' : 'left-0'}`}
+                >
+                    <div className="p-2 border-b border-surface-100 dark:border-surface-800">
+                        <div className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-surface-50 dark:bg-surface-800">
+                            <Search size={14} className="text-surface-400 shrink-0" />
+                            <input
+                                ref={inputRef}
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                                placeholder={searchPlaceholder}
+                                className="bg-transparent outline-none text-sm w-full"
+                            />
+                        </div>
+                    </div>
+                    <div className="max-h-60 overflow-y-auto py-1">
+                        {filtered.length ? (
+                            filtered.map((o) => (
+                                <button
+                                    key={o.value}
+                                    type="button"
+                                    onClick={() => handleSelect(o.value)}
+                                    className="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-left hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"
+                                >
+                                    <span className={`truncate ${isSelected(o.value) ? 'text-primary-600 font-medium' : 'text-surface-700 dark:text-surface-300'}`}>
+                                        {o.label}
+                                    </span>
+                                    {isSelected(o.value) && <Check size={15} className="text-primary-600 shrink-0" />}
+                                </button>
+                            ))
+                        ) : (
+                            <div className="px-3 py-6 text-center text-sm text-surface-400">{emptyText}</div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default SearchableSelect

--- a/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
+++ b/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { X, Plus, Trash2, HelpCircle, BarChart3, Zap, Image as ImageIcon, Camera, Users, BookOpen } from 'lucide-react'
 
 import { communityService } from '../../services/communityService'
+import SearchableSelect from '../common/SearchableSelect'
 import toast from 'react-hot-toast'
 
 const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
@@ -301,24 +302,41 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
                             </label>
                             {availableCourses.length > 0 ? (
                                 <>
-                                    <div className="flex flex-wrap gap-2">
-                                        {availableCourses.map((course) => {
-                                            const active = selectedCourses.includes(course.id)
-                                            return (
-                                                <button
-                                                    key={course.id}
-                                                    type="button"
-                                                    onClick={() => toggleCourse(course.id)}
-                                                    className={`px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all ${active
-                                                        ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20 text-primary-600'
-                                                        : 'border-surface-200 dark:border-surface-700 text-surface-600 hover:border-surface-300'
-                                                        }`}
-                                                >
-                                                    {course.name}
-                                                </button>
-                                            )
-                                        })}
-                                    </div>
+                                    <SearchableSelect
+                                        multiple
+                                        options={availableCourses.map((c) => ({ value: c.id, label: c.name }))}
+                                        value={selectedCourses}
+                                        onChange={setSelectedCourses}
+                                        placeholder="Select course(s)"
+                                        searchPlaceholder="Search courses..."
+                                        buttonClassName="flex items-center justify-between gap-2 w-full px-3 py-2 rounded-lg text-sm border border-surface-200 dark:border-surface-700 text-surface-600 hover:bg-surface-50 dark:hover:bg-surface-800 transition-colors"
+                                        renderTriggerLabel={(vals) =>
+                                            vals.length ? `${vals.length} course${vals.length > 1 ? 's' : ''} selected` : 'Select course(s) — leave empty for everyone'
+                                        }
+                                    />
+                                    {selectedCourses.length > 0 && (
+                                        <div className="flex flex-wrap gap-2 mt-2">
+                                            {selectedCourses.map((id) => {
+                                                const course = availableCourses.find((c) => c.id === id)
+                                                if (!course) return null
+                                                return (
+                                                    <span
+                                                        key={id}
+                                                        className="flex items-center gap-1 px-2.5 py-1 rounded-full text-sm bg-primary-50 dark:bg-primary-900/20 text-primary-600 border border-primary-200 dark:border-primary-800"
+                                                    >
+                                                        {course.name}
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => toggleCourse(id)}
+                                                            className="hover:text-error-500"
+                                                        >
+                                                            <X size={13} />
+                                                        </button>
+                                                    </span>
+                                                )
+                                            })}
+                                        </div>
+                                    )}
                                     <p className="text-xs text-surface-500 mt-2 flex items-center gap-1">
                                         <Users size={12} />
                                         {selectedCourses.length === 0

--- a/frontend/exam-frontend/src/pages/Community.jsx
+++ b/frontend/exam-frontend/src/pages/Community.jsx
@@ -12,6 +12,7 @@ import Loading from '../components/common/Loading'
 import CreatePostModal from '../components/community/CreatePostModal'
 import PostCard from '../components/community/PostCard'
 import CommunityLeaderboard from '../components/community/CommunityLeaderboard'
+import SearchableSelect from '../components/common/SearchableSelect'
 import toast from 'react-hot-toast'
 
 const Community = () => {
@@ -211,18 +212,19 @@ const Community = () => {
                             <Globe size={14} />
                             Everyone
                         </button>
-                        {courses.map((course) => (
-                            <button
-                                key={course.id}
-                                onClick={() => setCourseFilter(course.id)}
-                                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-sm transition-all ${courseFilter === course.id
-                                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600'
-                                    : 'text-surface-500 hover:bg-surface-100 dark:hover:bg-surface-800'
+                        {courses.length > 0 && (
+                            <SearchableSelect
+                                options={courses.map((c) => ({ value: c.id, label: c.name }))}
+                                value={courseFilter === 'all' || courseFilter === 'global' ? '' : courseFilter}
+                                onChange={(val) => setCourseFilter(val || 'all')}
+                                placeholder="Filter by course"
+                                searchPlaceholder="Search courses..."
+                                buttonClassName={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-all border ${courseFilter !== 'all' && courseFilter !== 'global'
+                                    ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 border-primary-200 dark:border-primary-800'
+                                    : 'text-surface-500 border-surface-200 dark:border-surface-700 hover:bg-surface-100 dark:hover:bg-surface-800'
                                     }`}
-                            >
-                                {course.name}
-                            </button>
-                        ))}
+                            />
+                        )}
                     </div>
 
                     {/* Sort Options */}


### PR DESCRIPTION
## Problem
The community course filter (and the Create Post course selector) rendered **every course as an inline chip**. For admins/instructors this is the full tenant course list, so with 100+ courses it becomes an unusable wall of chips that wraps across many rows.

## Fix
New lightweight, dependency-free `SearchableSelect` component — a trigger button + popover with a **search box** and a **height-capped scrollable list** (with click-outside / Esc to close). Scales cleanly to hundreds of courses.

- **Community filter row:** keeps the `All` and `Everyone` quick chips, and replaces the per-course chips with a searchable single-select **"Filter by course"** dropdown (highlighted when a specific course is active).
- **Create Post modal:** replaces the course chip grid with a searchable **multi-select** dropdown, plus removable chips showing the currently-selected courses.

Behavior is unchanged (same values sent to the API) — only the UI scales now.

Frontend-only; no backend/migration. Deploys via Netlify on merge.

_Note: course lists are searched client-side, which is instant for hundreds of courses. If a tenant ever reaches thousands, a server-side search param on `filter_options` would be the next step._

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>