### PR TITLE
Fix image cropper slowness and initial zoom (missing CSS import)

### DIFF
--- a/frontend/exam-frontend/src/components/common/ImageCropper.jsx
+++ b/frontend/exam-frontend/src/components/common/ImageCropper.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import Cropper from 'react-easy-crop'
+import 'react-easy-crop/react-easy-crop.css'
 import { motion, AnimatePresence } from 'framer-motion'
 import { X, ZoomIn, ZoomOut, Check } from 'lucide-react'
 
@@ -91,6 +92,7 @@ const ImageCropper = ({ image, onCropComplete, onCancel, aspect = 1, cropShape =
                         zoom={zoom}
                         aspect={aspect}
                         cropShape={cropShape}
+                        objectFit="contain"
                         showGrid={cropShape === 'rect'}
                         onCropChange={onCropChange}
                         onCropComplete={onCropCompleteInternal}


### PR DESCRIPTION
## Problem
The course thumbnail crop modal was **very slow/laggy** and the cropper did **not show the full image at zoom 1** (it opened zoomed-in / cut off).

## Root cause
The `react-easy-crop` stylesheet was **never imported** anywhere in the app. Without it, the `.reactEasyCrop_Contain` rules (`max-width/height: 100%`) never applied, so the `<img>` element rendered at its **full natural resolution** (e.g. a 4000px-wide photo) instead of being contained to the cropper viewport. This caused:

- **Slowness** — every drag/transform operated on a giant full-res image element, which is extremely expensive.
- **Wrong initial zoom** — without the size constraints, the image overflowed the viewport, so only a zoomed-in portion was visible at zoom 1.

## Fix
- Import `react-easy-crop/react-easy-crop.css` in `ImageCropper.jsx`.
- Set `objectFit="contain"` explicitly so the entire image is visible at zoom 1 and can be panned/zoomed from there.

This is a shared component, so it fixes **both** the course thumbnail cropper (16:9) and the profile photo cropper (round 1:1).

Frontend-only. Build passes (`✓ built`).