### PR TITLE
Move enrolled courses slider below Quick Actions

### DIFF
--- a/frontend/exam-frontend/src/pages/Dashboard.jsx
+++ b/frontend/exam-frontend/src/pages/Dashboard.jsx
@@ -230,11 +230,6 @@ const Dashboard = () => {
         </div>
       </div>
 
-      {/* Enrolled courses — quick access */}
-      {enrolledCourses.length > 0 && (
-        <EnrolledCoursesSlider courses={enrolledCourses} navigate={navigate} />
-      )}
-
       {/* Today's Progress Card */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
@@ -469,6 +464,11 @@ const Dashboard = () => {
           />
         </div>
       </div>
+
+      {/* Enrolled courses — quick access */}
+      {enrolledCourses.length > 0 && (
+        <EnrolledCoursesSlider courses={enrolledCourses} navigate={navigate} />
+      )}
 
       {/* Stats Grid */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">


### PR DESCRIPTION
## What
Repositions the **"Your courses"** slider on the student dashboard.

Previously it rendered between the header and the "Today's Progress" card, which looked out of place. It now renders **right after the Quick Actions section**, giving a more natural flow: header → Today's Progress → Quick Actions → Your courses → stats.

Pure JSX reorder, no logic change. Frontend-only. Build passes (`✓ built`).