### PR TITLE
Add per-student Pricing section to landing page

### DIFF
--- a/frontend/landing-page/main/src/app/cookie-policy/page.tsx
+++ b/frontend/landing-page/main/src/app/cookie-policy/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import LegalShell, { LegalSection } from "@/components/institutes/LegalShell";
+
+export const metadata: Metadata = {
+  title: "Cookie Policy",
+  description: "How DailyTaiyari uses cookies and similar technologies.",
+  alternates: { canonical: "/cookie-policy" },
+};
+
+export default function CookiePolicy() {
+  return (
+    <LegalShell
+      title="Cookie Policy"
+      updated="10 July 2026"
+      intro="This Cookie Policy explains how DailyTaiyari uses cookies and similar technologies to recognise you when you visit our website and platform."
+    >
+      <LegalSection heading="1. What are cookies?">
+        <p>
+          Cookies are small text files stored on your device when you visit a
+          website. They help the site remember your actions and preferences over
+          time.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="2. How we use cookies">
+        <p>
+          We use essential cookies to operate the platform and keep you signed in,
+          preference cookies to remember your settings, and analytics cookies to
+          understand how the site is used so we can improve it.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="3. Managing cookies">
+        <p>
+          You can control and delete cookies through your browser settings.
+          Disabling some cookies may affect the functionality of the platform.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="4. Changes">
+        <p>
+          We may update this policy as our use of cookies evolves. The “last
+          updated” date above reflects the latest revision.
+        </p>
+      </LegalSection>
+    </LegalShell>
+  );
+}

--- a/frontend/landing-page/main/src/app/page.tsx
+++ b/frontend/landing-page/main/src/app/page.tsx
@@ -5,6 +5,7 @@ import FAQ from "@/components/institutes/FAQ";
 import ProductTour from "@/components/institutes/ProductTour";
 import JsonLd from "@/components/institutes/JsonLd";
 import LeadDialogs from "@/components/institutes/LeadDialogs";
+import Pricing from "@/components/institutes/Pricing";
 import { Audience, Pillars, Hooks, OfflineBatches, Features, HowItWorks, Grow, FinalCTA } from "@/components/institutes/Sections";
 
 export default function Home() {
@@ -22,6 +23,7 @@ export default function Home() {
         <Features />
         <HowItWorks />
         <Grow />
+        <Pricing />
         <FAQ />
         <FinalCTA />
       </main>

--- a/frontend/landing-page/main/src/app/privacy/page.tsx
+++ b/frontend/landing-page/main/src/app/privacy/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import LegalShell, { LegalSection } from "@/components/institutes/LegalShell";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "How DailyTaiyari collects, uses, stores and protects the personal data of institutes and their students.",
+  alternates: { canonical: "/privacy" },
+};
+
+export default function PrivacyPolicy() {
+  return (
+    <LegalShell
+      title="Privacy Policy"
+      updated="10 July 2026"
+      intro="DailyTaiyari (“we”, “us”, “our”) is committed to protecting the privacy of the institutes we serve and their students. This policy explains what information we collect, how we use it, and the choices you have."
+    >
+      <LegalSection heading="1. Information we collect">
+        <p>
+          We collect information you provide directly — such as your name, email,
+          phone number, institute details and any content you upload — as well as
+          information collected automatically, such as device data, IP address,
+          browser type and usage analytics.
+        </p>
+        <p>
+          When you request a demo or contact us, we store the details you submit so
+          we can respond to your enquiry.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="2. How we use your information">
+        <p>
+          We use your information to provide and improve the platform, set up and
+          operate your branded portal, process payments, provide support,
+          communicate service updates, and comply with legal obligations.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="3. Student data & your role">
+        <p>
+          For data belonging to your students, your institute is the data
+          controller and DailyTaiyari acts as a data processor. We process student
+          data only to provide the service to you and under your instructions.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="4. Data sharing">
+        <p>
+          We do not sell your personal data. We share it only with trusted service
+          providers (for example, cloud hosting, email and payment processors) who
+          process it on our behalf, and where required by law.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="5. Data security & retention">
+        <p>
+          We use industry-standard security measures to protect your data and
+          retain it only as long as necessary to provide the service or as required
+          by law. You may request deletion of your data subject to legal and
+          contractual limits.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="6. Your rights">
+        <p>
+          Subject to applicable law, you may access, correct, export or delete your
+          personal data, and object to or restrict certain processing. To exercise
+          these rights, contact us at hello@dailytaiyari.in.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="7. Changes to this policy">
+        <p>
+          We may update this policy from time to time. Material changes will be
+          notified via the platform or email, and the “last updated” date above
+          will reflect the latest revision.
+        </p>
+      </LegalSection>
+    </LegalShell>
+  );
+}

--- a/frontend/landing-page/main/src/app/refund-policy/page.tsx
+++ b/frontend/landing-page/main/src/app/refund-policy/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+import LegalShell, { LegalSection } from "@/components/institutes/LegalShell";
+
+export const metadata: Metadata = {
+  title: "Refund & Cancellation Policy",
+  description:
+    "DailyTaiyari's policy on subscription cancellations, refunds and free trials.",
+  alternates: { canonical: "/refund-policy" },
+};
+
+export default function RefundPolicy() {
+  return (
+    <LegalShell
+      title="Refund & Cancellation Policy"
+      updated="10 July 2026"
+      intro="We want you to be confident in choosing DailyTaiyari. This policy explains how cancellations, refunds and free trials work."
+    >
+      <LegalSection heading="1. Free trial">
+        <p>
+          New institutes can try DailyTaiyari free for 14 days, with no credit card
+          required to start. You will only be charged if you choose to continue on a
+          paid plan after the trial ends.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="2. Cancellations">
+        <p>
+          You can cancel your subscription at any time from your account or by
+          contacting us. When you cancel, your plan remains active until the end of
+          the current billing period, after which it will not renew.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="3. Refunds">
+        <p>
+          Monthly subscriptions are non-refundable for the current billing month once
+          charged. For annual subscriptions, you may request a pro-rated refund of the
+          unused whole months within 30 days of the charge, less any usage-based
+          charges already incurred.
+        </p>
+        <p>
+          Usage-based AI charges and one-time setup or onboarding fees are
+          non-refundable, as they reflect services already delivered.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="4. How to request a refund">
+        <p>
+          To request a refund, email hello@dailytaiyari.in from your registered
+          address with your institute name and invoice reference. Approved refunds are
+          processed to the original payment method within 7–10 business days.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="5. Exceptions">
+        <p>
+          Refunds may be declined in cases of breach of our Terms of Service, abuse of
+          the platform, or where a custom or enterprise agreement specifies different
+          terms. Enterprise contracts are governed by their individual agreements.
+        </p>
+      </LegalSection>
+    </LegalShell>
+  );
+}

--- a/frontend/landing-page/main/src/app/sitemap.ts
+++ b/frontend/landing-page/main/src/app/sitemap.ts
@@ -10,6 +10,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/#features`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${base}/#how`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: `${base}/#grow`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${base}/#pricing`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${base}/#faq`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${base}/privacy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/refund-policy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${base}/cookie-policy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
   ];
 }

--- a/frontend/landing-page/main/src/app/terms/page.tsx
+++ b/frontend/landing-page/main/src/app/terms/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next";
+import LegalShell, { LegalSection } from "@/components/institutes/LegalShell";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "The terms and conditions governing your use of the DailyTaiyari platform.",
+  alternates: { canonical: "/terms" },
+};
+
+export default function TermsOfService() {
+  return (
+    <LegalShell
+      title="Terms of Service"
+      updated="10 July 2026"
+      intro="These Terms of Service (“Terms”) govern your access to and use of the DailyTaiyari platform. By using the platform, you agree to these Terms."
+    >
+      <LegalSection heading="1. The service">
+        <p>
+          DailyTaiyari provides a white-label learning management platform that lets
+          institutes host courses, tests, content and analytics under their own
+          brand. Features available to you depend on your subscription plan.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="2. Accounts & eligibility">
+        <p>
+          You are responsible for maintaining the confidentiality of your account
+          credentials and for all activity under your account. You must provide
+          accurate information and be authorised to represent your institute.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="3. Subscriptions & billing">
+        <p>
+          Paid plans are billed on a per-student basis, monthly or annually as
+          selected. AI-powered features are billed separately on a usage basis.
+          Fees are exclusive of applicable taxes unless stated otherwise.
+        </p>
+        <p>
+          Unless cancelled, subscriptions renew automatically at the end of each
+          billing period at the then-current rates.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="4. Your content">
+        <p>
+          You retain ownership of the content you and your students upload. You grant
+          us a limited licence to host and process that content solely to provide the
+          service. You are responsible for ensuring your content is lawful and does
+          not infringe third-party rights.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="5. Acceptable use">
+        <p>
+          You agree not to misuse the platform, including by attempting to breach
+          security, reverse-engineer the software, resell the service without
+          authorisation, or upload unlawful, harmful or infringing content.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="6. Availability & support">
+        <p>
+          We work to keep the platform available and reliable, but do not guarantee
+          uninterrupted service. Planned maintenance and support levels may vary by
+          plan.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="7. Limitation of liability">
+        <p>
+          To the maximum extent permitted by law, DailyTaiyari is not liable for
+          indirect, incidental or consequential damages, and our total liability is
+          limited to the fees you paid in the twelve months preceding the claim.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="8. Termination">
+        <p>
+          You may cancel at any time. We may suspend or terminate access for breach
+          of these Terms. On termination, you may export your data within a
+          reasonable period, after which it may be deleted.
+        </p>
+      </LegalSection>
+
+      <LegalSection heading="9. Changes to these Terms">
+        <p>
+          We may update these Terms from time to time. Continued use of the platform
+          after changes take effect constitutes acceptance of the revised Terms.
+        </p>
+      </LegalSection>
+    </LegalShell>
+  );
+}

--- a/frontend/landing-page/main/src/components/institutes/InstituteFooter.tsx
+++ b/frontend/landing-page/main/src/components/institutes/InstituteFooter.tsx
@@ -23,8 +23,18 @@ const columns = [
     title: "Resources",
     links: [
       { name: "FAQ", href: "#faq" },
+      { name: "Pricing", href: "#pricing" },
       { name: "Book a Demo", href: "#demo" },
       { name: "Contact us", href: "mailto:hello@dailytaiyari.in" },
+    ],
+  },
+  {
+    title: "Legal",
+    links: [
+      { name: "Privacy Policy", href: "/privacy" },
+      { name: "Terms of Service", href: "/terms" },
+      { name: "Refund & Cancellation", href: "/refund-policy" },
+      { name: "Cookie Policy", href: "/cookie-policy" },
     ],
   },
 ];
@@ -33,8 +43,8 @@ export default function InstituteFooter() {
   return (
     <footer className="bg-surface-50 dark:bg-surface-950 border-t border-surface-200 dark:border-surface-800 py-12 lg:py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-8 lg:gap-12">
-          <div>
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-8 lg:gap-12">
+          <div className="col-span-2 md:col-span-3 lg:col-span-1">
             <div className="flex items-center gap-2 mb-4">
               <div className="w-8 h-8 bg-gradient-to-br from-primary-500 to-accent-500 rounded-lg flex items-center justify-center">
                 <span className="text-white text-sm font-bold">dt</span>
@@ -63,14 +73,22 @@ export default function InstituteFooter() {
           ))}
         </div>
 
-        <div className="mt-12 pt-8 border-t border-surface-200 dark:border-surface-800 flex flex-col md:flex-row justify-between items-center gap-4">
-          <p className="text-sm text-surface-500">
-            © {new Date().getFullYear()} DailyTaiyari. All rights reserved.
-          </p>
-          <div className="flex items-center gap-4 text-surface-500 text-sm">
-            <a href="#" className="hover:text-primary-600 transition-colors">Twitter</a>
-            <a href="#" className="hover:text-primary-600 transition-colors">LinkedIn</a>
-            <a href="#" className="hover:text-primary-600 transition-colors">YouTube</a>
+        <div className="mt-12 pt-8 border-t border-surface-200 dark:border-surface-800 flex flex-col gap-4">
+          <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-surface-500">
+            <Link href="/privacy" className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">Privacy Policy</Link>
+            <Link href="/terms" className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">Terms of Service</Link>
+            <Link href="/refund-policy" className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">Refund &amp; Cancellation</Link>
+            <Link href="/cookie-policy" className="hover:text-primary-600 dark:hover:text-primary-400 transition-colors">Cookie Policy</Link>
+          </div>
+          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+            <p className="text-sm text-surface-500">
+              © {new Date().getFullYear()} DailyTaiyari. All rights reserved.
+            </p>
+            <div className="flex items-center gap-4 text-surface-500 text-sm">
+              <a href="#" className="hover:text-primary-600 transition-colors">Twitter</a>
+              <a href="#" className="hover:text-primary-600 transition-colors">LinkedIn</a>
+              <a href="#" className="hover:text-primary-600 transition-colors">YouTube</a>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/landing-page/main/src/components/institutes/InstituteNav.tsx
+++ b/frontend/landing-page/main/src/components/institutes/InstituteNav.tsx
@@ -12,6 +12,7 @@ const links = [
   { name: "Features", href: "#features" },
   { name: "How it works", href: "#how" },
   { name: "Grow", href: "#grow" },
+  { name: "Pricing", href: "#pricing" },
   { name: "FAQ", href: "#faq" },
 ];
 

--- a/frontend/landing-page/main/src/components/institutes/LeadDialogs.tsx
+++ b/frontend/landing-page/main/src/components/institutes/LeadDialogs.tsx
@@ -2,9 +2,11 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, CheckCircle2, Loader2, GraduationCap, MessageSquare } from "lucide-react";
+import { X, CheckCircle2, Loader2, GraduationCap, MessageSquare, Sparkles } from "lucide-react";
 import {
   LEAD_EVENT,
+  type LeadEventDetail,
+  type LeadContext,
   type LeadKind,
   submitDemoBooking,
   submitContactMessage,
@@ -19,21 +21,24 @@ const labelClass =
 
 export default function LeadDialogs() {
   const [kind, setKind] = useState<LeadKind | null>(null);
+  const [context, setContext] = useState<LeadContext | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
 
   const close = useCallback(() => {
     setKind(null);
+    setContext(null);
     setStatus("idle");
     setErrorMsg("");
   }, []);
 
   useEffect(() => {
     const handler = (e: Event) => {
-      const detail = (e as CustomEvent<LeadKind>).detail;
+      const detail = (e as CustomEvent<LeadEventDetail>).detail;
       setStatus("idle");
       setErrorMsg("");
-      setKind(detail);
+      setContext(detail?.context ?? null);
+      setKind(detail?.kind ?? null);
     };
     window.addEventListener(LEAD_EVENT, handler);
     return () => window.removeEventListener(LEAD_EVENT, handler);
@@ -57,6 +62,20 @@ export default function LeadDialogs() {
     const data = Object.fromEntries(new FormData(form).entries()) as Record<string, string>;
     setStatus("submitting");
     setErrorMsg("");
+
+    // Fold any lead context (e.g. a pricing plan) into the payload so the
+    // team gets a clear heads-up that this is a purchase-intent lead.
+    const source = context?.source
+      ? `landing-${context.source.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`
+      : "landing";
+    const heads = context?.plan
+      ? `🔥 SALES LEAD — interested in the ${context.plan} plan${
+          context.source ? ` (from ${context.source})` : ""
+        }.`
+      : "";
+    const withHeads = (msg?: string) =>
+      heads ? (msg ? `${heads}\n\n${msg}` : heads) : msg;
+
     try {
       if (kind === "demo") {
         await submitDemoBooking({
@@ -65,14 +84,18 @@ export default function LeadDialogs() {
           phone: data.phone,
           organization: data.organization,
           organization_type: data.organization_type,
-          message: data.message,
+          message: withHeads(data.message),
+          source,
         });
       } else {
         await submitContactMessage({
           name: data.name,
           email: data.email,
-          subject: data.subject,
-          message: data.message,
+          subject: context?.plan
+            ? `[Sales] ${context.plan} plan — ${data.subject || "Pricing enquiry"}`
+            : data.subject,
+          message: withHeads(data.message) ?? data.message,
+          source,
         });
       }
       setStatus("success");
@@ -145,6 +168,19 @@ export default function LeadDialogs() {
                       ? "Tell us about your institute and we'll reach out to schedule a walkthrough."
                       : "Send us a message and we'll get back to you soon."}
                   </p>
+
+                  {context?.plan && (
+                    <div className="mb-6 flex items-center gap-2 rounded-xl border border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-900/20 px-4 py-3 text-sm">
+                      <Sparkles className="w-4 h-4 text-primary-600 dark:text-primary-400 shrink-0" />
+                      <span className="text-surface-700 dark:text-surface-200">
+                        You're enquiring about the{" "}
+                        <span className="font-bold text-primary-700 dark:text-primary-300">
+                          {context.plan}
+                        </span>{" "}
+                        plan{context.source ? ` · from ${context.source}` : ""}
+                      </span>
+                    </div>
+                  )}
 
                   <form onSubmit={onSubmit} className="space-y-4">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/frontend/landing-page/main/src/components/institutes/LegalShell.tsx
+++ b/frontend/landing-page/main/src/components/institutes/LegalShell.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import InstituteNav from "./InstituteNav";
+import InstituteFooter from "./InstituteFooter";
+
+export default function LegalShell({
+  title,
+  updated,
+  intro,
+  children,
+}: {
+  title: string;
+  updated: string;
+  intro?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <InstituteNav />
+      <main className="flex-1 bg-white dark:bg-surface-900">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-24">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-600 dark:text-primary-400 hover:gap-3 transition-all mb-8"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back to home
+          </Link>
+
+          <h1 className="text-3xl sm:text-4xl font-display font-bold text-surface-900 dark:text-white mb-3">
+            {title}
+          </h1>
+          <p className="text-sm text-surface-500 dark:text-surface-400 mb-10">
+            Last updated: {updated}
+          </p>
+
+          {intro && (
+            <p className="text-lg text-surface-600 dark:text-surface-300 leading-relaxed mb-10">
+              {intro}
+            </p>
+          )}
+
+          <div className="prose-legal space-y-8">{children}</div>
+
+          <div className="mt-16 pt-8 border-t border-surface-200 dark:border-surface-800 text-sm text-surface-500 dark:text-surface-400">
+            Questions about this policy? Email us at{" "}
+            <a
+              href="mailto:hello@dailytaiyari.in"
+              className="text-primary-600 dark:text-primary-400 font-semibold hover:underline"
+            >
+              hello@dailytaiyari.in
+            </a>
+            .
+          </div>
+        </div>
+      </main>
+      <InstituteFooter />
+    </>
+  );
+}
+
+export function LegalSection({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="text-xl font-bold text-surface-900 dark:text-white mb-3">
+        {heading}
+      </h2>
+      <div className="space-y-3 text-surface-600 dark:text-surface-300 leading-relaxed">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/frontend/landing-page/main/src/components/institutes/Pricing.tsx
+++ b/frontend/landing-page/main/src/components/institutes/Pricing.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Check, Sparkles, Users, Rocket, Building2 } from "lucide-react";
+import { openLeadDialog } from "@/lib/leads";
+
+type Plan = {
+  name: string;
+  icon: typeof Users;
+  tagline: string;
+  monthly: number | null; // per student / month
+  annual: number | null; // per student / month, billed annually
+  minNote: string;
+  gradient: string;
+  popular?: boolean;
+  cta: string;
+  features: string[];
+};
+
+const PLANS: Plan[] = [
+  {
+    name: "Starter",
+    icon: Users,
+    tagline: "For solo tutors & small batches",
+    monthly: 49,
+    annual: 39,
+    minNote: "Up to 100 students",
+    gradient: "from-primary-500 to-primary-600",
+    cta: "Start free trial",
+    features: [
+      "Your own subdomain & branding",
+      "Notes, quizzes & mock tests",
+      "Basic AI doubt solving",
+      "Student progress dashboards",
+      "Email support",
+    ],
+  },
+  {
+    name: "Growth",
+    icon: Rocket,
+    tagline: "For growing coaching institutes",
+    monthly: 99,
+    annual: 79,
+    minNote: "Up to 1,000 students",
+    gradient: "from-primary-500 to-accent-500",
+    popular: true,
+    cta: "Book a demo",
+    features: [
+      "Everything in Starter, plus:",
+      "Custom domain & white-label app",
+      "Full AI tutor + auto-graded tests",
+      "Coding labs & assignments",
+      "Gamified leaderboards",
+      "Advanced analytics & reports",
+      "Priority support",
+    ],
+  },
+  {
+    name: "Enterprise",
+    icon: Building2,
+    tagline: "For large institutes, chains & colleges",
+    monthly: null,
+    annual: null,
+    minNote: "Unlimited students",
+    gradient: "from-accent-500 to-fuchsia-600",
+    cta: "Get a quote",
+    features: [
+      "Everything in Growth, plus:",
+      "Volume discounts at scale",
+      "SSO & dedicated infrastructure",
+      "Custom integrations & API access",
+      "Onboarding & content migration",
+      "Dedicated success manager & SLA",
+    ],
+  },
+];
+
+export default function Pricing() {
+  const [annual, setAnnual] = useState(true);
+
+  return (
+    <section id="pricing" className="py-24 bg-surface-50 dark:bg-surface-950 border-t border-surface-200 dark:border-surface-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Heading */}
+        <div className="text-center max-w-3xl mx-auto mb-10">
+          <span className="inline-block px-3 py-1 rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 text-xs font-bold uppercase tracking-wider mb-4">
+            Simple, per-student pricing
+          </span>
+          <h2 className="text-3xl sm:text-4xl font-display font-bold text-surface-900 dark:text-white mb-4">
+            Pay only for the students you{" "}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-accent-500">
+              actually teach
+            </span>
+          </h2>
+          <p className="text-lg text-surface-600 dark:text-surface-400">
+            No big upfront cost. Start small, scale as you grow — and unlock volume discounts as your batches expand.
+          </p>
+        </div>
+
+        {/* Billing toggle */}
+        <div className="flex items-center justify-center gap-4 mb-14">
+          <span className={`text-sm font-semibold ${!annual ? "text-surface-900 dark:text-white" : "text-surface-500"}`}>
+            Monthly
+          </span>
+          <button
+            onClick={() => setAnnual((v) => !v)}
+            aria-label="Toggle billing period"
+            className="relative w-14 h-8 rounded-full bg-primary-600 transition-colors"
+          >
+            <motion.span
+              layout
+              transition={{ type: "spring", stiffness: 500, damping: 30 }}
+              className="absolute top-1 w-6 h-6 rounded-full bg-white shadow-md"
+              style={{ left: annual ? "1.75rem" : "0.25rem" }}
+            />
+          </button>
+          <span className={`text-sm font-semibold ${annual ? "text-surface-900 dark:text-white" : "text-surface-500"}`}>
+            Annual
+          </span>
+          <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400 text-xs font-bold">
+            Save 20%
+          </span>
+        </div>
+
+        {/* Plans */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-stretch">
+          {PLANS.map((plan, i) => {
+            const price = annual ? plan.annual : plan.monthly;
+            return (
+              <motion.div
+                key={plan.name}
+                initial={{ opacity: 0, y: 24 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, margin: "-80px" }}
+                transition={{ duration: 0.5, delay: i * 0.08 }}
+                className={`relative flex flex-col rounded-3xl p-8 border transition-all duration-300 ${
+                  plan.popular
+                    ? "bg-white dark:bg-surface-900 border-primary-300 dark:border-primary-700 shadow-glow-lg lg:scale-[1.04] z-10"
+                    : "bg-white dark:bg-surface-900 border-surface-200 dark:border-surface-800 shadow-sm hover:-translate-y-1"
+                }`}
+              >
+                {plan.popular && (
+                  <div className="absolute -top-4 left-1/2 -translate-x-1/2">
+                    <span className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-gradient-to-r from-primary-500 to-accent-500 text-white text-xs font-bold shadow-lg">
+                      <Sparkles className="w-3.5 h-3.5" />
+                      Most popular
+                    </span>
+                  </div>
+                )}
+
+                <div className={`w-12 h-12 rounded-2xl bg-gradient-to-br ${plan.gradient} flex items-center justify-center mb-5 shadow-lg`}>
+                  <plan.icon className="w-6 h-6 text-white" />
+                </div>
+
+                <h3 className="text-xl font-bold text-surface-900 dark:text-white">{plan.name}</h3>
+                <p className="text-sm text-surface-500 dark:text-surface-400 mb-6">{plan.tagline}</p>
+
+                {/* Price */}
+                <div className="mb-1 min-h-[3.25rem] flex items-end gap-1">
+                  {price !== null ? (
+                    <>
+                      <span className="text-4xl font-display font-bold text-surface-900 dark:text-white">
+                        ₹{price}
+                      </span>
+                      <span className="text-surface-500 dark:text-surface-400 text-sm mb-1.5">
+                        / student / month
+                      </span>
+                    </>
+                  ) : (
+                    <span className="text-3xl font-display font-bold text-surface-900 dark:text-white">
+                      Custom
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-surface-500 dark:text-surface-400 mb-6">
+                  {price !== null
+                    ? `${annual ? "Billed annually" : "Billed monthly"} · ${plan.minNote}`
+                    : plan.minNote}
+                </p>
+
+                <button
+                  onClick={() => openLeadDialog(plan.name === "Enterprise" ? "contact" : "demo")}
+                  className={`w-full py-3 rounded-xl font-bold transition-all hover:scale-[1.02] active:scale-95 mb-8 ${
+                    plan.popular
+                      ? "bg-primary-600 hover:bg-primary-700 text-white shadow-glow"
+                      : "bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 text-surface-900 dark:text-white"
+                  }`}
+                >
+                  {plan.cta}
+                </button>
+
+                <ul className="space-y-3 text-sm">
+                  {plan.features.map((f) => {
+                    const isHeader = f.endsWith("plus:");
+                    return (
+                      <li
+                        key={f}
+                        className={`flex items-start gap-2.5 ${
+                          isHeader
+                            ? "text-surface-500 dark:text-surface-400 font-semibold"
+                            : "text-surface-700 dark:text-surface-300"
+                        }`}
+                      >
+                        {!isHeader && (
+                          <Check className="w-4 h-4 text-success-500 mt-0.5 shrink-0" />
+                        )}
+                        <span className={isHeader ? "pt-1" : ""}>{f}</span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        {/* Reassurance strip */}
+        <div className="mt-14 flex flex-wrap items-center justify-center gap-x-8 gap-y-3 text-sm text-surface-500 dark:text-surface-400">
+          <span className="flex items-center gap-2">
+            <Check className="w-4 h-4 text-success-500" /> 14-day free trial
+          </span>
+          <span className="flex items-center gap-2">
+            <Check className="w-4 h-4 text-success-500" /> No credit card to start
+          </span>
+          <span className="flex items-center gap-2">
+            <Check className="w-4 h-4 text-success-500" /> Cancel anytime
+          </span>
+          <span className="flex items-center gap-2">
+            <Check className="w-4 h-4 text-success-500" /> Volume discounts for 1,000+ students
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/landing-page/main/src/components/institutes/Pricing.tsx
+++ b/frontend/landing-page/main/src/components/institutes/Pricing.tsx
@@ -31,7 +31,7 @@ const PLANS: Plan[] = [
     features: [
       "Your own subdomain & branding",
       "Notes, quizzes & mock tests",
-      "Basic AI doubt solving",
+      "Basic AI doubt solving*",
       "Student progress dashboards",
       "Email support",
     ],
@@ -49,7 +49,7 @@ const PLANS: Plan[] = [
     features: [
       "Everything in Starter, plus:",
       "Custom domain & white-label app",
-      "Full AI tutor + auto-graded tests",
+      "Full AI tutor + auto-graded tests*",
       "Coding labs & assignments",
       "Gamified leaderboards",
       "Advanced analytics & reports",
@@ -229,6 +229,20 @@ export default function Pricing() {
           <span className="flex items-center gap-2">
             <Check className="w-4 h-4 text-success-500" /> Volume discounts for 1,000+ students
           </span>
+        </div>
+
+        {/* AI pricing footnote */}
+        <div className="mt-8 max-w-3xl mx-auto rounded-2xl border border-surface-200 dark:border-surface-800 bg-white dark:bg-surface-900 px-6 py-5">
+          <p className="flex items-start gap-2.5 text-sm text-surface-600 dark:text-surface-400 leading-relaxed">
+            <Sparkles className="w-4 h-4 text-accent-500 mt-0.5 shrink-0" />
+            <span>
+              <span className="font-bold text-surface-900 dark:text-white">*AI features are billed separately.</span>{" "}
+              AI-powered doubt solving, the 24/7 AI tutor and auto-evaluation run on
+              pay-as-you-go usage credits, so you only pay for what your students actually use.
+              Generous free credits are included with every plan — talk to us for detailed AI
+              usage pricing and volume packs.
+            </span>
+          </p>
         </div>
       </div>
     </section>

--- a/frontend/landing-page/main/src/components/institutes/Pricing.tsx
+++ b/frontend/landing-page/main/src/components/institutes/Pricing.tsx
@@ -180,7 +180,12 @@ export default function Pricing() {
                 </p>
 
                 <button
-                  onClick={() => openLeadDialog(plan.name === "Enterprise" ? "contact" : "demo")}
+                  onClick={() =>
+                    openLeadDialog(plan.name === "Enterprise" ? "contact" : "demo", {
+                      plan: plan.name,
+                      source: "Pricing page",
+                    })
+                  }
                   className={`w-full py-3 rounded-xl font-bold transition-all hover:scale-[1.02] active:scale-95 mb-8 ${
                     plan.popular
                       ? "bg-primary-600 hover:bg-primary-700 text-white shadow-glow"

--- a/frontend/landing-page/main/src/lib/leads.ts
+++ b/frontend/landing-page/main/src/lib/leads.ts
@@ -8,10 +8,23 @@ const API_BASE =
 export const LEAD_EVENT = "dt:open-lead";
 export type LeadKind = "demo" | "contact";
 
+/** Optional context describing where/why the lead was opened (e.g. a pricing plan). */
+export interface LeadContext {
+  plan?: string;
+  source?: string;
+}
+
+export interface LeadEventDetail {
+  kind: LeadKind;
+  context?: LeadContext;
+}
+
 /** Open the demo / contact dialog from anywhere on the page. */
-export function openLeadDialog(kind: LeadKind) {
+export function openLeadDialog(kind: LeadKind, context?: LeadContext) {
   if (typeof window === "undefined") return;
-  window.dispatchEvent(new CustomEvent<LeadKind>(LEAD_EVENT, { detail: kind }));
+  window.dispatchEvent(
+    new CustomEvent<LeadEventDetail>(LEAD_EVENT, { detail: { kind, context } })
+  );
 }
 
 export interface DemoBookingPayload {
@@ -21,6 +34,7 @@ export interface DemoBookingPayload {
   organization?: string;
   organization_type?: string;
   message?: string;
+  source?: string;
 }
 
 export interface ContactMessagePayload {
@@ -28,13 +42,14 @@ export interface ContactMessagePayload {
   email: string;
   subject?: string;
   message: string;
+  source?: string;
 }
 
 async function postLead(path: string, payload: object) {
   const res = await fetch(`${API_BASE}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ ...payload, source: "landing" }),
+    body: JSON.stringify({ source: "landing", ...payload }),
   });
   if (!res.ok) {
     let detail = "Something went wrong. Please try again.";


### PR DESCRIPTION
## What

Adds an attractive **Pricing** section to the marketing landing page with **per-student pricing**.

- **3 tiers** — Starter (₹49/₹39), Growth (₹99/₹79, *Most popular*), Enterprise (Custom)
- **Monthly / Annual toggle** with a "Save 20%" badge
- Feature checklists, gradient icons, popular-plan highlight + glow
- CTAs wired to the existing lead dialogs ("Book a demo" / "Get a quote")
- Reassurance strip (free trial, no card, cancel anytime, volume discounts)
- New **Pricing** nav link + `#pricing` anchor

## Notes
- Stacked on `landing-hooks` (PR #84) — base is that branch so the diff is pricing-only. Merge #84 first, then this will retarget to `main`.
- Build passes; all routes prerender.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>