### PR TITLE
Account guards: verify gate, goals-only onboarding, suspension enforcement

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -51,3 +51,67 @@ class TenantMiddleware(MiddlewareMixin):
 
         request.tenant = tenant
 
+
+
+# Auth/bootstrap endpoints a suspended user must still be able to reach so the
+# frontend can authenticate, refresh tokens, verify email, and load its profile
+# (which surfaces is_suspended to drive the blocking overlay).
+SUSPENSION_EXEMPT_PATHS = [
+    '/api/v1/auth/login/',
+    '/api/v1/auth/register/',
+    '/api/v1/auth/refresh/',
+    '/api/v1/auth/logout/',
+    '/api/v1/auth/verify-email/',
+    '/api/v1/auth/resend-otp/',
+    '/api/v1/auth/password/',
+    '/api/v1/auth/profile/',
+]
+
+
+class BlockSuspendedUsersMiddleware:
+    """Reject API requests from suspended accounts.
+
+    Defense-in-depth: individual DRF views set their own permission_classes,
+    which override any default permission. Enforcing suspension here guarantees
+    every /api/ endpoint (except auth/bootstrap paths) rejects a suspended user,
+    regardless of the view's permissions.
+
+    Returns HTTP 403 with code 'account_suspended' (not 401) so the frontend
+    keeps the session, avoids a refresh/logout loop, and shows the blocking
+    overlay instead.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # Import lazily-safe: simplejwt is already an installed app.
+        from rest_framework_simplejwt.authentication import JWTAuthentication
+        self._authenticator = JWTAuthentication()
+
+    def __call__(self, request):
+        path = request.path
+        if path.startswith('/api/') and not self._is_exempt(path):
+            user = self._get_user(request)
+            if user is not None and getattr(user, 'is_suspended', False):
+                return JsonResponse(
+                    {
+                        'detail': 'Your account has been suspended by your administrator.',
+                        'code': 'account_suspended',
+                    },
+                    status=403,
+                )
+        return self.get_response(request)
+
+    @staticmethod
+    def _is_exempt(path):
+        return any(path.startswith(p) for p in SUSPENSION_EXEMPT_PATHS)
+
+    def _get_user(self, request):
+        try:
+            result = self._authenticator.authenticate(request)
+        except Exception:
+            # Invalid/expired token — let the normal auth flow handle it.
+            return None
+        if result is None:
+            return None
+        user, _token = result
+        return user

--- a/backend/dailytaiyari/settings.py
+++ b/backend/dailytaiyari/settings.py
@@ -77,6 +77,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'core.middleware.TenantMiddleware',
+    'core.middleware.BlockSuspendedUsersMiddleware',
 ]
 
 ROOT_URLCONF = 'dailytaiyari.urls'

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -41,12 +41,11 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
         if user and user.check_password(password):
             if not user.is_active:
                 raise serializers.ValidationError('User account is disabled.')
-            if not user.is_email_verified:
-                raise serializers.ValidationError({
-                    'detail': 'Email not verified. Please verify your email to continue.',
-                    'code': 'email_not_verified',
-                    'email': user.email,
-                })
+            # NOTE: Unverified and suspended users are allowed to authenticate.
+            # The frontend gates the app behind a "verify your email" screen for
+            # unverified users, and blurs it behind a modal for suspended users.
+            # Suspended users are additionally blocked from data APIs by
+            # core.middleware.BlockSuspendedUsersMiddleware.
             self.user = user
             refresh = self.get_token(user)
             data = {
@@ -233,13 +232,7 @@ class AdminEnrollmentRequestSerializer(serializers.ModelSerializer):
 
 
 class OnboardingSerializer(serializers.Serializer):
-    """Serializer for student onboarding — IIT JEE & NEET only."""
-    primary_course_id = serializers.UUIDField()
-    additional_course_ids = serializers.ListField(
-        child=serializers.UUIDField(),
-        required=False,
-        default=[]
-    )
+    """Serializer for student onboarding — goals only (no course selection)."""
     target_year = serializers.IntegerField(required=False)
     daily_study_goal_minutes = serializers.IntegerField(default=60)
     preferred_study_time = serializers.ChoiceField(

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -262,7 +262,12 @@ class UserView(generics.RetrieveUpdateAPIView):
 
 
 class OnboardingView(APIView):
-    """Complete user onboarding with course selection."""
+    """Complete user onboarding — saves study goals only.
+
+    Course selection/enrollment is intentionally NOT part of onboarding.
+    After onboarding, students request enrollment from the Courses tab
+    (creating a pending CourseEnrollment that an admin approves).
+    """
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request):
@@ -273,40 +278,11 @@ class OnboardingView(APIView):
         user = request.user
         profile = user.profile
 
-        # Update profile
+        # Update profile goals
         profile.target_year = data.get('target_year')
         profile.daily_study_goal_minutes = data['daily_study_goal_minutes']
         profile.preferred_study_time = data['preferred_study_time']
-
-        # Set primary course
-        try:
-            primary_course = Course.objects.get(id=data['primary_course_id'])
-            profile.primary_course = primary_course
-        except Course.DoesNotExist:
-            return Response(
-                {'error': 'Primary course not found'},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
         profile.save()
-
-        # Create course enrollments — primary course auto-approved at onboarding
-        CourseEnrollment.objects.get_or_create(
-            student=profile,
-            course=primary_course,
-            defaults={'is_active': True, 'status': 'approved', 'reviewed_at': timezone.now()}
-        )
-
-        for course_id in data.get('additional_course_ids', []):
-            try:
-                course = Course.objects.get(id=course_id)
-                CourseEnrollment.objects.get_or_create(
-                    student=profile,
-                    course=course,
-                    defaults={'is_active': True, 'status': 'pending'}
-                )
-            except Course.DoesNotExist:
-                pass
 
         # Mark user as onboarded
         user.is_onboarded = True

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -7,6 +7,7 @@ import { useTenantStore } from './context/tenantStore'
 import MainLayout from './components/layout/MainLayout'
 import AuthLayout from './components/layout/AuthLayout'
 import SuspensionOverlay from './components/layout/SuspensionOverlay'
+import VerificationGate from './components/layout/VerificationGate'
 
 // Auth Pages
 import Login from './pages/auth/Login'
@@ -123,6 +124,7 @@ function App() {
   return (
     <>
       <SuspensionOverlay />
+      <VerificationGate />
       <Routes>
         {/* Auth Routes */}
         <Route element={<AuthLayout />}>

--- a/frontend/exam-frontend/src/components/layout/VerificationGate.jsx
+++ b/frontend/exam-frontend/src/components/layout/VerificationGate.jsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { MailCheck, LogOut } from 'lucide-react'
+import { useAuthStore } from '../../context/authStore'
+import toast from 'react-hot-toast'
+
+const RESEND_COOLDOWN = 60
+
+const VerificationGate = () => {
+    const { user, isAuthenticated, verifyEmail, resendOtp, logout, isLoading } = useAuthStore()
+
+    const [code, setCode] = useState('')
+    const [cooldown, setCooldown] = useState(RESEND_COOLDOWN)
+
+    useEffect(() => {
+        if (cooldown <= 0) return
+        const t = setInterval(() => setCooldown((c) => c - 1), 1000)
+        return () => clearInterval(t)
+    }, [cooldown])
+
+    // Only gate authenticated, unverified, non-suspended users.
+    // (Suspension takes priority and is handled by SuspensionOverlay.)
+    const email = user?.email || ''
+    if (!isAuthenticated || !user || user.is_suspended || user.is_email_verified) {
+        return null
+    }
+
+    const handleSubmit = async (e) => {
+        e.preventDefault()
+        if (code.trim().length < 4) {
+            toast.error('Enter the code from your email')
+            return
+        }
+        const result = await verifyEmail(email, code.trim())
+        if (result.success) {
+            toast.success('Email verified! 🎉')
+        } else {
+            toast.error(result.error || 'Verification failed')
+        }
+    }
+
+    const handleResend = async () => {
+        const result = await resendOtp(email)
+        if (result.success) {
+            toast.success('A new code is on its way')
+            setCooldown(RESEND_COOLDOWN)
+        } else {
+            toast.error(result.error || 'Could not resend code')
+        }
+    }
+
+    return (
+        <AnimatePresence>
+            <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="fixed inset-0 z-[9998] flex items-center justify-center p-4 bg-surface-900/90 backdrop-blur-md"
+            >
+                <motion.div
+                    initial={{ scale: 0.9, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    className="max-w-md w-full bg-white dark:bg-surface-800 rounded-3xl p-8 shadow-2xl text-center border border-primary-100 dark:border-primary-900/30"
+                >
+                    <div className="w-20 h-20 bg-primary-100 dark:bg-primary-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+                        <MailCheck className="w-10 h-10 text-primary-600 dark:text-primary-400" />
+                    </div>
+
+                    <h2 className="text-2xl font-bold text-surface-900 dark:text-white mb-3">
+                        Verify your email
+                    </h2>
+
+                    <p className="text-surface-600 dark:text-surface-400 mb-6 leading-relaxed">
+                        We sent a 6-digit code to{' '}
+                        <span className="font-medium text-surface-800 dark:text-surface-200">{email}</span>.
+                        Enter it below to unlock your account.
+                    </p>
+
+                    <form onSubmit={handleSubmit} className="space-y-5">
+                        <input
+                            type="text"
+                            inputMode="numeric"
+                            autoComplete="one-time-code"
+                            value={code}
+                            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                            placeholder="123456"
+                            className="input text-center text-2xl tracking-[0.5em] font-semibold"
+                            maxLength={6}
+                            required
+                        />
+
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            className="btn-primary w-full py-3"
+                        >
+                            {isLoading ? 'Verifying...' : 'Verify Email'}
+                        </button>
+                    </form>
+
+                    <div className="mt-6 text-sm">
+                        <span className="text-surface-500">Didn't get the code? </span>
+                        {cooldown > 0 ? (
+                            <span className="text-surface-400">Resend in {cooldown}s</span>
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={handleResend}
+                                className="text-primary-600 font-medium hover:underline"
+                            >
+                                Resend code
+                            </button>
+                        )}
+                    </div>
+
+                    <button
+                        onClick={logout}
+                        className="mt-6 w-full flex items-center justify-center gap-2 py-3 rounded-2xl bg-surface-100 hover:bg-surface-200 dark:bg-surface-700 dark:hover:bg-surface-600 text-surface-700 dark:text-surface-200 font-bold transition-all"
+                    >
+                        <LogOut className="w-4 h-4" /> Sign Out
+                    </button>
+                </motion.div>
+            </motion.div>
+        </AnimatePresence>
+    )
+}
+
+export default VerificationGate

--- a/frontend/exam-frontend/src/context/authStore.js
+++ b/frontend/exam-frontend/src/context/authStore.js
@@ -76,13 +76,31 @@ export const useAuthStore = create(
         set({ isLoading: true, error: null })
         try {
           await api.post('/auth/verify-email/', { email, code })
-          set({ isLoading: false })
+          // Reflect verification locally so any in-app verify gate clears.
+          const current = get().user
+          set({
+            isLoading: false,
+            user: current ? { ...current, is_email_verified: true } : current,
+          })
+          // Refresh profile if we're an authenticated, onboarded session.
+          if (get().isAuthenticated && get().isOnboarded) {
+            get().fetchProfile()
+          }
           return { success: true }
         } catch (error) {
           const message = error.response?.data?.error ||
             error.response?.data?.detail || 'Verification failed'
           set({ error: message, isLoading: false })
           return { success: false, error: message }
+        }
+      },
+
+      // Mark the current session as suspended (driven by a 403 account_suspended
+      // response). Keeps the session so the blocking overlay can show.
+      markSuspended: () => {
+        const current = get().user
+        if (current && !current.is_suspended) {
+          set({ user: { ...current, is_suspended: true } })
         }
       },
 

--- a/frontend/exam-frontend/src/pages/auth/Onboarding.jsx
+++ b/frontend/exam-frontend/src/pages/auth/Onboarding.jsx
@@ -1,25 +1,16 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { useAuthStore } from '../../context/authStore'
-import { courseService } from '../../services/courseService'
-import Loading from '../../components/common/Loading'
 import toast from 'react-hot-toast'
 import {
-  Target,
   Rocket,
   Sunrise,
   Sun,
   Sunset,
   Moon,
   ChevronRight,
-  Check
 } from 'lucide-react'
-
-const steps = [
-  { id: 1, title: 'Choose Your Course', icon: <Target size={20} /> },
-  { id: 2, title: 'Set Your Goals', icon: <Rocket size={20} /> },
-]
 
 const studyTimes = [
   { value: 'morning', label: 'Morning (6AM-12PM)', icon: <Sunrise size={20} /> },
@@ -32,11 +23,7 @@ const Onboarding = () => {
   const navigate = useNavigate()
   const { isAuthenticated, isOnboarded, completeOnboarding, isLoading } = useAuthStore()
 
-  const [currentStep, setCurrentStep] = useState(1)
-  const [courses, setCourses] = useState([])
   const [formData, setFormData] = useState({
-    primary_course_id: '',
-    additional_course_ids: [],
     target_year: new Date().getFullYear() + 1,
     daily_study_goal_minutes: 60,
     preferred_study_time: 'evening',
@@ -50,37 +37,7 @@ const Onboarding = () => {
     }
   }, [isAuthenticated, isOnboarded, navigate])
 
-  useEffect(() => {
-    loadCourses()
-  }, [])
-
-  const loadCourses = async () => {
-    try {
-      const data = await courseService.getCourses()
-      setCourses(data.results || data)
-    } catch (error) {
-      console.error('Failed to load courses:', error)
-    }
-  }
-
-  const handleNext = () => {
-    if (currentStep < 2) {
-      setCurrentStep(currentStep + 1)
-    }
-  }
-
-  const handleBack = () => {
-    if (currentStep > 1) {
-      setCurrentStep(currentStep - 1)
-    }
-  }
-
   const handleSubmit = async () => {
-    if (!formData.primary_course_id) {
-      toast.error('Please select your course')
-      return
-    }
-
     const result = await completeOnboarding(formData)
     if (result.success) {
       toast.success('Welcome to DailyTaiyari! 🎉')
@@ -93,179 +50,105 @@ const Onboarding = () => {
   return (
     <div className="min-h-screen bg-surface-50 dark:bg-surface-950 flex items-center justify-center p-4">
       <div className="w-full max-w-2xl">
-        {/* Progress Steps */}
         <div className="flex items-center justify-center mb-8">
-          {steps.map((step, index) => (
-            <div key={step.id} className="flex items-center">
-              <div
-                className={`w-10 h-10 rounded-full flex items-center justify-center font-semibold transition-colors ${currentStep >= step.id
-                  ? 'bg-primary-500 text-white'
-                  : 'bg-surface-200 dark:bg-surface-700 text-surface-500'
-                  }`}
-              >
-                {currentStep > step.id ? <Check size={20} /> : step.icon}
-              </div>
-              {index < steps.length - 1 && (
-                <div
-                  className={`w-20 h-1 mx-2 rounded-full transition-colors ${currentStep > step.id
-                    ? 'bg-primary-500'
-                    : 'bg-surface-200 dark:bg-surface-700'
-                    }`}
-                />
-              )}
-            </div>
-          ))}
+          <div className="w-12 h-12 rounded-full flex items-center justify-center font-semibold bg-primary-500 text-white">
+            <Rocket size={22} />
+          </div>
         </div>
 
-        {/* Step Content */}
         <motion.div
-          key={currentStep}
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -20 }}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
           className="card p-8"
         >
           <h2 className="text-2xl font-display font-bold mb-2 text-center">
-            {steps[currentStep - 1].title}
+            Set Your Goals
           </h2>
           <p className="text-surface-500 text-center mb-8">
-            {currentStep === 1 && 'Which course would you like to start with?'}
-            {currentStep === 2 && 'Set your daily study goals'}
+            Tell us how you like to study. You can browse and join courses from the
+            Courses tab once you're in.
           </p>
 
-          {/* Step 1: Course Selection */}
-          {currentStep === 1 && (
-            <div className="space-y-4">
-              <p className="text-sm text-surface-500 mb-4">Select your primary course:</p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                {courses.map((course) => (
+          <div className="space-y-6">
+            {/* Daily Study Goal */}
+            <div>
+              <label className="block text-sm font-medium mb-3">
+                Daily Study Goal (minutes)
+              </label>
+              <div className="flex items-center gap-4">
+                <input
+                  type="range"
+                  min="30"
+                  max="180"
+                  step="15"
+                  value={formData.daily_study_goal_minutes}
+                  onChange={(e) =>
+                    setFormData({ ...formData, daily_study_goal_minutes: parseInt(e.target.value) })
+                  }
+                  className="flex-1"
+                />
+                <span className="w-20 text-center font-semibold text-primary-600">
+                  {formData.daily_study_goal_minutes} min
+                </span>
+              </div>
+            </div>
+
+            {/* Preferred Study Time */}
+            <div>
+              <label className="block text-sm font-medium mb-3">
+                Preferred Study Time
+              </label>
+              <div className="grid grid-cols-2 gap-3">
+                {studyTimes.map((time) => (
                   <button
-                    key={course.id}
-                    onClick={() => setFormData({ ...formData, primary_course_id: course.id })}
-                    className={`p-4 rounded-xl border-2 text-left transition-all ${formData.primary_course_id === course.id
+                    key={time.value}
+                    onClick={() =>
+                      setFormData({ ...formData, preferred_study_time: time.value })
+                    }
+                    className={`p-3 rounded-xl border-2 text-left transition-all flex items-center gap-3 ${formData.preferred_study_time === time.value
                       ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
                       : 'border-surface-200 dark:border-surface-700 hover:border-primary-300'
                       }`}
                   >
-                    <div className="flex items-center gap-3">
-                      <div
-                        className="w-10 h-10 rounded-lg flex items-center justify-center text-white font-bold"
-                        style={{ backgroundColor: course.color }}
-                      >
-                        {course.name.charAt(0)}
-                      </div>
-                      <div>
-                        <h4 className="font-semibold">{course.name}</h4>
-                        <p className="text-xs text-surface-500">{course.description?.slice(0, 60) || course.course_type}</p>
-                      </div>
-                    </div>
+                    <span className={`${formData.preferred_study_time === time.value ? 'text-primary-500' : 'text-surface-400'}`}>
+                      {time.icon}
+                    </span>
+                    <span className="text-sm font-medium">{time.label}</span>
                   </button>
                 ))}
               </div>
             </div>
-          )}
 
-          {/* Step 2: Goals */}
-          {currentStep === 2 && (
-            <div className="space-y-6">
-              {/* Daily Study Goal */}
-              <div>
-                <label className="block text-sm font-medium mb-3">
-                  Daily Study Goal (minutes)
-                </label>
-                <div className="flex items-center gap-4">
-                  <input
-                    type="range"
-                    min="30"
-                    max="180"
-                    step="15"
-                    value={formData.daily_study_goal_minutes}
-                    onChange={(e) =>
-                      setFormData({ ...formData, daily_study_goal_minutes: parseInt(e.target.value) })
-                    }
-                    className="flex-1"
-                  />
-                  <span className="w-20 text-center font-semibold text-primary-600">
-                    {formData.daily_study_goal_minutes} min
-                  </span>
-                </div>
-              </div>
-
-              {/* Preferred Study Time */}
-              <div>
-                <label className="block text-sm font-medium mb-3">
-                  Preferred Study Time
-                </label>
-                <div className="grid grid-cols-2 gap-3">
-                  {studyTimes.map((time) => (
-                    <button
-                      key={time.value}
-                      onClick={() =>
-                        setFormData({ ...formData, preferred_study_time: time.value })
-                      }
-                      className={`p-3 rounded-xl border-2 text-left transition-all flex items-center gap-3 ${formData.preferred_study_time === time.value
-                        ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
-                        : 'border-surface-200 dark:border-surface-700 hover:border-primary-300'
-                        }`}
-                    >
-                      <span className={`${formData.preferred_study_time === time.value ? 'text-primary-500' : 'text-surface-400'}`}>
-                        {time.icon}
-                      </span>
-                      <span className="text-sm font-medium">{time.label}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Target Year */}
-              <div>
-                <label className="block text-sm font-medium mb-2">Target Year</label>
-                <select
-                  value={formData.target_year}
-                  onChange={(e) =>
-                    setFormData({ ...formData, target_year: parseInt(e.target.value) })
-                  }
-                  className="input"
-                >
-                  {[0, 1, 2, 3].map((offset) => {
-                    const year = new Date().getFullYear() + offset
-                    return (
-                      <option key={year} value={year}>
-                        {year}
-                      </option>
-                    )
-                  })}
-                </select>
-              </div>
+            {/* Target Year */}
+            <div>
+              <label className="block text-sm font-medium mb-2">Target Year</label>
+              <select
+                value={formData.target_year}
+                onChange={(e) =>
+                  setFormData({ ...formData, target_year: parseInt(e.target.value) })
+                }
+                className="input"
+              >
+                {[0, 1, 2, 3].map((offset) => {
+                  const year = new Date().getFullYear() + offset
+                  return (
+                    <option key={year} value={year}>
+                      {year}
+                    </option>
+                  )
+                })}
+              </select>
             </div>
-          )}
+          </div>
 
-          {/* Navigation Buttons */}
-          <div className="flex justify-between mt-8">
+          <div className="flex justify-end mt-8">
             <button
-              onClick={handleBack}
-              className={`btn-secondary ${currentStep === 1 ? 'invisible' : ''}`}
+              onClick={handleSubmit}
+              disabled={isLoading}
+              className="btn-primary flex items-center gap-2"
             >
-              Back
+              {isLoading ? 'Setting up...' : <>{'Start Learning'} <ChevronRight size={18} /></>}
             </button>
-
-            {currentStep < 2 ? (
-              <button
-                onClick={handleNext}
-                disabled={currentStep === 1 && !formData.primary_course_id}
-                className="btn-primary"
-              >
-                Continue
-              </button>
-            ) : (
-              <button
-                onClick={handleSubmit}
-                disabled={isLoading}
-                className="btn-primary flex items-center gap-2"
-              >
-                {isLoading ? 'Setting up...' : <>{'Start Learning'} <ChevronRight size={18} /></>}
-              </button>
-            )}
           </div>
         </motion.div>
       </div>
@@ -274,4 +157,3 @@ const Onboarding = () => {
 }
 
 export default Onboarding
-

--- a/frontend/exam-frontend/src/services/api.js
+++ b/frontend/exam-frontend/src/services/api.js
@@ -39,6 +39,15 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config
 
+    // Suspended account: keep the session, flip the flag so the blocking
+    // overlay renders app-wide. Do NOT logout or redirect.
+    if (error.response?.status === 403 && error.response?.data?.code === 'account_suspended') {
+      import('../context/authStore')
+        .then(({ useAuthStore }) => useAuthStore.getState().markSuspended())
+        .catch(() => {})
+      return Promise.reject(error)
+    }
+
     // If 401 and not already retrying, try to refresh token
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true


### PR DESCRIPTION
## What & why

Addresses the account-flow requirements: drop course auto-enrollment from onboarding, gate the app for unverified users, and enforce suspension everywhere.

### Registration & onboarding
- Registration no longer auto-enrolls users in a course. Onboarding is now **goals-only** (daily goal, study time, target year) — course selection is removed.
- Students join courses from the **Courses tab**, which creates a `pending` enrollment for admin approval (existing flow).

### Email verification (allow login, then gate)
- Backend login **no longer blocks** unverified users (`CustomTokenObtainPairSerializer` returns tokens).
- New full-screen `VerificationGate` overlay blocks the app until the email is verified (enter OTP / resend / sign out). `verifyEmail` flips the local flag so the gate clears instantly.

### Suspension enforcement
- New `BlockSuspendedUsersMiddleware` rejects suspended accounts on **all `/api/` endpoints** with `403 {code: account_suspended}`, regardless of per-view `permission_classes`. Auth/bootstrap paths (login, refresh, verify, profile, etc.) stay reachable.
- The api interceptor flips `is_suspended` on a 403 so the existing `SuspensionOverlay` blurs the app **without logging the user out** or looping through token refresh.

## Testing
- Frontend `npm run build` ✓
- Backend `py_compile` ✓ on changed files
- Backend needs `restart web` only — no migration, no new deps, no image rebuild.

## Verify live
- Unverified user can log in but is gated to the verify screen.
- New registration creates no course enrollment; onboarding doesn't ask for a course.
- Suspended user gets 403 on data APIs and sees the blur modal.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>