### PR TITLE
Fix Netlify build: landing-page src/lib was gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,8 @@ credentials.json
 ehthumbs.db
 Icon?
 Thumbs.db
+
+# Next.js landing-page source lib (NOT Python build output — the generic `lib/`
+# rule above would otherwise swallow it and break Netlify builds)
+!frontend/landing-page/main/src/lib/
+!frontend/landing-page/main/src/lib/**

--- a/frontend/landing-page/main/src/lib/leads.ts
+++ b/frontend/landing-page/main/src/lib/leads.ts
@@ -1,0 +1,60 @@
+// Public platform lead helpers (demo bookings + contact messages).
+// These call the DailyTaiyari backend directly — NO tenant header, no auth.
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ||
+  "https://api.dailytaiyari.in/api/v1";
+
+export const LEAD_EVENT = "dt:open-lead";
+export type LeadKind = "demo" | "contact";
+
+/** Open the demo / contact dialog from anywhere on the page. */
+export function openLeadDialog(kind: LeadKind) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<LeadKind>(LEAD_EVENT, { detail: kind }));
+}
+
+export interface DemoBookingPayload {
+  name: string;
+  email: string;
+  phone?: string;
+  organization?: string;
+  organization_type?: string;
+  message?: string;
+}
+
+export interface ContactMessagePayload {
+  name: string;
+  email: string;
+  subject?: string;
+  message: string;
+}
+
+async function postLead(path: string, payload: object) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...payload, source: "landing" }),
+  });
+  if (!res.ok) {
+    let detail = "Something went wrong. Please try again.";
+    try {
+      const data = await res.json();
+      const first = Object.values(data)[0];
+      if (typeof first === "string") detail = first;
+      else if (Array.isArray(first) && first.length) detail = String(first[0]);
+    } catch {
+      /* ignore parse errors */
+    }
+    throw new Error(detail);
+  }
+  return res.json();
+}
+
+export function submitDemoBooking(payload: DemoBookingPayload) {
+  return postLead("/platform/demo-bookings/", payload);
+}
+
+export function submitContactMessage(payload: ContactMessagePayload) {
+  return postLead("/platform/contact-messages/", payload);
+}


### PR DESCRIPTION
## Problem

Netlify builds were failing with:
```
Module not found: Can't resolve '@/lib/leads'
```
across `Hero.tsx`, `InstituteNav.tsx`, `LeadCTAButtons.tsx`, `LeadDialogs.tsx`.

## Root cause

The generic **Python** packaging rule `lib/` in the root `.gitignore` also matched the Next.js landing page's `src/lib/` directory. So `src/lib/leads.ts` was **never committed**. Local builds passed because the file exists on disk, but Netlify only has committed files — hence the module-not-found.

## Fix

- Add scoped negations to `.gitignore` to re-include `frontend/landing-page/main/src/lib/` (the Python `lib/` protection stays intact everywhere else — the only other `lib/` dirs are under `backend/.venv/`, already ignored).
- Commit the previously-missing `src/lib/leads.ts`.

## Verification

Built from a **committed-only archive** of this branch (simulating Netlify's clean checkout) — `leads.ts` is present and `npm run build` passes with all routes prerendered.