### PR TITLE
Add explicit Instructor label to course tiles

### DIFF
--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -8,16 +8,21 @@ import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
 import toast from 'react-hot-toast'
-import { GraduationCap, CheckCircle2, Clock, PlusCircle, ArrowRight, Settings2, Search, X, Users } from 'lucide-react'
+import { GraduationCap, CheckCircle2, Clock, PlusCircle, ArrowRight, Settings2, Search, X } from 'lucide-react'
 
 const InstructorLine = ({ instructors = [] }) => {
   if (!instructors.length) return null
   const shown = instructors.slice(0, 2)
   const extra = instructors.slice(2)
+  const label = instructors.length > 1 ? 'Instructors' : 'Instructor'
   return (
-    <div className="flex items-center gap-1.5 mt-2 text-xs text-surface-500 min-w-0">
-      <Users size={13} className="shrink-0 text-surface-400" />
-      <span className="truncate">
+    <div className="flex items-center gap-1.5 mt-2 text-xs min-w-0">
+      <span className="inline-flex items-center gap-1 shrink-0 text-primary-600 dark:text-primary-400 font-semibold uppercase tracking-wide text-[10px]">
+        <GraduationCap size={13} className="shrink-0" />
+        {label}
+      </span>
+      <span className="text-surface-300 dark:text-surface-600 shrink-0">·</span>
+      <span className="truncate text-surface-600 dark:text-surface-300 font-medium">
         {shown.map((i) => i.name).join(', ')}
       </span>
       {extra.length > 0 && (


### PR DESCRIPTION
## Problem
On the Courses page, each tile showed a generic people icon followed by the instructor's name (e.g. "Aadhya Rao"). Nothing communicated that this person is the **instructor** — it just looked like a stray name.

## Change
Redesigned the `InstructorLine` component in `Courses.jsx`:
- Replaced the `Users` icon with a `GraduationCap` icon.
- Added an explicit **"Instructor"** / **"Instructors"** label (pluralized by count) in the brand primary color, uppercase, before the name(s).
- Kept the existing "+N" overflow chip with hover tooltip for 3+ instructors.

Result: `🎓 INSTRUCTOR · Aadhya Rao`

Frontend-only change. Build passes (`✓ built`).