### PR TITLE
Course details page with pricing and enrollment request flow

### DIFF
--- a/backend/exams/admin_serializers.py
+++ b/backend/exams/admin_serializers.py
@@ -14,6 +14,7 @@ User = get_user_model()
 class AdminCourseSerializer(serializers.ModelSerializer):
     """Writable serializer for Course in the content builder."""
     subjects_count = serializers.IntegerField(source='subjects.count', read_only=True)
+    discount_percent = serializers.ReadOnlyField()
     instructors = serializers.PrimaryKeyRelatedField(
         many=True, required=False, queryset=User.objects.filter(role='instructor'),
     )
@@ -26,6 +27,8 @@ class AdminCourseSerializer(serializers.ModelSerializer):
             'color', 'status', 'is_featured', 'thumbnail',
             'duration_minutes', 'total_marks', 'negative_marking',
             'negative_marking_ratio', 'total_students', 'total_questions',
+            'pricing_type', 'price', 'original_price', 'currency',
+            'discount_percent', 'subtitle', 'highlights', 'refund_policy',
             'subjects_count', 'instructors', 'instructors_detail',
             'created_at', 'updated_at',
         ]

--- a/backend/exams/migrations/0012_course_pricing_details.py
+++ b/backend/exams/migrations/0012_course_pricing_details.py
@@ -1,0 +1,52 @@
+# Hand-authored: add pricing + details-page fields to Course.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exams', '0011_course_thumbnail'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='course',
+            name='pricing_type',
+            field=models.CharField(
+                choices=[('free', 'Free'), ('paid', 'Paid')],
+                default='free',
+                max_length=10,
+            ),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='price',
+            field=models.DecimalField(decimal_places=2, default=0, max_digits=10),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='original_price',
+            field=models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='currency',
+            field=models.CharField(default='INR', max_length=3),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='subtitle',
+            field=models.CharField(blank=True, default='', max_length=255),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='highlights',
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.AddField(
+            model_name='course',
+            name='refund_policy',
+            field=models.TextField(blank=True, default=''),
+        ),
+    ]

--- a/backend/exams/models.py
+++ b/backend/exams/models.py
@@ -57,6 +57,25 @@ class Course(TimeStampedModel):
     total_students = models.PositiveIntegerField(default=0)
     total_questions = models.PositiveIntegerField(default=0)
 
+    # ── Pricing ────────────────────────────────────────────────────────────
+    # Payment gateway is not wired yet; for now both free and paid courses
+    # simply create an enrollment request that an admin approves.
+    PRICING_TYPES = [
+        ('free', 'Free'),
+        ('paid', 'Paid'),
+    ]
+    pricing_type = models.CharField(max_length=10, choices=PRICING_TYPES, default='free')
+    price = models.DecimalField(max_digits=10, decimal_places=2, default=0)
+    # Optional higher "list" price, shown struck-through to convey a discount.
+    original_price = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
+    currency = models.CharField(max_length=3, default='INR')
+
+    # ── Marketing / details page content ───────────────────────────────────
+    subtitle = models.CharField(max_length=255, blank=True, default='')
+    # "What you will get" bullet points — a list of short strings.
+    highlights = models.JSONField(default=list, blank=True)
+    refund_policy = models.TextField(blank=True, default='')
+
     # Instructors assigned by a tenant admin. Assigned instructors can edit the
     # course content (chapters, topics, quizzes, etc.) but cannot manage the
     # instructor list themselves — that stays admin-only.
@@ -74,6 +93,21 @@ class Course(TimeStampedModel):
 
     def __str__(self):
         return self.name
+
+    @property
+    def is_free(self):
+        return self.pricing_type == 'free' or not self.price
+
+    @property
+    def discount_percent(self):
+        """Percentage off vs. original_price, if a valid discount exists."""
+        try:
+            if self.original_price and self.price and self.original_price > self.price:
+                return round((float(self.original_price) - float(self.price)) / float(self.original_price) * 100, 2)
+        except (TypeError, ValueError):
+            pass
+        return 0
+
 
 
 class Subject(OrderedModel):

--- a/backend/exams/serializers.py
+++ b/backend/exams/serializers.py
@@ -10,7 +10,10 @@ class CourseSerializer(serializers.ModelSerializer):
     subjects_count = serializers.SerializerMethodField()
     mock_tests_count = serializers.SerializerMethodField()
     quizzes_count = serializers.SerializerMethodField()
-    
+    discount_percent = serializers.ReadOnlyField()
+    is_free = serializers.ReadOnlyField()
+    instructors = serializers.SerializerMethodField()
+
     class Meta:
         model = Course
         fields = [
@@ -18,9 +21,12 @@ class CourseSerializer(serializers.ModelSerializer):
             'icon', 'color', 'status', 'is_featured', 'thumbnail',
             'duration_minutes', 'total_marks', 'negative_marking',
             'negative_marking_ratio', 'total_students', 'total_questions',
-            'subjects_count', 'mock_tests_count', 'quizzes_count', 'created_at'
+            'subjects_count', 'mock_tests_count', 'quizzes_count',
+            'pricing_type', 'price', 'original_price', 'currency',
+            'is_free', 'discount_percent', 'subtitle', 'highlights',
+            'refund_policy', 'instructors', 'created_at'
         ]
-    
+
     def get_subjects_count(self, obj):
         return obj.subjects.count()
 
@@ -29,6 +35,12 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_quizzes_count(self, obj):
         return obj.quizzes.count()
+
+    def get_instructors(self, obj):
+        return [
+            {'id': str(u.id), 'name': u.full_name or u.first_name or u.email}
+            for u in obj.instructors.all()
+        ]
 
 
 class CourseListSerializer(serializers.ModelSerializer):

--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -223,6 +223,13 @@ class AvailableCoursesForEnrollmentView(APIView):
                     {'id': str(u.id), 'name': u.full_name or u.first_name or u.email}
                     for u in e.instructors.all()
                 ],
+                'pricing_type': e.pricing_type,
+                'price': str(e.price),
+                'original_price': str(e.original_price) if e.original_price is not None else None,
+                'currency': e.currency,
+                'is_free': e.is_free,
+                'discount_percent': e.discount_percent,
+                'subtitle': e.subtitle or '',
             }
             for e in courses
         ]

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -22,6 +22,7 @@ import Dashboard from './pages/Dashboard'
 import Study from './pages/Study'
 import StudyCourse from './pages/StudyCourse'
 import Courses from './pages/Courses'
+import CourseDetail from './pages/CourseDetail'
 import StudyChapters from './pages/StudyChapters'
 import StudyChapterTopics from './pages/StudyChapterTopics'
 import StudyTopicContent from './pages/StudyTopicContent'
@@ -181,6 +182,7 @@ function App() {
         >
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/courses" element={<Courses />} />
+          <Route path="/courses/:courseId" element={<CourseDetail />} />
           <Route path="/courses/:courseId/manage" element={<EditorRoute><CourseManager /></EditorRoute>} />
           <Route path="/courses/:courseId/manage/assignments/:assignmentId" element={<EditorRoute><AssignmentGrading /></EditorRoute>} />
           <Route path="/courses/:courseId/manage/assignments/:assignmentId/submissions/:submissionId" element={<EditorRoute><SubmissionReview /></EditorRoute>} />

--- a/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
@@ -36,6 +36,7 @@ const SCHEMAS = {
         fields: [
             { name: 'name', label: 'Name', type: 'text', required: true },
             { name: 'code', label: 'Code', type: 'text', required: true, hint: 'Unique slug, e.g. neet' },
+            { name: 'subtitle', label: 'Subtitle / tagline', type: 'text', full: true },
             { name: 'course_type', label: 'Type', type: 'select', options: opt(EXAM_TYPES), default: 'competitive' },
             { name: 'status', label: 'Status', type: 'select', options: opt(EXAM_STATUS), default: 'active' },
             { name: 'color', label: 'Color', type: 'color', default: '#3B82F6' },
@@ -43,7 +44,13 @@ const SCHEMAS = {
             { name: 'total_marks', label: 'Total Marks', type: 'number' },
             { name: 'is_featured', label: 'Featured', type: 'checkbox' },
             { name: 'negative_marking', label: 'Negative Marking', type: 'checkbox' },
+            { name: 'pricing_type', label: 'Pricing', type: 'select', options: opt(['free', 'paid']), default: 'free' },
+            { name: 'price', label: 'Price', type: 'number', step: '0.01', default: 0, hint: 'Used when pricing is paid.' },
+            { name: 'original_price', label: 'Original price (strike-through)', type: 'number', step: '0.01' },
+            { name: 'currency', label: 'Currency', type: 'select', options: opt(['INR', 'USD', 'EUR', 'GBP']), default: 'INR' },
             { name: 'description', label: 'Description', type: 'textarea', full: true },
+            { name: 'highlights', label: 'What you will get (one point per line)', type: 'stringlist', full: true, placeholder: 'All Previous Year Questions (PYQ)\nFully solved answers\nExam-oriented approach' },
+            { name: 'refund_policy', label: 'Refund policy', type: 'textarea', full: true },
         ],
     },
     subject: {
@@ -128,6 +135,10 @@ const buildInitial = (fields, instance) => {
     const out = {}
     fields.forEach((f) => {
         let v = instance ? instance[f.name] : undefined
+        if (f.type === 'stringlist') {
+            out[f.name] = Array.isArray(v) ? v : (v == null ? (f.default ?? []) : [])
+            return
+        }
         if (v === undefined || v === null) v = f.default ?? (f.type === 'checkbox' ? false : '')
         out[f.name] = v
     })
@@ -149,6 +160,10 @@ const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
             if (f.type === 'number') {
                 v = v === '' || v === null ? null : Number(v)
                 if (v === null && !f.required) return
+            }
+            if (f.type === 'stringlist') {
+                const arr = Array.isArray(v) ? v : String(v || '').split('\n')
+                v = arr.map((s) => String(s).trim()).filter(Boolean)
             }
             payload[f.name] = v
         })
@@ -175,7 +190,7 @@ const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
                 <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         {schema.fields.map((f) => (
-                            <div key={f.name} className={f.full || f.type === 'textarea' ? 'sm:col-span-2' : ''}>
+                            <div key={f.name} className={f.full || f.type === 'textarea' || f.type === 'stringlist' ? 'sm:col-span-2' : ''}>
                                 {f.type === 'checkbox' ? (
                                     <label className="flex items-center gap-2 cursor-pointer py-2">
                                         <input
@@ -196,6 +211,13 @@ const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
                                                 className="input font-mono text-sm" rows={f.rows || 3}
                                                 value={values[f.name] ?? ''}
                                                 onChange={(e) => set(f.name, e.target.value)}
+                                            />
+                                        ) : f.type === 'stringlist' ? (
+                                            <textarea
+                                                className="input text-sm" rows={f.rows || 4}
+                                                placeholder={f.placeholder || 'One item per line'}
+                                                value={(Array.isArray(values[f.name]) ? values[f.name] : []).join('\n')}
+                                                onChange={(e) => set(f.name, e.target.value.split('\n'))}
                                             />
                                         ) : f.type === 'select' ? (
                                             <select className="input" value={values[f.name] ?? ''} onChange={(e) => set(f.name, e.target.value)}>

--- a/frontend/exam-frontend/src/components/admin/builderShared.jsx
+++ b/frontend/exam-frontend/src/components/admin/builderShared.jsx
@@ -203,6 +203,7 @@ export const SCHEMAS = {
         fields: [
             { name: 'name', label: 'Name', type: 'text', required: true },
             { name: 'code', label: 'Code', type: 'text', required: true, hint: 'Unique slug, e.g. neet' },
+            { name: 'subtitle', label: 'Subtitle / tagline', type: 'text', full: true, hint: 'Short line shown under the course title on the details page.' },
             { name: 'course_type', label: 'Type', type: 'select', options: opt(EXAM_TYPES), default: 'competitive' },
             { name: 'status', label: 'Status', type: 'select', options: opt(EXAM_STATUS), default: 'active' },
             { name: 'color', label: 'Color', type: 'color', default: '#3B82F6' },
@@ -210,7 +211,13 @@ export const SCHEMAS = {
             { name: 'total_marks', label: 'Total Marks', type: 'number' },
             { name: 'is_featured', label: 'Featured', type: 'checkbox' },
             { name: 'negative_marking', label: 'Negative Marking', type: 'checkbox' },
+            { name: 'pricing_type', label: 'Pricing', type: 'select', options: opt(['free', 'paid']), default: 'free' },
+            { name: 'price', label: 'Price', type: 'number', step: '0.01', default: 0, showIf: (v) => v.pricing_type === 'paid', hint: 'Amount the student pays. Payment gateway is handled separately for now.' },
+            { name: 'original_price', label: 'Original price (strike-through)', type: 'number', step: '0.01', showIf: (v) => v.pricing_type === 'paid', hint: 'Optional higher price to show a discount.' },
+            { name: 'currency', label: 'Currency', type: 'select', options: opt(['INR', 'USD', 'EUR', 'GBP']), default: 'INR', showIf: (v) => v.pricing_type === 'paid' },
             { name: 'description', label: 'Description', type: 'textarea', full: true },
+            { name: 'highlights', label: 'What you will get (one point per line)', type: 'stringlist', full: true, placeholder: 'All Previous Year Questions (PYQ)\nFully solved answers\nExam-oriented approach' },
+            { name: 'refund_policy', label: 'Refund policy', type: 'textarea', full: true, hint: 'Shown on the course details page.' },
         ],
     },
     subject: {
@@ -318,7 +325,10 @@ export const buildInitial = (fields, instance) => {
     const out = {}
     fields.forEach((f) => {
         let v = instance ? instance[f.name] : undefined
-        if (v === undefined || v === null) v = f.default ?? (f.type === 'checkbox' ? false : '')
+        if (v === undefined || v === null) {
+            v = f.default ?? (f.type === 'checkbox' ? false : f.type === 'stringlist' ? [] : '')
+        }
+        if (f.type === 'stringlist' && !Array.isArray(v)) v = v ? [String(v)] : []
         // datetime-local inputs need a trimmed "YYYY-MM-DDTHH:mm" value.
         if (f.type === 'datetime-local' && typeof v === 'string' && v.length > 16) v = v.slice(0, 16)
         out[f.name] = v
@@ -355,6 +365,10 @@ export const EntityModal = ({ type, instance, defaults, onClose, onSubmit, savin
                 v = v === '' || v === null ? null : Number(v)
                 if (v === null && !f.required) return
             }
+            if (f.type === 'stringlist') {
+                const arr = Array.isArray(v) ? v : String(v || '').split('\n')
+                v = arr.map((s) => String(s).trim()).filter(Boolean)
+            }
             payload[f.name] = v
         })
         onSubmit(payload)
@@ -380,7 +394,7 @@ export const EntityModal = ({ type, instance, defaults, onClose, onSubmit, savin
                 <form onSubmit={handleSubmit} className="p-5 overflow-y-auto space-y-4">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                         {visibleFields.map((f) => (
-                            <div key={f.name} className={f.full || f.type === 'textarea' ? 'sm:col-span-2' : ''}>
+                            <div key={f.name} className={f.full || f.type === 'textarea' || f.type === 'stringlist' ? 'sm:col-span-2' : ''}>
                                 {f.type === 'checkbox' ? (
                                     <label className="flex items-center gap-2 cursor-pointer py-2">
                                         <input
@@ -406,6 +420,13 @@ export const EntityModal = ({ type, instance, defaults, onClose, onSubmit, savin
                                                     onChange={(e) => set(f.name, e.target.value)}
                                                 />
                                             )
+                                        ) : f.type === 'stringlist' ? (
+                                            <textarea
+                                                className="input text-sm" rows={f.rows || 4}
+                                                placeholder={f.placeholder || 'One item per line'}
+                                                value={(Array.isArray(values[f.name]) ? values[f.name] : []).join('\n')}
+                                                onChange={(e) => set(f.name, e.target.value.split('\n'))}
+                                            />
                                         ) : f.type === 'file' ? (
                                             <div className="space-y-2">
                                                 {values[f.name] instanceof File ? (

--- a/frontend/exam-frontend/src/pages/CourseDetail.jsx
+++ b/frontend/exam-frontend/src/pages/CourseDetail.jsx
@@ -1,0 +1,323 @@
+import { useMemo, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { courseService } from '../services/courseService'
+import { useAuthStore } from '../context/authStore'
+import Loading from '../components/common/Loading'
+import CourseThumbnail from '../components/course/CourseThumbnail'
+import toast from 'react-hot-toast'
+import {
+  ArrowLeft, ArrowRight, GraduationCap, CheckCircle2, Clock, PlusCircle,
+  BookOpen, Layers, ShieldCheck, Sparkles, Users, Tag, Settings2,
+} from 'lucide-react'
+
+const CURRENCY_SYMBOLS = { INR: '₹', USD: '$', EUR: '€', GBP: '£' }
+const money = (currency, amount) => {
+  const sym = CURRENCY_SYMBOLS[currency] || `${currency} `
+  const n = Number(amount)
+  return `${sym}${Number.isFinite(n) ? n.toLocaleString('en-IN') : amount}`
+}
+
+const TabButton = ({ active, onClick, children }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`relative px-1 pb-3 text-sm font-medium whitespace-nowrap transition-colors ${
+      active
+        ? 'text-primary-600 dark:text-primary-400'
+        : 'text-surface-500 hover:text-surface-800 dark:hover:text-surface-200'
+    }`}
+  >
+    {children}
+    {active && (
+      <motion.span
+        layoutId="courseDetailTab"
+        className="absolute left-0 right-0 -bottom-px h-0.5 rounded-full bg-primary-500"
+      />
+    )}
+  </button>
+)
+
+const CourseDetail = () => {
+  const { courseId } = useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { user, profile } = useAuthStore()
+  const role = user?.role || profile?.user?.role
+  const isAdmin = role === 'admin'
+
+  const [tab, setTab] = useState('overview')
+  const [requesting, setRequesting] = useState(false)
+
+  const { data: course, isLoading, isError } = useQuery({
+    queryKey: ['courseDetail', courseId],
+    queryFn: () => courseService.getCourseDetails(courseId),
+    enabled: !!courseId,
+  })
+
+  const { data: studyData = { courses: [], pending: [] } } = useQuery({
+    queryKey: ['studyCourses'],
+    queryFn: () => courseService.getStudyCourses(),
+  })
+
+  const status = useMemo(() => {
+    if ((studyData.courses || []).some((c) => String(c.id) === String(courseId))) return 'approved'
+    if ((studyData.pending || []).some((c) => String(c.id) === String(courseId))) return 'pending'
+    return null
+  }, [studyData, courseId])
+
+  const requestEnroll = async () => {
+    setRequesting(true)
+    try {
+      await courseService.requestEnrollment(courseId)
+      toast.success('Enrollment request sent for admin approval')
+      queryClient.invalidateQueries({ queryKey: ['studyCourses'] })
+      queryClient.invalidateQueries({ queryKey: ['enrollments'] })
+    } catch (err) {
+      toast.error(
+        err?.response?.data?.course?.[0] ||
+        err?.response?.data?.detail ||
+        'Request failed'
+      )
+    } finally {
+      setRequesting(false)
+    }
+  }
+
+  if (isLoading) return <Loading fullScreen />
+  if (isError || !course) {
+    return (
+      <div className="card p-10 text-center text-surface-500">
+        <GraduationCap size={48} className="mx-auto mb-3 text-surface-300" />
+        <p className="font-medium">Course not found</p>
+        <button onClick={() => navigate('/courses')} className="btn-secondary mt-4">
+          <ArrowLeft size={16} /> Back to courses
+        </button>
+      </div>
+    )
+  }
+
+  const isFree = course.is_free || course.pricing_type === 'free' || !Number(course.price)
+  const hasDiscount = Number(course.discount_percent) > 0 && course.original_price
+  const highlights = Array.isArray(course.highlights) ? course.highlights : []
+  const subjects = Array.isArray(course.subjects) ? course.subjects : []
+  const instructors = Array.isArray(course.instructors) ? course.instructors : []
+
+  const tabs = [
+    { key: 'overview', label: 'Overview' },
+    { key: 'curriculum', label: 'Curriculum' },
+    ...(instructors.length ? [{ key: 'instructors', label: 'Instructors' }] : []),
+  ]
+
+  const EnrollAction = () => {
+    if (status === 'approved') {
+      return (
+        <button onClick={() => navigate(`/study/course/${course.id}`)} className="btn-primary w-full group/btn">
+          Enter course
+          <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />
+        </button>
+      )
+    }
+    if (status === 'pending') {
+      return (
+        <span className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800/60">
+          <Clock size={16} /> Awaiting admin approval
+        </span>
+      )
+    }
+    return (
+      <button onClick={requestEnroll} disabled={requesting} className="btn-primary w-full disabled:opacity-70">
+        <PlusCircle size={18} />
+        {requesting ? 'Sending…' : isFree ? 'Request enrollment · Free' : 'Request enrollment'}
+      </button>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <button
+        onClick={() => navigate('/courses')}
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-surface-500 hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+      >
+        <ArrowLeft size={16} /> Back to courses
+      </button>
+
+      {/* Hero banner */}
+      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary-600 to-primary-700 text-white">
+        <div className="absolute -top-10 -right-10 w-56 h-56 rounded-full bg-white/10" />
+        <div className="absolute -bottom-16 -left-10 w-64 h-64 rounded-full bg-black/10" />
+        <div className="relative p-6 sm:p-10">
+          {course.course_type && (
+            <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-[11px] font-semibold uppercase tracking-wide bg-white/15 backdrop-blur-sm">
+              {course.course_type}
+            </span>
+          )}
+          <h1 className="mt-3 text-2xl sm:text-4xl font-display font-bold leading-tight max-w-3xl">
+            {course.name}
+          </h1>
+          {course.subtitle && (
+            <p className="mt-2 text-white/85 max-w-2xl">{course.subtitle}</p>
+          )}
+          <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-white/85">
+            <span className="inline-flex items-center gap-1.5"><Layers size={15} /> {course.subjects_count || subjects.length || 0} subjects</span>
+            <span className="inline-flex items-center gap-1.5"><BookOpen size={15} /> {course.mock_tests_count || 0} tests</span>
+            {instructors.length > 0 && (
+              <span className="inline-flex items-center gap-1.5"><Users size={15} /> {instructors.map((i) => i.name).join(', ')}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+        {/* Main content */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Tabs */}
+          <div className="border-b border-surface-200 dark:border-surface-800">
+            <div className="flex items-center gap-6 overflow-x-auto">
+              {tabs.map((t) => (
+                <TabButton key={t.key} active={tab === t.key} onClick={() => setTab(t.key)}>
+                  {t.label}
+                </TabButton>
+              ))}
+            </div>
+          </div>
+
+          {tab === 'overview' && (
+            <div className="space-y-8">
+              <section>
+                <h2 className="text-lg font-display font-bold mb-2">Description</h2>
+                <p className="text-surface-600 dark:text-surface-300 leading-relaxed whitespace-pre-line">
+                  {course.description || 'No description provided yet.'}
+                </p>
+              </section>
+
+              {highlights.length > 0 && (
+                <section>
+                  <h2 className="text-lg font-display font-bold mb-3 flex items-center gap-2">
+                    <Sparkles size={18} className="text-primary-500" /> What you will get
+                  </h2>
+                  <ul className="space-y-2.5">
+                    {highlights.map((h, i) => (
+                      <li key={i} className="flex items-start gap-2.5 text-surface-700 dark:text-surface-300">
+                        <CheckCircle2 size={18} className="text-success-500 mt-0.5 shrink-0" />
+                        <span>{h}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {course.refund_policy && (
+                <section className="rounded-xl border border-surface-200 dark:border-surface-800 bg-surface-50 dark:bg-surface-900 p-4">
+                  <h3 className="font-semibold flex items-center gap-2 mb-1.5">
+                    <ShieldCheck size={17} className="text-primary-500" /> Refund Policy
+                  </h3>
+                  <p className="text-sm text-surface-600 dark:text-surface-400 leading-relaxed whitespace-pre-line">
+                    {course.refund_policy}
+                  </p>
+                </section>
+              )}
+            </div>
+          )}
+
+          {tab === 'curriculum' && (
+            <div className="space-y-3">
+              {subjects.length === 0 ? (
+                <div className="card p-8 text-center text-surface-500">
+                  <Layers size={40} className="mx-auto mb-3 text-surface-300" />
+                  <p>Curriculum will be shared soon.</p>
+                </div>
+              ) : (
+                subjects.map((s, i) => (
+                  <div key={s.id} className="card p-4 flex items-center gap-3">
+                    <span className="w-9 h-9 rounded-lg bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center font-semibold shrink-0">
+                      {i + 1}
+                    </span>
+                    <div className="min-w-0">
+                      <h3 className="font-semibold truncate">{s.name}</h3>
+                      <p className="text-xs text-surface-400">
+                        {(s.topics_count || s.total_topics || 0)} topics
+                        {s.quizzes_count ? ` · ${s.quizzes_count} quizzes` : ''}
+                      </p>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {tab === 'instructors' && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {instructors.map((ins) => (
+                <div key={ins.id} className="card p-4 flex items-center gap-3">
+                  <span className="w-11 h-11 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 text-white flex items-center justify-center font-semibold shrink-0">
+                    {ins.name?.charAt(0).toUpperCase() || 'I'}
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="font-semibold truncate">{ins.name}</h3>
+                    <p className="text-xs text-surface-400">Instructor</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Pricing / enroll card */}
+        <div className="lg:sticky lg:top-6">
+          <div className="card overflow-hidden">
+            <CourseThumbnail course={course} />
+            <div className="p-5 space-y-4">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-surface-400">Price</p>
+                {isFree ? (
+                  <div className="mt-1 flex items-center gap-2">
+                    <span className="text-2xl font-display font-bold text-success-600 dark:text-success-400">Free</span>
+                  </div>
+                ) : (
+                  <div className="mt-1 flex flex-wrap items-baseline gap-2">
+                    <span className="text-3xl font-display font-bold text-primary-600 dark:text-primary-400">
+                      {money(course.currency, course.price)}
+                    </span>
+                    {hasDiscount && (
+                      <>
+                        <span className="text-surface-400 line-through text-sm">
+                          {money(course.currency, course.original_price)}
+                        </span>
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-success-50 dark:bg-success-900/30 text-success-700 dark:text-success-400">
+                          <Tag size={11} /> {course.discount_percent}% off
+                        </span>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <EnrollAction />
+
+              {status !== 'approved' && (
+                <p className="text-xs text-center text-surface-400">
+                  {isFree
+                    ? 'Enrollment is confirmed once an admin approves your request.'
+                    : 'Your request goes to the admin for approval. Payment is handled separately.'}
+                </p>
+              )}
+
+              {isAdmin && (
+                <button
+                  onClick={() => navigate(`/courses/${course.id}/manage`)}
+                  className="w-full inline-flex items-center justify-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold text-surface-600 dark:text-surface-300 bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors"
+                >
+                  <Settings2 size={15} /> Manage course
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CourseDetail

--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -1,14 +1,13 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { courseService } from '../services/courseService'
 import { contentBuilderService } from '../services/contentBuilderService'
 import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
-import toast from 'react-hot-toast'
-import { GraduationCap, CheckCircle2, Clock, PlusCircle, ArrowRight, Settings2, Search, X } from 'lucide-react'
+import { GraduationCap, CheckCircle2, Clock, ArrowRight, Settings2, Search, X } from 'lucide-react'
 
 const InstructorLine = ({ instructors = [] }) => {
   if (!instructors.length) return null
@@ -39,9 +38,39 @@ const InstructorLine = ({ instructors = [] }) => {
   )
 }
 
+const CURRENCY_SYMBOLS = { INR: '₹', USD: '$', EUR: '€', GBP: '£' }
+const CoursePrice = ({ course }) => {
+  const isFree = course.is_free || course.pricing_type === 'free' || !Number(course.price)
+  if (isFree) {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-bold bg-success-50 dark:bg-success-900/30 text-success-700 dark:text-success-400">
+        Free
+      </span>
+    )
+  }
+  const sym = CURRENCY_SYMBOLS[course.currency] || `${course.currency} `
+  const hasDiscount = Number(course.discount_percent) > 0 && course.original_price
+  return (
+    <div className="flex items-baseline gap-2">
+      <span className="text-lg font-display font-bold text-primary-600 dark:text-primary-400">
+        {sym}{Number(course.price).toLocaleString('en-IN')}
+      </span>
+      {hasDiscount && (
+        <>
+          <span className="text-xs text-surface-400 line-through">
+            {sym}{Number(course.original_price).toLocaleString('en-IN')}
+          </span>
+          <span className="text-[11px] font-semibold text-success-600 dark:text-success-400">
+            {course.discount_percent}% off
+          </span>
+        </>
+      )}
+    </div>
+  )
+}
+
 const Courses = () => {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const { user, profile } = useAuthStore()
   const role = user?.role || profile?.user?.role
   const isAdmin = role === 'admin'
@@ -108,21 +137,6 @@ const Courses = () => {
     { key: 'enrolled', label: 'Enrolled', count: counts.enrolled },
     { key: 'pending', label: 'Pending', count: counts.pending },
   ]
-
-  const requestEnroll = async (courseId) => {
-    try {
-      await courseService.requestEnrollment(courseId)
-      toast.success('Request sent for admin approval')
-      queryClient.invalidateQueries({ queryKey: ['studyCourses'] })
-      queryClient.invalidateQueries({ queryKey: ['enrollments'] })
-    } catch (err) {
-      toast.error(
-        err?.response?.data?.course?.[0] ||
-        err?.response?.data?.detail ||
-        'Request failed'
-      )
-    }
-  }
 
   if (availLoading) return <Loading fullScreen />
 
@@ -280,6 +294,10 @@ const Courses = () => {
                     <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
                   )}
 
+                  <div className="mt-3">
+                    <CoursePrice course={course} />
+                  </div>
+
                   <div className="mt-auto pt-4">
                     {status === 'approved' ? (
                       <button
@@ -291,18 +309,22 @@ const Courses = () => {
                         <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />
                       </button>
                     ) : status === 'pending' ? (
-                      <span className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800/60">
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/courses/${course.id}`)}
+                        className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800/60 hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors"
+                      >
                         <Clock size={16} />
-                        Awaiting admin approval
-                      </span>
+                        Awaiting approval · View
+                      </button>
                     ) : (
                       <button
                         type="button"
-                        onClick={() => requestEnroll(course.id)}
-                        className="btn-secondary w-full border border-surface-200 dark:border-surface-700 hover:border-primary-300 dark:hover:border-primary-700 hover:text-primary-600 dark:hover:text-primary-400"
+                        onClick={() => navigate(`/courses/${course.id}`)}
+                        className="btn-primary w-full group/btn"
                       >
-                        <PlusCircle size={18} />
-                        Request enrollment
+                        View details
+                        <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />
                       </button>
                     )}
                   </div>


### PR DESCRIPTION
## What & why

Students used to enroll directly from the courses grid. This PR introduces a dedicated **course details page** as the step before enrollment, as requested: open a course → see full details + pricing → request enrollment. Both free and paid courses still create an **admin-approved enrollment request** (payment gateway intentionally deferred).

## Backend
- `Course` model gains pricing fields — `pricing_type` (free/paid), `price`, `original_price`, `currency` — plus details-page content: `subtitle`, `highlights` (JSON list of bullet points) and `refund_policy`. Adds `is_free` and `discount_percent` properties.
- Migration `0012_course_pricing_details` for the new columns.
- Fields surfaced via `CourseSerializer` (public + instructors list), `AdminCourseSerializer` (writable) and `AvailableCoursesForEnrollmentView`.

## Frontend (student app)
- New **`CourseDetail`** page at `/courses/:courseId`: hero, Overview/Curriculum/Instructors tabs, "What you will get", refund policy, and a sticky pricing card with an enroll/awaiting-approval/request CTA.
- Courses grid cards now navigate to the details page and show the price.
- Admin course forms (`builderShared` + `ContentBuilder`) get pricing, subtitle, refund policy and a new `stringlist` field type for `highlights`.

## Deploy notes
- ⚠️ **New DB columns** — after merge, the backend on the VM must run `migrate exams` (0012) and restart `web`. Frontend deploys via Netlify automatically.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>