### PR TITLE
Keep admin Mock Tests and Jobs inside the full-page admin layout

### DIFF
--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -235,17 +235,7 @@ function App() {
           <Route path="/jobs" element={<FeatureRoute feature="jobs"><Jobs /></FeatureRoute>} />
           <Route path="/jobs/:jobId" element={<FeatureRoute feature="jobs"><JobDetail /></FeatureRoute>} />
 
-          {/* Job Portal (admin) */}
-          <Route path="/admin/jobs" element={<AdminRoute><JobManager /></AdminRoute>} />
-          <Route path="/admin/jobs/:jobId" element={<AdminRoute><JobApplicants /></AdminRoute>} />
-          <Route path="/admin/jobs/:jobId/applications/:applicationId" element={<AdminRoute><JobApplicationReview /></AdminRoute>} />
-
-          {/* Admin Dashboard */}
-          <Route path="/admin/mock-tests" element={<AdminRoute><MockTestManager /></AdminRoute>} />
-          <Route path="/admin/mock-tests/grading" element={<AdminRoute><MockTestGrading /></AdminRoute>} />
-          <Route path="/admin/mock-tests/:testId/submissions" element={<AdminRoute><MockTestSubmissions /></AdminRoute>} />
-          <Route path="/admin/mock-tests/:testId/submissions/:attemptId" element={<AdminRoute><MockTestSubmissionReview /></AdminRoute>} />
-          <Route path="/admin/mock-tests/:testId" element={<AdminRoute><MockTestBuilder /></AdminRoute>} />
+          {/* Admin Job Portal & Mock Tests now live under the full-page Admin View below */}
         </Route>
 
         {/* Full-page Admin View */}
@@ -260,6 +250,18 @@ function App() {
         >
           <Route path="/admin-dashboard" element={<AdminDashboard />} />
           <Route path="/admin-dashboard/content/:courseId" element={<CourseManager />} />
+
+          {/* Job Portal (admin) */}
+          <Route path="/admin/jobs" element={<JobManager />} />
+          <Route path="/admin/jobs/:jobId" element={<JobApplicants />} />
+          <Route path="/admin/jobs/:jobId/applications/:applicationId" element={<JobApplicationReview />} />
+
+          {/* Mock Tests (admin) */}
+          <Route path="/admin/mock-tests" element={<MockTestManager />} />
+          <Route path="/admin/mock-tests/grading" element={<MockTestGrading />} />
+          <Route path="/admin/mock-tests/:testId/submissions" element={<MockTestSubmissions />} />
+          <Route path="/admin/mock-tests/:testId/submissions/:attemptId" element={<MockTestSubmissionReview />} />
+          <Route path="/admin/mock-tests/:testId" element={<MockTestBuilder />} />
         </Route>
 
 


### PR DESCRIPTION
## What & why

Clicking **Mock Tests** or **Jobs** in the admin sidebar dropped the user back into the student layout (the "course view"), because those `/admin/mock-tests` and `/admin/jobs` routes were still nested under the student `MainLayout`.

## Change

Moved the admin Mock Tests and Job Portal route groups under the full-page `AdminLayout`, so they now render with the admin sidebar and top bar — consistent with the rest of the admin console. All their internal navigation already stays within `/admin/...`, so the whole flow (manage, build, grade, submissions, applicants) keeps the admin shell.

## Verification

- `npm run build` passes