### PR TITLE
Make admin dashboard a full-page view with left-side navigation

### DIFF
--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { useTenantStore } from './context/tenantStore'
 // Layouts
 import MainLayout from './components/layout/MainLayout'
 import AuthLayout from './components/layout/AuthLayout'
+import AdminLayout from './components/layout/AdminLayout'
 import SuspensionOverlay from './components/layout/SuspensionOverlay'
 import VerificationGate from './components/layout/VerificationGate'
 
@@ -226,12 +227,24 @@ function App() {
           <Route path="/community/:id" element={<FeatureRoute feature="community"><CommunityPost /></FeatureRoute>} />
 
           {/* Admin Dashboard */}
-          <Route path="/admin-dashboard" element={<AdminDashboard />} />
           <Route path="/admin/mock-tests" element={<AdminRoute><MockTestManager /></AdminRoute>} />
           <Route path="/admin/mock-tests/grading" element={<AdminRoute><MockTestGrading /></AdminRoute>} />
           <Route path="/admin/mock-tests/:testId/submissions" element={<AdminRoute><MockTestSubmissions /></AdminRoute>} />
           <Route path="/admin/mock-tests/:testId/submissions/:attemptId" element={<AdminRoute><MockTestSubmissionReview /></AdminRoute>} />
           <Route path="/admin/mock-tests/:testId" element={<AdminRoute><MockTestBuilder /></AdminRoute>} />
+        </Route>
+
+        {/* Full-page Admin View */}
+        <Route
+          element={
+            <ProtectedRoute>
+              <AdminRoute>
+                <AdminLayout />
+              </AdminRoute>
+            </ProtectedRoute>
+          }
+        >
+          <Route path="/admin-dashboard" element={<AdminDashboard />} />
         </Route>
 
 

--- a/frontend/exam-frontend/src/components/layout/AdminLayout.jsx
+++ b/frontend/exam-frontend/src/components/layout/AdminLayout.jsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Menu, Moon, Sun, ArrowLeftRight, LogOut, User } from 'lucide-react'
+import AdminSidebar from './AdminSidebar'
+import { useAppStore } from '../../context/appStore'
+import { useAuthStore } from '../../context/authStore'
+
+const AdminLayout = () => {
+  const navigate = useNavigate()
+  const { mobileMenuOpen, toggleMobileMenu, closeMobileMenu, darkMode, toggleDarkMode } = useAppStore()
+  const { profile, fetchProfile, logout } = useAuthStore()
+  const [showUserMenu, setShowUserMenu] = useState(false)
+
+  useEffect(() => {
+    fetchProfile()
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-surface-50 dark:bg-surface-950">
+      {/* Desktop Sidebar */}
+      <aside className="fixed left-0 top-0 z-40 hidden h-screen w-64 lg:block">
+        <AdminSidebar />
+      </aside>
+
+      {/* Mobile Slide-in Sidebar */}
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <motion.div
+            initial={{ x: -280 }}
+            animate={{ x: 0 }}
+            exit={{ x: -280 }}
+            transition={{ type: 'spring', damping: 25, stiffness: 200 }}
+            className="fixed left-0 top-0 z-50 h-screen w-64 lg:hidden"
+          >
+            <AdminSidebar />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Main Content */}
+      <div className="min-h-screen lg:ml-64">
+        {/* Top Bar */}
+        <header className="sticky top-0 z-30 bg-white/80 dark:bg-surface-900/80 backdrop-blur-lg border-b border-surface-200 dark:border-surface-800">
+          <div className="flex items-center justify-between h-16 px-4 lg:px-6">
+            {/* Left: mobile menu + single view switch button */}
+            <div className="flex items-center gap-3">
+              <button
+                onClick={toggleMobileMenu}
+                className="lg:hidden btn-icon"
+                aria-label="Toggle menu"
+              >
+                <Menu className="w-6 h-6" />
+              </button>
+
+              <motion.button
+                whileHover={{ scale: 1.03 }}
+                whileTap={{ scale: 0.97 }}
+                onClick={() => navigate('/dashboard')}
+                className="flex items-center gap-2 px-4 py-2 rounded-xl border bg-accent-50 border-accent-200 text-accent-700 dark:bg-accent-900/30 dark:border-accent-800 dark:text-accent-400 transition-all"
+              >
+                <ArrowLeftRight className="w-4 h-4" />
+                <span className="text-sm font-semibold">Back to Student View</span>
+              </motion.button>
+            </div>
+
+            {/* Right: dark mode + user */}
+            <div className="flex items-center gap-2 lg:gap-3">
+              <button onClick={toggleDarkMode} className="btn-icon" aria-label="Toggle dark mode">
+                {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+              </button>
+
+              <div className="relative">
+                <button
+                  onClick={() => setShowUserMenu(!showUserMenu)}
+                  className="flex items-center gap-2 p-1 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"
+                >
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-primary-400 to-accent-400 flex items-center justify-center overflow-hidden">
+                    {profile?.user?.avatar ? (
+                      <img src={profile.user.avatar} alt={profile.user.full_name} className="w-full h-full object-cover" />
+                    ) : (
+                      <span className="text-white text-sm font-semibold">
+                        {profile?.user?.first_name?.charAt(0) || 'A'}
+                      </span>
+                    )}
+                  </div>
+                </button>
+
+                {showUserMenu && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    className="absolute right-0 mt-2 w-56 card shadow-lg overflow-hidden"
+                  >
+                    <div className="p-4 border-b border-surface-200 dark:border-surface-700">
+                      <p className="font-medium">{profile?.user?.full_name || 'Administrator'}</p>
+                      <p className="text-sm text-surface-500">{profile?.user?.email}</p>
+                    </div>
+                    <div className="p-2">
+                      <button
+                        onClick={() => { setShowUserMenu(false); navigate('/profile') }}
+                        className="w-full flex items-center gap-2 text-left px-3 py-2 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"
+                      >
+                        <User className="w-4 h-4" /> Profile Settings
+                      </button>
+                      <button
+                        onClick={() => { setShowUserMenu(false); logout(); navigate('/login') }}
+                        className="w-full flex items-center gap-2 text-left px-3 py-2 rounded-lg text-error-600 hover:bg-error-50 dark:hover:bg-error-900/20 transition-colors"
+                      >
+                        <LogOut className="w-4 h-4" /> Sign Out
+                      </button>
+                    </div>
+                  </motion.div>
+                )}
+              </div>
+            </div>
+          </div>
+        </header>
+
+        {/* Page Content */}
+        <main className="p-4 lg:p-6">
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            <Outlet />
+          </motion.div>
+        </main>
+      </div>
+
+      {/* Mobile Menu Overlay */}
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm lg:hidden"
+            onClick={closeMobileMenu}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+export default AdminLayout

--- a/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
@@ -1,0 +1,146 @@
+import { NavLink, useLocation, useSearchParams } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { useAuthStore } from '../../context/authStore'
+import { useAppStore } from '../../context/appStore'
+import { useTenantStore } from '../../context/tenantStore'
+import {
+  TrendingUp,
+  Users,
+  GraduationCap,
+  BarChart3,
+  Library,
+  SlidersHorizontal,
+  ClipboardList,
+  Shield,
+} from 'lucide-react'
+
+// Admin navigation sections. `tab` items drive the in-page section shown by
+// AdminDashboard via the `?tab=` query param; `path` items navigate to a route.
+export const ADMIN_NAV_ITEMS = [
+  { tab: 'overview', label: 'Overview', icon: TrendingUp },
+  { tab: 'students', label: 'Student Records', icon: Users },
+  { tab: 'enrollments', label: 'Enrollments', icon: GraduationCap },
+  { tab: 'performance', label: 'Reports', icon: BarChart3 },
+  { tab: 'content', label: 'Content Builder', icon: Library },
+  { path: '/admin/mock-tests', label: 'Mock Tests', icon: ClipboardList },
+  { tab: 'settings', label: 'Settings', icon: SlidersHorizontal },
+]
+
+const AdminSidebar = () => {
+  const location = useLocation()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { profile } = useAuthStore()
+  const { closeMobileMenu } = useAppStore()
+  const tenant = useTenantStore((s) => s.tenant)
+
+  const activeTab = searchParams.get('tab') || 'overview'
+  const onAdminDashboard = location.pathname.startsWith('/admin-dashboard')
+
+  const selectTab = (tab) => {
+    setSearchParams(tab === 'overview' ? {} : { tab })
+    closeMobileMenu()
+  }
+
+  return (
+    <div className="h-full bg-white dark:bg-surface-900 border-r border-surface-200 dark:border-surface-800 flex flex-col">
+      {/* Logo */}
+      <div className="p-6 border-b border-surface-200 dark:border-surface-800">
+        <div className="flex items-center gap-3">
+          {tenant?.logo ? (
+            <div className="w-10 h-10 rounded-xl overflow-hidden flex items-center justify-center bg-surface-100 dark:bg-surface-800">
+              <img src={tenant.logo} alt={tenant.name || 'Logo'} className="w-full h-full object-contain" />
+            </div>
+          ) : (
+            <div className="w-10 h-10 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
+              <span className="text-white font-bold">
+                {(tenant?.name || 'dt').slice(0, 2).toLowerCase()}
+              </span>
+            </div>
+          )}
+          <div>
+            <h1 className="font-display font-bold text-lg gradient-text">{tenant?.name || 'DailyTaiyari'}</h1>
+            <p className="text-xs text-surface-500">Admin Console</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Admin badge card */}
+      <div className="p-4 mx-4 mt-4 rounded-xl bg-gradient-to-br from-primary-50 to-accent-50 dark:from-primary-900/20 dark:to-accent-900/20">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-primary-100 dark:bg-primary-800 flex items-center justify-center overflow-hidden">
+            {profile?.user?.avatar ? (
+              <img src={profile.user.avatar} alt={profile.user.full_name} className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-primary-600 dark:text-primary-300 font-semibold">
+                {profile?.user?.first_name?.charAt(0) || 'A'}
+              </span>
+            )}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-medium truncate">{profile?.user?.full_name || 'Administrator'}</p>
+            <p className="text-xs text-surface-500 flex items-center gap-1">
+              <Shield className="w-3 h-3" /> Institutional Admin
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
+        {ADMIN_NAV_ITEMS.map((item) => {
+          const IconComponent = item.icon
+
+          // Route-based item (e.g. Mock Tests) — navigate to a separate page.
+          if (item.path) {
+            return (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                onClick={closeMobileMenu}
+                className={({ isActive }) =>
+                  `relative flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-200 group ${
+                    isActive
+                      ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                      : 'text-surface-600 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+                  }`
+                }
+              >
+                <IconComponent size={20} strokeWidth={2} className="text-surface-500 group-hover:text-primary-400 transition-all" />
+                <span className="font-medium">{item.label}</span>
+              </NavLink>
+            )
+          }
+
+          // Section item — toggles the in-page tab.
+          const isActive = onAdminDashboard && activeTab === item.tab
+          return (
+            <button
+              key={item.tab}
+              onClick={() => selectTab(item.tab)}
+              className={`relative w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-200 group text-left ${
+                isActive
+                  ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400'
+                  : 'text-surface-600 dark:text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+              }`}
+            >
+              {isActive && (
+                <motion.div
+                  layoutId="activeAdminNav"
+                  className="absolute -left-4 top-1/2 -translate-y-1/2 w-1 h-8 bg-primary-500 rounded-r-full"
+                />
+              )}
+              <IconComponent
+                size={20}
+                strokeWidth={isActive ? 2.5 : 2}
+                className={`transition-all ${isActive ? 'text-primary-500' : 'text-surface-500 group-hover:text-primary-400'}`}
+              />
+              <span className="font-medium">{item.label}</span>
+            </button>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}
+
+export default AdminSidebar

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import toast from 'react-hot-toast'
 import { analyticsService } from '../services/analyticsService'
@@ -42,7 +42,6 @@ import {
     Mail,
     Phone,
     Filter,
-    ClipboardList,
     Upload,
     Image as ImageIcon,
     ToggleRight,
@@ -1313,9 +1312,11 @@ const TABS = [
 ]
 
 const AdminDashboard = () => {
-    const [activeTab, setActiveTab] = useState('overview')
+    const [searchParams] = useSearchParams()
+    const activeTab = searchParams.get('tab') || 'overview'
     const queryClient = useQueryClient()
-    const navigate = useNavigate()
+
+    const activeMeta = TABS.find((t) => t.id === activeTab) || TABS[0]
 
     const { data: stats, isLoading, error, isFetching } = useQuery({
         queryKey: ['tenantAdminStats'],
@@ -1349,47 +1350,21 @@ const AdminDashboard = () => {
     }
 
     return (
-        <div className="space-y-6 sm:space-y-8 max-w-7xl mx-auto">
-            {/* Header */}
-            <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-primary-600 via-primary-600 to-primary-700 p-6 sm:p-8 text-white shadow-lg shadow-primary-500/20">
-                <div className="absolute -right-10 -top-10 w-48 h-48 bg-white/10 rounded-full blur-2xl" />
-                <div className="absolute -right-4 bottom-0 w-32 h-32 bg-white/5 rounded-full blur-xl" />
-                <div className="relative flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+        <div className="space-y-6 max-w-7xl mx-auto">
+            {/* Section Header */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                    <div className="p-2.5 rounded-xl bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400">
+                        <activeMeta.icon className="w-5 h-5" />
+                    </div>
                     <div>
-                        <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/15 text-xs font-semibold mb-3">
-                            <Shield className="w-3.5 h-3.5" /> Institutional Admin
-                        </div>
-                        <h1 className="text-2xl sm:text-3xl font-bold">Admin Dashboard</h1>
-                        <p className="text-white/80 mt-1 text-sm sm:text-base">Manage student records and track institutional performance</p>
-                    </div>
-                    <button onClick={refreshAll} className="self-start sm:self-auto inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
-                        <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} /> Refresh
-                    </button>
-                    <div className="flex items-center gap-2 self-start sm:self-auto">
-                        <button onClick={() => navigate('/admin/mock-tests')} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
-                            <ClipboardList className="w-4 h-4" /> Mock Tests
-                        </button>
-                        <button onClick={refreshAll} className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-white/15 hover:bg-white/25 transition-colors text-sm font-semibold backdrop-blur-sm">
-                            <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} /> Refresh
-                        </button>
+                        <h1 className="text-xl sm:text-2xl font-bold text-surface-900 dark:text-white">{activeMeta.label}</h1>
+                        <p className="text-surface-500 text-sm">Manage student records and track institutional performance</p>
                     </div>
                 </div>
-            </div>
-
-            {/* Tabs */}
-            <div className="overflow-x-auto -mx-1 px-1">
-                <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-xl w-max min-w-full sm:w-fit sm:min-w-0">
-                    {TABS.map((tab) => (
-                        <button
-                            key={tab.id}
-                            onClick={() => setActiveTab(tab.id)}
-                            className={`px-4 sm:px-6 py-2 rounded-lg text-sm font-bold transition-all flex items-center gap-2 whitespace-nowrap ${activeTab === tab.id ? 'bg-white dark:bg-surface-700 text-primary-600 dark:text-primary-400 shadow-sm' : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'}`}
-                        >
-                            <tab.icon className="w-4 h-4" />
-                            {tab.label}
-                        </button>
-                    ))}
-                </div>
+                <button onClick={refreshAll} className="self-start sm:self-auto inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors text-sm font-semibold text-surface-700 dark:text-surface-200">
+                    <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} /> Refresh
+                </button>
             </div>
 
             <AnimatePresence mode="wait">


### PR DESCRIPTION
## What & why

The admin dashboard previously rendered inside the student layout with a row of tabs and a cluttered header. This reworks it into a **dedicated full-page admin view** with navigation on the left, matching the student experience.

## Changes

- **New `AdminLayout`** — full-page shell with a fixed left sidebar and a slim top bar containing a **single "Back to Student View"** toggle, dark-mode toggle, and user menu. Includes mobile slide-in nav.
- **New `AdminSidebar`** — left navigation for all admin sections (Overview, Student Records, Enrollments, Reports, Content Builder, Mock Tests, Settings), plus tenant logo and admin identity card. Active section is driven by a `?tab=` URL param.
- **`AdminDashboard`** — removed the in-page tab bar and the duplicate Refresh/Mock Tests header buttons; now reads the active section from the URL and shows a clean compact section header.
- **`App.jsx`** — `/admin-dashboard` now routes through `AdminLayout` (wrapped in `AdminRoute` + `ProtectedRoute`) instead of the student `MainLayout`.

The existing student-side "Switch to Admin View" button still routes here, giving a single toggle in each direction.

## Verification

- `npm run build` passes
- Dev server boots and responds cleanly