### PR TITLE
Community: strict anti-abuse moderation + admin hide/delete

### DIFF
--- a/backend/community/serializers.py
+++ b/backend/community/serializers.py
@@ -270,6 +270,11 @@ class PostCreateSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({
                     'poll_options': 'Poll must have at least 2 options.'
                 })
+            poll_check = ContentModerationService.validate_text(
+                *poll_options, label='Poll options'
+            )
+            if not poll_check['is_valid']:
+                raise serializers.ValidationError({'poll_options': poll_check['errors']})
         
         # Validate quiz
         if data.get('post_type') == 'quiz':
@@ -290,6 +295,13 @@ class PostCreateSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({
                     'quiz_data': 'Quiz must have a correct_answer index.'
                 })
+            quiz_texts = [quiz_data.get('question'), quiz_data.get('explanation')]
+            quiz_texts += list(quiz_data.get('options', []))
+            quiz_check = ContentModerationService.validate_text(
+                *quiz_texts, label='Quiz'
+            )
+            if not quiz_check['is_valid']:
+                raise serializers.ValidationError({'quiz_data': quiz_check['errors']})
         
         return data
     

--- a/backend/community/services.py
+++ b/backend/community/services.py
@@ -1,6 +1,8 @@
 """
 Community services - Content moderation, XP rewards, leaderboard.
 """
+import re
+import unicodedata
 from datetime import date, timedelta
 from django.db import transaction
 from django.db.models import Sum, Count, F, Q
@@ -16,53 +18,137 @@ from gamification.models import XPTransaction
 
 class ContentModerationService:
     """
-    Service for filtering inappropriate content.
+    Strict, evasion-resistant profanity filter for English + Hinglish.
+
+    The matcher normalises text before checking so common bypass tricks are
+    defeated:
+      - leetspeak substitution (f4ck, ch00t, @ss, $ex, b1tch ...),
+      - separators / spacing between letters (c.h.u.t.i.y.a, m a d a r c h o d),
+      - repeated characters (fuuuuck, chuuutiya),
+      - accents / unicode look-alikes.
+
+    Two word lists are kept to balance strictness against false positives:
+      - ``PREFIX_WORDS``: unambiguous abuse stems (long / clearly offensive).
+        These match even with a trailing suffix (chutiya, chutiyapa) but still
+        require a word boundary at the start, so embeddings like "parachute"
+        (contains "chut") or "grandiose" (contains "randi") are NOT flagged.
+      - ``EXACT_WORDS``: short / ambiguous tokens (sala, mc, bc, ass ...) that
+        only match as standalone whole words, so "salad", "class", "assignment"
+        are safe.
     """
-    
-    # Additional custom bad words (Hindi transliterated abuses, etc.)
-    CUSTOM_BAD_WORDS = [
-        'bhosdike', 'bhosdi', 'madarchod', 'behenchod', 'chutiya', 
-        'gandu', 'laude', 'lodu', 'randi', 'harami', 'sala', 'saala',
-        'bakchod', 'chut', 'lawde', 'bsdk', 'mc', 'bc', 'lodu'
+
+    # Long / unambiguous abusive stems (English + Hindi/Hinglish transliterations
+    # and their common spellings). Matched as a prefix at a word boundary.
+    PREFIX_WORDS = [
+        # English
+        'fuck', 'fuk', 'fuc', 'motherfuck', 'fucker', 'shit', 'bullshit',
+        'bitch', 'bastard', 'asshole', 'dickhead', 'cunt', 'pussy', 'nigger',
+        'nigga', 'faggot', 'retard', 'slut', 'whore', 'wank', 'jerkoff',
+        'cocksuck', 'dumbass', 'jackass', 'bollock', 'bugger', 'prick',
+        # Hindi / Hinglish
+        'madarchod', 'madarchd', 'maderchod', 'behenchod', 'bhenchod',
+        'bhosdike', 'bhosdika', 'bhosdiwala', 'bhosdi', 'bhosad', 'bhosda',
+        'chutiya', 'chutiye', 'chutiyapa', 'chutmar', 'chodu', 'chod',
+        'gandu', 'gaandu', 'gaand', 'gawar', 'harami', 'haramkhor',
+        'haramzada', 'haramzade', 'bhadwa', 'bhadve',
+        'lawda', 'lawde', 'lauda', 'laude', 'laund', 'lund', 'loda', 'lodu',
+        'jhaant', 'jhant', 'tatti', 'tatte', 'bakchod', 'bakchodi',
+        'chinaal', 'kutta', 'kutti', 'kaminey', 'kamina', 'kamine',
+        'chodna', 'chudai', 'chudwa', 'gaandfat', 'najayaz', 'phuck',
     ]
-    
+
+    # Short / ambiguous tokens — matched only as complete words.
+    EXACT_WORDS = [
+        'ass', 'sex', 'dick', 'cock', 'damn', 'crap', 'piss', 'tits', 'boob',
+        'sala', 'saala', 'chut', 'choot', 'fck', 'bsdk', 'mkc', 'mkb', 'bkl',
+        'lvda', 'lawd', 'randi', 'raand',
+    ]
+
+    _LEET_MAP = {
+        '0': 'o', '1': 'i', '3': 'e', '4': 'a', '5': 's', '7': 't', '8': 'b',
+        '@': 'a', '$': 's', '+': 't', '(': 'c', '|': 'i', '!': 'i',
+    }
+
+    _compiled = None
+
+    @classmethod
+    def _normalize(cls, text: str) -> str:
+        """Lowercase, strip accents and apply leetspeak substitutions."""
+        if not text:
+            return ''
+        text = unicodedata.normalize('NFKD', str(text))
+        text = text.encode('ascii', 'ignore').decode('ascii')
+        text = text.lower()
+        return ''.join(cls._LEET_MAP.get(ch, ch) for ch in text)
+
+    @classmethod
+    def _build_patterns(cls):
+        """Compile regexes once. Letters may repeat and be split by separators."""
+        if cls._compiled is not None:
+            return cls._compiled
+
+        def core(word):
+            # Each letter -> letter+ (repeats) joined by optional separators.
+            return r'[\W_0-9]*'.join(re.escape(c) + '+' for c in word)
+
+        patterns = []
+        for w in cls.PREFIX_WORDS:
+            # Word boundary at start, allow a trailing suffix.
+            patterns.append(re.compile(r'\b' + core(w) + r'\w*', re.IGNORECASE))
+        for w in cls.EXACT_WORDS:
+            # Whole word only.
+            patterns.append(re.compile(r'\b' + core(w) + r'\b', re.IGNORECASE))
+        cls._compiled = patterns
+        return patterns
+
     @classmethod
     def initialize(cls):
-        """Initialize the profanity filter with custom words."""
+        """Initialize the secondary (better_profanity) English filter."""
         profanity.load_censor_words()
-        profanity.add_censor_words(cls.CUSTOM_BAD_WORDS)
-    
+        profanity.add_censor_words(cls.PREFIX_WORDS + cls.EXACT_WORDS)
+
+    @classmethod
+    def contains_profanity(cls, text: str) -> bool:
+        """True if the text contains disallowed language (any layer trips)."""
+        if not text:
+            return False
+        normalized = cls._normalize(text)
+        for pattern in cls._build_patterns():
+            if pattern.search(normalized):
+                return True
+        # Secondary English dictionary as a safety net.
+        cls.initialize()
+        return bool(profanity.contains_profanity(normalized))
+
     @classmethod
     def is_clean(cls, text: str) -> bool:
-        """Check if text is free of profanity."""
-        cls.initialize()
-        return not profanity.contains_profanity(text)
-    
+        return not cls.contains_profanity(text)
+
     @classmethod
     def censor(cls, text: str) -> str:
-        """Censor profanity in text with asterisks."""
         cls.initialize()
-        return profanity.censor(text)
-    
+        return profanity.censor(text or '')
+
     @classmethod
     def validate_content(cls, title: str = None, content: str = None) -> dict:
-        """
-        Validate title and content for profanity.
-        Returns: {'is_valid': bool, 'errors': list}
-        """
-        cls.initialize()
+        """Validate title and content. Returns {'is_valid', 'errors'}."""
         errors = []
-        
-        if title and profanity.contains_profanity(title):
+        if title and cls.contains_profanity(title):
             errors.append("Title contains inappropriate language. Please revise.")
-        
-        if content and profanity.contains_profanity(content):
+        if content and cls.contains_profanity(content):
             errors.append("Content contains inappropriate language. Please revise.")
-        
-        return {
-            'is_valid': len(errors) == 0,
-            'errors': errors
-        }
+        return {'is_valid': len(errors) == 0, 'errors': errors}
+
+    @classmethod
+    def validate_text(cls, *texts, label: str = 'Content') -> dict:
+        """Validate an arbitrary set of text fields (poll options, quiz, etc.)."""
+        for t in texts:
+            if t and cls.contains_profanity(t):
+                return {
+                    'is_valid': False,
+                    'errors': [f"{label} contains inappropriate language. Please revise."],
+                }
+        return {'is_valid': True, 'errors': []}
 
 
 class CommunityXPService:

--- a/backend/community/views.py
+++ b/backend/community/views.py
@@ -70,14 +70,25 @@ class PostViewSet(TenantAwareViewSet):
     permission_classes = [IsAuthenticated]
     
     def get_queryset(self):
-        queryset = Post.objects.filter(status='active').select_related(
+        is_staff = _is_staff_user(self.request.user)
+
+        queryset = Post.objects.all().select_related(
             'author__user', 'course', 'subject'
         ).prefetch_related('poll_options', 'quiz', 'courses')
+
+        # Status filtering. Non-staff only ever see active posts. Staff may pass
+        # ?status=hidden|closed|active|all to moderate/review other states.
+        status_param = (self.request.query_params.get('status') or '').lower()
+        if is_staff and status_param:
+            if status_param != 'all':
+                queryset = queryset.filter(status=status_param)
+        else:
+            queryset = queryset.filter(status='active')
 
         # Course-scoped visibility: global posts are visible to all, but posts
         # linked to course(s) are only visible to enrolled students (the author
         # and admins/instructors always see them).
-        if not _is_staff_user(self.request.user):
+        if not is_staff:
             queryset = queryset.filter(accessible_posts_q(self.request.user)).distinct()
 
         # Filters
@@ -155,6 +166,46 @@ class PostViewSet(TenantAwareViewSet):
         instance.refresh_from_db()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
+
+    def _is_author(self, post):
+        profile = getattr(self.request.user, 'profile', None)
+        return profile is not None and post.author_id == profile.id
+
+    def destroy(self, request, *args, **kwargs):
+        """Only the author or staff (admin/instructor) may delete a post."""
+        instance = self.get_object()
+        if not (self._is_author(instance) or _is_staff_user(request.user)):
+            return Response(
+                {'detail': 'You do not have permission to delete this post.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().destroy(request, *args, **kwargs)
+
+    @action(detail=True, methods=['post'])
+    def hide(self, request, pk=None):
+        """Staff-only: hide a post from the community feed."""
+        if not _is_staff_user(request.user):
+            return Response(
+                {'detail': 'Only admins and instructors can hide posts.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        post = self.get_object()
+        post.status = 'hidden'
+        post.save(update_fields=['status'])
+        return Response({'status': 'hidden', 'id': str(post.id)})
+
+    @action(detail=True, methods=['post'])
+    def unhide(self, request, pk=None):
+        """Staff-only: restore a hidden post to the community feed."""
+        if not _is_staff_user(request.user):
+            return Response(
+                {'detail': 'Only admins and instructors can unhide posts.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        post = self.get_object()
+        post.status = 'active'
+        post.save(update_fields=['status'])
+        return Response({'status': 'active', 'id': str(post.id)})
     
     def perform_create(self, serializer):
         post = serializer.save()
@@ -340,6 +391,18 @@ class CommentViewSet(TenantAwareViewSet):
         if self.action in ['create', 'update', 'partial_update']:
             return CommentCreateSerializer
         return CommentSerializer
+
+    def destroy(self, request, *args, **kwargs):
+        """Only the author or staff (admin/instructor) may delete a comment."""
+        instance = self.get_object()
+        profile = getattr(request.user, 'profile', None)
+        is_author = profile is not None and instance.author_id == profile.id
+        if not (is_author or _is_staff_user(request.user)):
+            return Response(
+                {'detail': 'You do not have permission to delete this comment.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return super().destroy(request, *args, **kwargs)
     
     def perform_create(self, serializer):
         comment = serializer.save()

--- a/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
+++ b/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
@@ -48,9 +48,15 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
         },
         onError: (error) => {
             console.error('Post creation error:', error.response?.data)
-            const message = error.response?.data?.content?.[0] ||
-                error.response?.data?.title?.[0] ||
-                error.response?.data?.detail ||
+            const data = error.response?.data || {}
+            const firstOf = (v) => Array.isArray(v) ? v[0] : v
+            const message = firstOf(data.content) ||
+                firstOf(data.title) ||
+                firstOf(data.poll_options) ||
+                firstOf(data.quiz_data) ||
+                firstOf(data.courses) ||
+                firstOf(data.non_field_errors) ||
+                data.detail ||
                 'Failed to create post'
             toast.error(message)
         }

--- a/frontend/exam-frontend/src/components/community/PostCard.jsx
+++ b/frontend/exam-frontend/src/components/community/PostCard.jsx
@@ -1,10 +1,14 @@
 import { motion } from 'framer-motion'
+import { useState } from 'react'
 import {
     MessageCircle, ThumbsUp, Eye, CheckCircle,
-    BarChart3, Zap, Clock, User, BadgeCheck, BookOpen, Globe
+    BarChart3, Zap, Clock, User, BadgeCheck, BookOpen, Globe,
+    MoreVertical, EyeOff, Trash2
 } from 'lucide-react'
 
-const PostCard = ({ post, onLike, onClick }) => {
+const PostCard = ({ post, onLike, onClick, isAdmin = false, isAuthor = false, onHide, onUnhide, onDelete }) => {
+    const [menuOpen, setMenuOpen] = useState(false)
+    const canModerate = isAdmin || isAuthor
     const typeConfig = {
         question: {
             icon: MessageCircle,
@@ -80,11 +84,18 @@ const PostCard = ({ post, onLike, onClick }) => {
                 </div>
 
                 {/* Type + Course Badges */}
-                <div className="flex flex-col items-end gap-1.5">
+                <div className="flex items-start gap-2">
+                  <div className="flex flex-col items-end gap-1.5">
                     <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${config.color}`}>
                         <TypeIcon size={12} />
                         {config.label}
                     </div>
+                    {post.status === 'hidden' && (
+                        <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-50 dark:bg-red-900/20 text-red-600 border border-red-200 dark:border-red-800">
+                            <EyeOff size={11} />
+                            Hidden
+                        </span>
+                    )}
                     {post.courses && post.courses.length > 0 ? (
                         <div className="flex flex-wrap justify-end gap-1">
                             {post.courses.slice(0, 2).map((c) => (
@@ -109,6 +120,51 @@ const PostCard = ({ post, onLike, onClick }) => {
                             Everyone
                         </span>
                     )}
+                  </div>
+
+                  {canModerate && (
+                    <div className="relative">
+                        <button
+                            onClick={(e) => { e.stopPropagation(); setMenuOpen((v) => !v) }}
+                            className="p-1 rounded-lg text-surface-400 hover:text-surface-700 hover:bg-surface-100 dark:hover:bg-surface-700 transition-colors"
+                            title="Options"
+                        >
+                            <MoreVertical size={16} />
+                        </button>
+                        {menuOpen && (
+                            <>
+                                <div
+                                    className="fixed inset-0 z-10"
+                                    onClick={(e) => { e.stopPropagation(); setMenuOpen(false) }}
+                                />
+                                <div className="absolute right-0 mt-1 w-40 py-1 rounded-lg shadow-lg bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 z-20">
+                                    {isAdmin && post.status !== 'hidden' && (
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); setMenuOpen(false); onHide?.() }}
+                                            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-surface-700 dark:text-surface-200 hover:bg-surface-100 dark:hover:bg-surface-700"
+                                        >
+                                            <EyeOff size={14} /> Hide post
+                                        </button>
+                                    )}
+                                    {isAdmin && post.status === 'hidden' && (
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); setMenuOpen(false); onUnhide?.() }}
+                                            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-surface-700 dark:text-surface-200 hover:bg-surface-100 dark:hover:bg-surface-700"
+                                        >
+                                            <Eye size={14} /> Unhide post
+                                        </button>
+                                    )}
+                                    <button
+                                        onClick={(e) => { e.stopPropagation(); setMenuOpen(false); onDelete?.() }}
+                                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                                    >
+                                        <Trash2 size={14} /> Delete post
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                  )}
                 </div>
             </div>
 

--- a/frontend/exam-frontend/src/pages/Community.jsx
+++ b/frontend/exam-frontend/src/pages/Community.jsx
@@ -8,6 +8,7 @@ import {
     BarChart3, Zap, Trophy, Users, BookOpen, Globe
 } from 'lucide-react'
 import { communityService } from '../services/communityService'
+import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CreatePostModal from '../components/community/CreatePostModal'
 import PostCard from '../components/community/PostCard'
@@ -18,6 +19,9 @@ import toast from 'react-hot-toast'
 const Community = () => {
     const navigate = useNavigate()
     const queryClient = useQueryClient()
+    const { user, profile } = useAuthStore()
+    const role = user?.role || profile?.user?.role
+    const isAdmin = role === 'admin' || role === 'instructor'
     const [activeTab, setActiveTab] = useState('all')
     const [sortBy, setSortBy] = useState('recent')
     const [courseFilter, setCourseFilter] = useState('all')
@@ -54,6 +58,33 @@ const Community = () => {
         onSuccess: () => {
             queryClient.invalidateQueries(['communityPosts'])
         }
+    })
+
+    const hideMutation = useMutation({
+        mutationFn: (postId) => communityService.hidePost(postId),
+        onSuccess: () => {
+            toast.success('Post hidden')
+            queryClient.invalidateQueries(['communityPosts'])
+        },
+        onError: () => toast.error('Could not hide post')
+    })
+
+    const unhideMutation = useMutation({
+        mutationFn: (postId) => communityService.unhidePost(postId),
+        onSuccess: () => {
+            toast.success('Post restored')
+            queryClient.invalidateQueries(['communityPosts'])
+        },
+        onError: () => toast.error('Could not restore post')
+    })
+
+    const deleteMutation = useMutation({
+        mutationFn: (postId) => communityService.deletePost(postId),
+        onSuccess: () => {
+            toast.success('Post deleted')
+            queryClient.invalidateQueries(['communityPosts'])
+        },
+        onError: () => toast.error('Could not delete post')
     })
 
     const posts = postsData?.results || postsData || []
@@ -262,6 +293,15 @@ const Community = () => {
                                             post={post}
                                             onLike={() => likeMutation.mutate(post.id)}
                                             onClick={() => navigate(`/community/${post.id}`)}
+                                            isAdmin={isAdmin}
+                                            isAuthor={user?.id === post.author?.id}
+                                            onHide={() => hideMutation.mutate(post.id)}
+                                            onUnhide={() => unhideMutation.mutate(post.id)}
+                                            onDelete={() => {
+                                                if (window.confirm('Delete this post permanently?')) {
+                                                    deleteMutation.mutate(post.id)
+                                                }
+                                            }}
                                         />
                                     </motion.div>
                                 ))

--- a/frontend/exam-frontend/src/pages/CommunityPost.jsx
+++ b/frontend/exam-frontend/src/pages/CommunityPost.jsx
@@ -5,7 +5,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
     ArrowLeft, ThumbsUp, MessageCircle, Eye, Share2,
     CheckCircle, Clock, BarChart3, Zap, Trophy, Send,
-    BadgeCheck, Camera, Image as ImageIcon, X, BookOpen, Globe
+    BadgeCheck, Camera, Image as ImageIcon, X, BookOpen, Globe,
+    EyeOff, Trash2
 } from 'lucide-react'
 
 import { communityService } from '../services/communityService'
@@ -45,6 +46,34 @@ const CommunityPost = () => {
         onSuccess: () => {
             queryClient.invalidateQueries(['communityPost', id])
         }
+    })
+
+    const hideMutation = useMutation({
+        mutationFn: () => communityService.hidePost(id),
+        onSuccess: () => {
+            toast.success('Post hidden')
+            queryClient.invalidateQueries(['communityPost', id])
+        },
+        onError: () => toast.error('Could not hide post')
+    })
+
+    const unhideMutation = useMutation({
+        mutationFn: () => communityService.unhidePost(id),
+        onSuccess: () => {
+            toast.success('Post restored')
+            queryClient.invalidateQueries(['communityPost', id])
+        },
+        onError: () => toast.error('Could not restore post')
+    })
+
+    const deleteMutation = useMutation({
+        mutationFn: () => communityService.deletePost(id),
+        onSuccess: () => {
+            toast.success('Post deleted')
+            queryClient.invalidateQueries(['communityPosts'])
+            navigate('/community')
+        },
+        onError: () => toast.error('Could not delete post')
     })
 
     // Add comment
@@ -168,6 +197,9 @@ const CommunityPost = () => {
     }
 
     const isAuthor = user?.id === post.author?.id
+    const role = user?.role || profile?.user?.role
+    const isAdmin = role === 'admin' || role === 'instructor'
+    const canModerate = isAdmin || isAuthor
     const comments = commentsData?.results || commentsData || []
     const hasVoted = post.user_poll_vote !== null
     const hasAttemptedQuiz = post.quiz?.user_attempt !== null
@@ -201,12 +233,52 @@ const CommunityPost = () => {
                         {post.post_type.charAt(0).toUpperCase() + post.post_type.slice(1)}
                     </div>
 
-                    {post.is_solved && (
-                        <div className="flex items-center gap-1 text-success-500 text-sm font-medium">
-                            <CheckCircle size={16} />
-                            Solved
-                        </div>
-                    )}
+                    <div className="flex items-center gap-3">
+                        {post.status === 'hidden' && (
+                            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-50 dark:bg-red-900/20 text-red-600 border border-red-200 dark:border-red-800">
+                                <EyeOff size={12} /> Hidden
+                            </span>
+                        )}
+                        {post.is_solved && (
+                            <div className="flex items-center gap-1 text-success-500 text-sm font-medium">
+                                <CheckCircle size={16} />
+                                Solved
+                            </div>
+                        )}
+                        {canModerate && (
+                            <div className="flex items-center gap-2">
+                                {isAdmin && post.status !== 'hidden' && (
+                                    <button
+                                        onClick={() => hideMutation.mutate()}
+                                        className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium text-surface-600 dark:text-surface-300 bg-surface-100 dark:bg-surface-700 hover:bg-surface-200 dark:hover:bg-surface-600 transition-colors"
+                                        title="Hide post"
+                                    >
+                                        <EyeOff size={14} /> Hide
+                                    </button>
+                                )}
+                                {isAdmin && post.status === 'hidden' && (
+                                    <button
+                                        onClick={() => unhideMutation.mutate()}
+                                        className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium text-surface-600 dark:text-surface-300 bg-surface-100 dark:bg-surface-700 hover:bg-surface-200 dark:hover:bg-surface-600 transition-colors"
+                                        title="Unhide post"
+                                    >
+                                        <Eye size={14} /> Unhide
+                                    </button>
+                                )}
+                                <button
+                                    onClick={() => {
+                                        if (window.confirm('Delete this post permanently?')) {
+                                            deleteMutation.mutate()
+                                        }
+                                    }}
+                                    className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium text-red-600 bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
+                                    title="Delete post"
+                                >
+                                    <Trash2 size={14} /> Delete
+                                </button>
+                            </div>
+                        )}
+                    </div>
                 </div>
 
                 {/* Author */}

--- a/frontend/exam-frontend/src/services/communityService.js
+++ b/frontend/exam-frontend/src/services/communityService.js
@@ -40,6 +40,16 @@ export const communityService = {
         await api.delete(`/community/posts/${id}/`)
     },
 
+    hidePost: async (id) => {
+        const response = await api.post(`/community/posts/${id}/hide/`)
+        return response.data
+    },
+
+    unhidePost: async (id) => {
+        const response = await api.post(`/community/posts/${id}/unhide/`)
+        return response.data
+    },
+
     likePost: async (id) => {
         const response = await api.post(`/community/posts/${id}/like/`)
         return response.data


### PR DESCRIPTION
## What
Adds strict, evasion-resistant content moderation and admin/author moderation controls to the community forum.

### Moderation (English + Hinglish)
- Rewrote `ContentModerationService` as a normalization + regex matcher that defeats common bypasses: leetspeak (`ch00t`, `m@d@rch0d`), separators/spacing (`c.h.u.t.i.y.a`, `m a d a r c h o d`), repeated chars (`chuuutiya`), and accents.
- Two tuned word lists (prefix stems vs. whole-word) keep it strict while avoiding false positives on legit text (`random`, `Gandhi`, `class`, `assignment`, `300 BC`, `on sale`).
- Now applied to **post title/content, comments, poll options, and quiz question/options/explanation**.

### Admin / author controls
- `PostViewSet.destroy` restricted to author or staff (fixes a bug where any authenticated user could delete any accessible post).
- Staff-only `hide`/`unhide` actions; staff can view non-active posts via `?status=`.
- `CommentViewSet.destroy` restricted to author/staff.
- Frontend: moderation menu on PostCard + detail page (hide/unhide/delete), Hidden badge, and clearer moderation error toasts on create.

## Notes
- No DB migration (`hidden` status already existed).
- Backend system check passes on VM; frontend builds clean.