### PR TITLE
fix: strip HTML tags from course description preview on course cards

### DIFF
--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -9,6 +9,17 @@ import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
 import { GraduationCap, CheckCircle2, Clock, ArrowRight, Settings2, Search, X } from 'lucide-react'
 
+// Course descriptions are stored as rich HTML. On the card we only want a
+// short plain-text preview, so strip tags and decode entities before
+// clamping — otherwise raw markup like "<h3>…</h3>" leaks into the UI.
+const stripHtml = (html) => {
+  if (!html) return ''
+  if (typeof window === 'undefined') return html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+  const el = document.createElement('div')
+  el.innerHTML = html
+  return (el.textContent || el.innerText || '').replace(/\s+/g, ' ').trim()
+}
+
 const InstructorLine = ({ instructors = [] }) => {
   if (!instructors.length) return null
   const shown = instructors.slice(0, 2)
@@ -124,7 +135,7 @@ const Courses = () => {
       if (filter === 'enrolled' && status !== 'approved') return false
       if (filter === 'pending' && status !== 'pending') return false
       if (!q) return true
-      const haystack = [c.name, c.description, c.code, c.course_type]
+      const haystack = [c.name, stripHtml(c.description), c.code, c.course_type]
         .filter(Boolean)
         .join(' ')
         .toLowerCase()
@@ -291,7 +302,7 @@ const Courses = () => {
                   <h3 className="text-base sm:text-lg font-semibold leading-snug line-clamp-1">{course.name}</h3>
                   <InstructorLine instructors={course.instructors} />
                   {course.description && (
-                    <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
+                    <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{stripHtml(course.description)}</p>
                   )}
 
                   <div className="mt-3">


### PR DESCRIPTION
## Problem

Course descriptions are stored as rich HTML. On the **Courses** grid the description was rendered as plain text, so raw markup like `<h3>Class XI PCM — Strong Foundations</h3> <p>…` leaked directly into the card preview (see screenshot in the issue).

## Fix

- Add a small `stripHtml()` helper that converts the HTML to plain text (decodes entities, collapses whitespace) using the DOM, with a regex fallback for SSR.
- Use it for the clamped card description and for the search haystack (so tag names like `h3` aren't searchable).
- `CourseDetail` is unchanged — it still renders the full rich text via `dangerouslySetInnerHTML`.

## Verification
- `npm run build` (Vite) passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>