### PR TITLE
Show uploaded course thumbnail on Study tab enrolled courses

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -262,7 +262,10 @@ class StudyCoursesView(APIView):
                 'is_featured': getattr(e.course, 'is_featured', False),
                 'course_type': getattr(e.course, 'course_type', '') or '',
                 'description': getattr(e.course, 'description', '') or '',
-                'thumbnail': (e.course.icon.url if getattr(e.course, 'icon', None) else None),
+                'thumbnail': (
+                    e.course.thumbnail.url if getattr(e.course, 'thumbnail', None)
+                    else (e.course.icon.url if getattr(e.course, 'icon', None) else None)
+                ),
                 'enrollment_status': e.status,
             }
             if e.status == 'approved':


### PR DESCRIPTION
## Problem
After uploading a course thumbnail, enrolled courses on the **Study tab** still showed the letter/gradient placeholder instead of the uploaded image.

## Root cause
`StudyCoursesView` built its `thumbnail` field from the course **icon** only:
```python
'thumbnail': (e.course.icon.url if getattr(e.course, 'icon', None) else None),
```
It never looked at the real `Course.thumbnail` field, so uploaded thumbnails were ignored on the Study tab. (The Courses page worked because its `available-for-enrollment` endpoint already prefers `thumbnail`.)

## Fix
Prefer `Course.thumbnail`, fall back to `icon`, mirroring the `available-for-enrollment` endpoint:
```python
'thumbnail': (
    e.course.thumbnail.url if getattr(e.course, 'thumbnail', None)
    else (e.course.icon.url if getattr(e.course, 'icon', None) else None)
),
```

Backend-only, **no migration**. Python syntax validated.

## Deploy note
Requires a backend restart on the VM to pick up the code (no migration needed).