### PR TITLE
Fix quiz back navigation to return to course topic

### DIFF
--- a/backend/quiz/serializers.py
+++ b/backend/quiz/serializers.py
@@ -422,6 +422,7 @@ class QuizAttemptReviewSerializer(serializers.ModelSerializer):
     Includes ALL questions (answered and unanswered).
     """
     quiz_title = serializers.CharField(source='quiz.title', read_only=True)
+    topic = serializers.CharField(source='quiz.topic_id', read_only=True)
     all_questions = serializers.SerializerMethodField()
     
     class Meta:
@@ -431,7 +432,7 @@ class QuizAttemptReviewSerializer(serializers.ModelSerializer):
             'time_taken_seconds', 'status', 'total_questions',
             'attempted_questions', 'correct_answers', 'wrong_answers',
             'skipped_questions', 'marks_obtained', 'total_marks',
-            'percentage', 'xp_earned', 'all_questions'
+            'percentage', 'xp_earned', 'all_questions', 'topic'
         ]
     
     def get_all_questions(self, obj):

--- a/frontend/exam-frontend/src/pages/QuizAttempt.jsx
+++ b/frontend/exam-frontend/src/pages/QuizAttempt.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
@@ -24,8 +24,21 @@ import Confetti from 'react-confetti'
 const QuizAttempt = () => {
   const { quizId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
   const queryClient = useQueryClient()
   const { fetchProfile, user } = useAuthStore()
+
+  // Where the user came from (set when launched from a course topic page).
+  const courseCtx = location.state
+  const goBackToCourse = () => {
+    if (courseCtx?.chapterId && courseCtx?.topicId) {
+      navigate(`/study/chapter/${courseCtx.chapterId}/topic/${courseCtx.topicId}`)
+    } else if (quiz?.topic) {
+      navigate(`/topic/${quiz.topic}`)
+    } else {
+      navigate('/quiz')
+    }
+  }
 
   const [currentQuestion, setCurrentQuestion] = useState(0)
   const [answers, setAnswers] = useState({})
@@ -335,17 +348,17 @@ const QuizAttempt = () => {
           {/* Actions */}
           <div className="space-y-3">
             <button
-              onClick={() => navigate(`/quiz/review/${result.id}`)}
+              onClick={() => navigate(`/quiz/review/${result.id}`, { state: courseCtx })}
               className="btn-primary w-full flex items-center justify-center gap-2"
             >
               <FileText size={20} /> Review Answers
             </button>
             <div className="grid grid-cols-2 gap-3">
               <button
-                onClick={() => navigate('/quiz')}
+                onClick={goBackToCourse}
                 className="btn-secondary"
               >
-                Back to Quizzes
+                Back to Course
               </button>
               <button
                 onClick={() => navigate('/analytics')}

--- a/frontend/exam-frontend/src/pages/QuizReview.jsx
+++ b/frontend/exam-frontend/src/pages/QuizReview.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import { quizService } from '../services/quizService'
@@ -41,11 +41,24 @@ const REPORT_TYPES = [
 const QuizReview = () => {
   const { attemptId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
   const [reportModalOpen, setReportModalOpen] = useState(false)
   const [reportingQuestion, setReportingQuestion] = useState(null)
   const [reportType, setReportType] = useState('')
   const [reportDescription, setReportDescription] = useState('')
   const [filter, setFilter] = useState('all') // all, correct, wrong, skipped
+
+  // Where the user came from (set when launched from a course topic page).
+  const courseCtx = location.state
+  const goBackToCourse = () => {
+    if (courseCtx?.chapterId && courseCtx?.topicId) {
+      navigate(`/study/chapter/${courseCtx.chapterId}/topic/${courseCtx.topicId}`)
+    } else if (attempt?.topic) {
+      navigate(`/topic/${attempt.topic}`)
+    } else {
+      navigate('/quiz')
+    }
+  }
 
   const { data: attempt, isLoading, error } = useQuery({
     queryKey: ['attemptReview', attemptId],
@@ -144,17 +157,17 @@ const QuizReview = () => {
       <div className="flex items-center justify-between">
         <div>
           <button
-            onClick={() => navigate(-1)}
+            onClick={goBackToCourse}
             className="flex items-center gap-1 text-surface-500 hover:text-surface-700 mb-2"
           >
             <ChevronLeft size={18} />
-            Back
+            Back to Course
           </button>
           <h1 className="text-2xl font-display font-bold">Quiz Review</h1>
           <p className="text-surface-500 mt-1">{attempt?.quiz_title}</p>
         </div>
         <button
-          onClick={() => navigate(`/quiz/${attempt?.quiz}`)}
+          onClick={() => navigate(`/quiz/${attempt?.quiz}`, { state: courseCtx })}
           className="btn-primary"
         >
           Retry Quiz
@@ -482,13 +495,13 @@ const QuizReview = () => {
       {/* Bottom Actions */}
       <div className="flex gap-4 justify-center pb-8">
         <button
-          onClick={() => navigate('/quiz')}
+          onClick={goBackToCourse}
           className="btn-secondary"
         >
-          Back to Quizzes
+          Back to Course
         </button>
         <button
-          onClick={() => navigate(`/quiz/${attempt?.quiz}`)}
+          onClick={() => navigate(`/quiz/${attempt?.quiz}`, { state: courseCtx })}
           className="btn-primary"
         >
           Retry This Quiz

--- a/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
+++ b/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
@@ -30,6 +30,9 @@ const StudyTopicContent = () => {
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState('all')
 
+  // Carried into quiz attempt/review so their "Back to Course" returns here.
+  const quizNavState = { from: 'course', chapterId, topicId }
+
   const { data, isLoading } = useQuery({
     queryKey: ['studyChapterDetail', chapterId],
     queryFn: () => courseService.getStudyChapterDetail(chapterId),
@@ -180,10 +183,10 @@ const StudyTopicContent = () => {
           exit={{ opacity: 0, y: -10 }}
           transition={{ duration: 0.2 }}
         >
-          {activeTab === 'all' && <AllTab reading={reading} videos={videos} quizzes={quizzes} assignments={assignments} coding={codingProblems} navigate={navigate} />}
+          {activeTab === 'all' && <AllTab reading={reading} videos={videos} quizzes={quizzes} assignments={assignments} coding={codingProblems} navigate={navigate} quizNavState={quizNavState} />}
           {activeTab === 'reading' && <ReadingTab items={reading} navigate={navigate} />}
           {activeTab === 'videos' && <VideosTab items={videos} navigate={navigate} />}
-          {activeTab === 'quizzes' && <QuizzesTab items={quizzes} navigate={navigate} />}
+          {activeTab === 'quizzes' && <QuizzesTab items={quizzes} navigate={navigate} quizNavState={quizNavState} />}
           {activeTab === 'assignments' && <AssignmentsTab items={assignments} navigate={navigate} />}
           {activeTab === 'coding' && <CodingTab items={codingProblems} navigate={navigate} />}
         </motion.div>
@@ -249,7 +252,7 @@ const codingStatus = (p) => {
   return { tone: 'idle', icon: Circle, label: 'Not attempted' }
 }
 
-const AllTab = ({ reading, videos, quizzes, assignments = [], coding = [], navigate }) => {
+const AllTab = ({ reading, videos, quizzes, assignments = [], coding = [], navigate, quizNavState }) => {
   // Reading + videos share a real `order`; interleave them, quizzes go last.
   const materials = [...reading, ...videos]
     .map(item => ({ ...item, _kind: item.content_type === 'video' ? 'video' : 'reading' }))
@@ -321,7 +324,7 @@ const AllTab = ({ reading, videos, quizzes, assignments = [], coding = [], navig
         }
 
         const onClick = () => {
-          if (isQuiz) navigate(`/quiz/${item.id}`)
+          if (isQuiz) navigate(`/quiz/${item.id}`, { state: quizNavState })
           else if (isAssignment) navigate(`/assignment/${item.id}`)
           else if (isCoding) navigate(`/coding/${item.id}`)
           else navigate(`/content/${item.id}`)
@@ -492,7 +495,7 @@ const VideosTab = ({ items, navigate }) => {
   )
 }
 
-const QuizzesTab = ({ items, navigate }) => {
+const QuizzesTab = ({ items, navigate, quizNavState }) => {
   if (items.length === 0) {
     return <EmptyState icon={PenTool} message="No practice quizzes available yet" />
   }
@@ -516,18 +519,18 @@ const QuizzesTab = ({ items, navigate }) => {
                 {Math.round(quiz.best_score)}%
               </span>
             )}
-            onClick={() => navigate(`/quiz/${quiz.id}`)}
+            onClick={() => navigate(`/quiz/${quiz.id}`, { state: quizNavState })}
             action={
               <div className="flex gap-2 mt-3">
                 <button
-                  onClick={(e) => { e.stopPropagation(); navigate(`/quiz/${quiz.id}`) }}
+                  onClick={(e) => { e.stopPropagation(); navigate(`/quiz/${quiz.id}`, { state: quizNavState }) }}
                   className="flex-1 btn-primary text-xs py-1.5"
                 >
                   {attempted ? 'Retry' : 'Start'}
                 </button>
                 {attempted && quiz.last_attempt && (
                   <button
-                    onClick={(e) => { e.stopPropagation(); navigate(`/quiz/review/${quiz.last_attempt.id}`) }}
+                    onClick={(e) => { e.stopPropagation(); navigate(`/quiz/review/${quiz.last_attempt.id}`, { state: quizNavState }) }}
                     className="flex-1 btn-outline text-xs py-1.5"
                   >
                     Review


### PR DESCRIPTION
## Summary
Fixes quiz navigation so users return to their course topic instead of the quiz list, and stops a submitted quiz from restarting when going back.

## Changes
- **Quiz result page** (`QuizAttempt.jsx`): "Back to Quizzes" → "Back to Course", navigating to the originating topic page (`/study/chapter/:chapterId/topic/:topicId`).
- **Quiz review page** (`QuizReview.jsx`): The top "Back" button used `navigate(-1)`, which restarted the quiz — it now returns to the topic page. Bottom "Back to Quizzes" → "Back to Course". Retry buttons preserve course context.
- **Origin tracking** (`StudyTopicContent.jsx`): Passes `{ from: 'course', chapterId, topicId }` as navigation state when launching a quiz or its review from a topic.
- **Backend** (`quiz/serializers.py`): Adds `topic` to the attempt-review response as a fallback for direct review links (falls back to `/topic/:topicId`).

Fallback order for the button: course topic context → quiz's topic → `/quiz`.

## Testing
- Frontend `vite build` passes.