### PR TITLE
Course details: rich HTML description + curriculum drill-down

### DIFF
--- a/backend/exams/serializers.py
+++ b/backend/exams/serializers.py
@@ -133,10 +133,87 @@ class ChapterDetailSerializer(ChapterSerializer):
         return TopicSerializer([ct.topic for ct in qs], many=True).data
 
 
+def chapter_content_type_counts(topic_ids):
+    """Published content grouped by student-facing type for a set of topics.
+
+    Mirrors the taxonomy used by the study flow (reading / videos / quizzes /
+    assignments / coding) so the pre-enrollment curriculum preview matches what
+    an enrolled student actually sees. Returns an ordered list of
+    {key, label, count}, only including non-zero buckets.
+    """
+    from content.models import Content
+    from quiz.models import Quiz
+    from assignments.models import Assignment
+    from coding.models import CodingProblem
+
+    if not topic_ids:
+        return []
+
+    published_content = Content.objects.filter(topic_id__in=topic_ids, status='published')
+    reading = published_content.filter(
+        content_type__in=['notes', 'pdf', 'revision', 'formula']
+    ).count()
+    videos = published_content.filter(content_type='video').count()
+    quizzes = Quiz.objects.filter(topic_id__in=topic_ids, status='published').count()
+    assignments = Assignment.objects.filter(topic_id__in=topic_ids, status='published').count()
+    coding = CodingProblem.objects.filter(topic_id__in=topic_ids, status='published').count()
+
+    buckets = [
+        ('reading', 'Reading material', reading),
+        ('videos', 'Videos', videos),
+        ('quizzes', 'Quizzes', quizzes),
+        ('assignments', 'Assignments', assignments),
+        ('coding', 'Coding problems', coding),
+    ]
+    return [
+        {'key': key, 'label': label, 'count': count}
+        for key, label, count in buckets if count
+    ]
+
+
+class CurriculumChapterSerializer(serializers.ModelSerializer):
+    """Chapter with a per-type breakdown of the content it contains."""
+    topics_count = serializers.SerializerMethodField()
+    content_types = serializers.SerializerMethodField()
+    content_total = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Chapter
+        fields = [
+            'id', 'name', 'code', 'description', 'order',
+            'estimated_hours', 'topics_count', 'content_types', 'content_total',
+        ]
+
+    def _topic_ids(self, obj):
+        return list(obj.chapter_topics.values_list('topic_id', flat=True))
+
+    def get_topics_count(self, obj):
+        return obj.chapter_topics.count()
+
+    def get_content_types(self, obj):
+        return chapter_content_type_counts(self._topic_ids(obj))
+
+    def get_content_total(self, obj):
+        return sum(b['count'] for b in chapter_content_type_counts(self._topic_ids(obj)))
+
+
+class CurriculumSubjectSerializer(SubjectSerializer):
+    """Subject with nested chapters + their content breakdown for the
+    course-details curriculum preview."""
+    chapters = serializers.SerializerMethodField()
+
+    class Meta(SubjectSerializer.Meta):
+        fields = SubjectSerializer.Meta.fields + ['chapters']
+
+    def get_chapters(self, obj):
+        qs = obj.chapters.all().order_by('order', 'name').prefetch_related('chapter_topics')
+        return CurriculumChapterSerializer(qs, many=True).data
+
+
 class CourseDetailSerializer(CourseSerializer):
-    """Detailed course serializer with subjects."""
-    subjects = SubjectSerializer(many=True, read_only=True)
-    
+    """Detailed course serializer with curriculum (subjects -> chapters)."""
+    subjects = CurriculumSubjectSerializer(many=True, read_only=True)
+
     class Meta(CourseSerializer.Meta):
         fields = CourseSerializer.Meta.fields + ['subjects']
 

--- a/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
@@ -8,6 +8,7 @@ import {
     ListChecks, CheckCircle2, Circle,
 } from 'lucide-react'
 import { contentBuilderService as svc } from '../../services/contentBuilderService'
+import { NotesTextarea } from './builderShared'
 
 /* ===========================================================================
  * Field / form configuration per entity
@@ -48,7 +49,7 @@ const SCHEMAS = {
             { name: 'price', label: 'Price', type: 'number', step: '0.01', default: 0, hint: 'Used when pricing is paid.' },
             { name: 'original_price', label: 'Original price (strike-through)', type: 'number', step: '0.01' },
             { name: 'currency', label: 'Currency', type: 'select', options: opt(['INR', 'USD', 'EUR', 'GBP']), default: 'INR' },
-            { name: 'description', label: 'Description', type: 'textarea', full: true },
+            { name: 'description', label: 'Description', type: 'textarea', full: true, image: true, rows: 10, hint: 'Supports rich HTML / Markdown and images — paste, drop, or add an image directly.' },
             { name: 'highlights', label: 'What you will get (one point per line)', type: 'stringlist', full: true, placeholder: 'All Previous Year Questions (PYQ)\nFully solved answers\nExam-oriented approach' },
             { name: 'refund_policy', label: 'Refund policy', type: 'textarea', full: true },
         ],
@@ -207,11 +208,15 @@ const EntityModal = ({ type, instance, onClose, onSubmit, saving }) => {
                                             {f.label}{f.required && <span className="text-rose-500"> *</span>}
                                         </label>
                                         {f.type === 'textarea' ? (
-                                            <textarea
-                                                className="input font-mono text-sm" rows={f.rows || 3}
-                                                value={values[f.name] ?? ''}
-                                                onChange={(e) => set(f.name, e.target.value)}
-                                            />
+                                            f.image ? (
+                                                <NotesTextarea value={values[f.name] ?? ''} onChange={(val) => set(f.name, val)} rows={f.rows} />
+                                            ) : (
+                                                <textarea
+                                                    className="input font-mono text-sm" rows={f.rows || 3}
+                                                    value={values[f.name] ?? ''}
+                                                    onChange={(e) => set(f.name, e.target.value)}
+                                                />
+                                            )
                                         ) : f.type === 'stringlist' ? (
                                             <textarea
                                                 className="input text-sm" rows={f.rows || 4}

--- a/frontend/exam-frontend/src/components/admin/builderShared.jsx
+++ b/frontend/exam-frontend/src/components/admin/builderShared.jsx
@@ -215,7 +215,7 @@ export const SCHEMAS = {
             { name: 'price', label: 'Price', type: 'number', step: '0.01', default: 0, showIf: (v) => v.pricing_type === 'paid', hint: 'Amount the student pays. Payment gateway is handled separately for now.' },
             { name: 'original_price', label: 'Original price (strike-through)', type: 'number', step: '0.01', showIf: (v) => v.pricing_type === 'paid', hint: 'Optional higher price to show a discount.' },
             { name: 'currency', label: 'Currency', type: 'select', options: opt(['INR', 'USD', 'EUR', 'GBP']), default: 'INR', showIf: (v) => v.pricing_type === 'paid' },
-            { name: 'description', label: 'Description', type: 'textarea', full: true },
+            { name: 'description', label: 'Description', type: 'textarea', full: true, image: true, rows: 10, hint: 'Supports rich HTML / Markdown and images — paste, drop, or add an image directly.' },
             { name: 'highlights', label: 'What you will get (one point per line)', type: 'stringlist', full: true, placeholder: 'All Previous Year Questions (PYQ)\nFully solved answers\nExam-oriented approach' },
             { name: 'refund_policy', label: 'Refund policy', type: 'textarea', full: true, hint: 'Shown on the course details page.' },
         ],

--- a/frontend/exam-frontend/src/pages/CourseDetail.jsx
+++ b/frontend/exam-frontend/src/pages/CourseDetail.jsx
@@ -1,7 +1,12 @@
 import { useMemo, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import ReactMarkdown from 'react-markdown'
+import remarkMath from 'remark-math'
+import remarkGfm from 'remark-gfm'
+import rehypeKatex from 'rehype-katex'
+import 'katex/dist/katex.min.css'
 import { courseService } from '../services/courseService'
 import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
@@ -10,6 +15,7 @@ import toast from 'react-hot-toast'
 import {
   ArrowLeft, ArrowRight, GraduationCap, CheckCircle2, Clock, PlusCircle,
   BookOpen, Layers, ShieldCheck, Sparkles, Users, Tag, Settings2,
+  ChevronDown, FileText, Video, ListChecks, ClipboardList, Code2,
 } from 'lucide-react'
 
 const CURRENCY_SYMBOLS = { INR: '₹', USD: '$', EUR: '€', GBP: '£' }
@@ -18,6 +24,49 @@ const money = (currency, amount) => {
   const n = Number(amount)
   return `${sym}${Number.isFinite(n) ? n.toLocaleString('en-IN') : amount}`
 }
+
+// Icon + accent per content-type bucket returned by the curriculum API.
+const CONTENT_TYPE_META = {
+  reading: { icon: FileText, cls: 'text-sky-600 dark:text-sky-400 bg-sky-50 dark:bg-sky-900/30' },
+  videos: { icon: Video, cls: 'text-rose-600 dark:text-rose-400 bg-rose-50 dark:bg-rose-900/30' },
+  quizzes: { icon: ListChecks, cls: 'text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30' },
+  assignments: { icon: ClipboardList, cls: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30' },
+  coding: { icon: Code2, cls: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30' },
+}
+
+const RichText = ({ value }) => {
+  const text = (value || '').trim()
+  if (!text) return <p className="text-surface-500">No description provided yet.</p>
+  return (
+    <div className="prose dark:prose-invert max-w-none prose-headings:font-display prose-p:leading-relaxed prose-img:rounded-xl prose-ul:my-3 prose-table:my-4 [&_.katex-display]:overflow-x-auto">
+      {text.startsWith('<') ? (
+        <div dangerouslySetInnerHTML={{ __html: text }} />
+      ) : (
+        <ReactMarkdown remarkPlugins={[remarkMath, remarkGfm]} rehypePlugins={[rehypeKatex]}>
+          {text}
+        </ReactMarkdown>
+      )}
+    </div>
+  )
+}
+
+const ContentTypeBadges = ({ types }) => (
+  <div className="flex flex-wrap gap-1.5">
+    {types.map((t) => {
+      const meta = CONTENT_TYPE_META[t.key] || CONTENT_TYPE_META.reading
+      const Icon = meta.icon
+      return (
+        <span
+          key={t.key}
+          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-[11px] font-semibold ${meta.cls}`}
+          title={`${t.count} ${t.label}`}
+        >
+          <Icon size={12} /> {t.count} {t.label}
+        </span>
+      )
+    })}
+  </div>
+)
 
 const TabButton = ({ active, onClick, children }) => (
   <button
@@ -49,6 +98,14 @@ const CourseDetail = () => {
 
   const [tab, setTab] = useState('overview')
   const [requesting, setRequesting] = useState(false)
+  const [openSubjects, setOpenSubjects] = useState(() => new Set())
+
+  const toggleSubject = (id) =>
+    setOpenSubjects((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
 
   const { data: course, isLoading, isError } = useQuery({
     queryKey: ['courseDetail', courseId],
@@ -187,9 +244,7 @@ const CourseDetail = () => {
             <div className="space-y-8">
               <section>
                 <h2 className="text-lg font-display font-bold mb-2">Description</h2>
-                <p className="text-surface-600 dark:text-surface-300 leading-relaxed whitespace-pre-line">
-                  {course.description || 'No description provided yet.'}
-                </p>
+                <RichText value={course.description} />
               </section>
 
               {highlights.length > 0 && (
@@ -229,20 +284,78 @@ const CourseDetail = () => {
                   <p>Curriculum will be shared soon.</p>
                 </div>
               ) : (
-                subjects.map((s, i) => (
-                  <div key={s.id} className="card p-4 flex items-center gap-3">
-                    <span className="w-9 h-9 rounded-lg bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center font-semibold shrink-0">
-                      {i + 1}
-                    </span>
-                    <div className="min-w-0">
-                      <h3 className="font-semibold truncate">{s.name}</h3>
-                      <p className="text-xs text-surface-400">
-                        {(s.topics_count || s.total_topics || 0)} topics
-                        {s.quizzes_count ? ` · ${s.quizzes_count} quizzes` : ''}
-                      </p>
+                subjects.map((s, i) => {
+                  const chapters = Array.isArray(s.chapters) ? s.chapters : []
+                  const isOpen = openSubjects.has(s.id)
+                  return (
+                    <div key={s.id} className="card overflow-hidden">
+                      <button
+                        type="button"
+                        onClick={() => toggleSubject(s.id)}
+                        className="w-full flex items-center gap-3 p-4 text-left hover:bg-surface-50 dark:hover:bg-surface-800/50 transition-colors"
+                        aria-expanded={isOpen}
+                      >
+                        <span className="w-9 h-9 rounded-lg bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 flex items-center justify-center font-semibold shrink-0">
+                          {i + 1}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <h3 className="font-semibold truncate">{s.name}</h3>
+                          <p className="text-xs text-surface-400">
+                            {chapters.length} {chapters.length === 1 ? 'chapter' : 'chapters'}
+                            {' · '}{(s.topics_count || s.total_topics || 0)} topics
+                          </p>
+                        </div>
+                        <ChevronDown
+                          size={18}
+                          className={`shrink-0 text-surface-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                        />
+                      </button>
+
+                      <AnimatePresence initial={false}>
+                        {isOpen && (
+                          <motion.div
+                            initial={{ height: 0, opacity: 0 }}
+                            animate={{ height: 'auto', opacity: 1 }}
+                            exit={{ height: 0, opacity: 0 }}
+                            transition={{ duration: 0.2 }}
+                            className="overflow-hidden"
+                          >
+                            <div className="border-t border-surface-200 dark:border-surface-800 divide-y divide-surface-100 dark:divide-surface-800/70">
+                              {chapters.length === 0 ? (
+                                <p className="px-4 py-3 text-sm text-surface-400">Chapters coming soon.</p>
+                              ) : (
+                                chapters.map((ch, ci) => (
+                                  <div key={ch.id} className="px-4 py-3">
+                                    <div className="flex items-start gap-3">
+                                      <span className="text-xs font-mono text-surface-400 mt-0.5 shrink-0 w-8">
+                                        {i + 1}.{ci + 1}
+                                      </span>
+                                      <div className="min-w-0 flex-1 space-y-1.5">
+                                        <div className="flex items-center justify-between gap-2">
+                                          <h4 className="text-sm font-medium text-surface-800 dark:text-surface-100">{ch.name}</h4>
+                                          {Number(ch.estimated_hours) > 0 && (
+                                            <span className="text-[11px] text-surface-400 inline-flex items-center gap-1 shrink-0">
+                                              <Clock size={11} /> {ch.estimated_hours}h
+                                            </span>
+                                          )}
+                                        </div>
+                                        {Array.isArray(ch.content_types) && ch.content_types.length > 0 ? (
+                                          <ContentTypeBadges types={ch.content_types} />
+                                        ) : (
+                                          <p className="text-[11px] text-surface-400">Content coming soon</p>
+                                        )}
+                                      </div>
+                                    </div>
+                                  </div>
+                                ))
+                              )}
+                            </div>
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
                     </div>
-                  </div>
-                ))
+                  )
+                })
               )}
             </div>
           )}


### PR DESCRIPTION
## What & why

Follow-up to the course details page, covering three requests:

### 1. Rich HTML description with images
The course **description** on the details page now renders **HTML or Markdown** (with inline images and LaTeX), reusing the same renderer as the content viewer, instead of plain pre-wrapped text. The admin course form's description field is upgraded to the **image-capable rich editor** (paste / drop / upload) in both `builderShared` (CourseManager) and `ContentBuilder`.

### 2. Curriculum drill-down with content-type counts
The Curriculum tab is now an expandable **Subject → Chapter** accordion. Each chapter shows a per-type breakdown — **reading material, videos, quizzes, assignments, coding problems** — as labelled count badges. A new `CurriculumSubjectSerializer` / `CurriculumChapterSerializer` computes these using the same taxonomy and `status='published'` filter as the enrolled study flow, so the preview matches reality.

### 3. Descriptions + paid courses (data)
Handled directly on the server after merge (not code): add descriptions to all courses and mark two as paid.

## Scope
Only 4 files touched — `exams/serializers.py`, `CourseDetail.jsx`, `builderShared.jsx`, `ContentBuilder.jsx`. No new DB columns, so **no migration** is required for this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>