### PR TITLE
fix: strip HTML tags from course description preview on Study tab

### DIFF
--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -8,17 +8,7 @@ import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
 import { GraduationCap, CheckCircle2, Clock, ArrowRight, Settings2, Search, X } from 'lucide-react'
-
-// Course descriptions are stored as rich HTML. On the card we only want a
-// short plain-text preview, so strip tags and decode entities before
-// clamping — otherwise raw markup like "<h3>…</h3>" leaks into the UI.
-const stripHtml = (html) => {
-  if (!html) return ''
-  if (typeof window === 'undefined') return html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
-  const el = document.createElement('div')
-  el.innerHTML = html
-  return (el.textContent || el.innerText || '').replace(/\s+/g, ' ').trim()
-}
+import { stripHtml } from '../utils/html'
 
 const InstructorLine = ({ instructors = [] }) => {
   if (!instructors.length) return null

--- a/frontend/exam-frontend/src/pages/Study.jsx
+++ b/frontend/exam-frontend/src/pages/Study.jsx
@@ -5,6 +5,7 @@ import { courseService } from '../services/courseService'
 import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
 import { GraduationCap, Clock, Compass, ArrowRight } from 'lucide-react'
+import { stripHtml } from '../utils/html'
 
 const Study = () => {
   const navigate = useNavigate()
@@ -89,7 +90,7 @@ const Study = () => {
               <div className="p-4 sm:p-5 flex flex-col flex-1">
                 <h3 className="text-base sm:text-lg font-semibold leading-snug line-clamp-1">{course.name}</h3>
                 {course.description && (
-                  <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{course.description}</p>
+                  <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{stripHtml(course.description)}</p>
                 )}
 
                 <div className="mt-auto pt-4">

--- a/frontend/exam-frontend/src/utils/html.js
+++ b/frontend/exam-frontend/src/utils/html.js
@@ -1,0 +1,12 @@
+// Course descriptions (and other rich fields) are stored as HTML. When we
+// need a short plain-text preview — e.g. a clamped card description — render
+// through this helper so raw markup like "<h3>…</h3>" never leaks into the UI.
+export const stripHtml = (html) => {
+  if (!html) return ''
+  if (typeof window === 'undefined') {
+    return html.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+  }
+  const el = document.createElement('div')
+  el.innerHTML = html
+  return (el.textContent || el.innerText || '').replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
## Problem

Same HTML-leak bug as the Courses grid, now on the **Study** tab ("Your enrolled courses"). Course descriptions are stored as rich HTML but rendered as plain text on the cards, so raw markup like `<h3>Class XII PCM — Board + Beyond</h3> <p>…` showed up in the preview.

## Fix

- Extract the `stripHtml()` helper into a shared `src/utils/html.js`.
- Use it for the Study card description preview.
- Refactor `Courses.jsx` to import the shared helper instead of keeping a local duplicate.

Full rich text is still rendered on `CourseDetail`.

## Verification
- `npm run build` (Vite) passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>