### PR TITLE
Fix admin sidebar tab navigation from Mock Tests / Jobs sub-pages

### DIFF
--- a/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation, useSearchParams } from 'react-router-dom'
+import { NavLink, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAuthStore } from '../../context/authStore'
 import { useAppStore } from '../../context/appStore'
@@ -30,16 +30,17 @@ export const ADMIN_NAV_ITEMS = [
 
 const AdminSidebar = () => {
   const location = useLocation()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { profile } = useAuthStore()
   const { closeMobileMenu } = useAppStore()
   const tenant = useTenantStore((s) => s.tenant)
 
   const activeTab = searchParams.get('tab') || 'overview'
-  const onAdminDashboard = location.pathname.startsWith('/admin-dashboard')
+  const onAdminDashboard = location.pathname === '/admin-dashboard'
 
   const selectTab = (tab) => {
-    setSearchParams(tab === 'overview' ? {} : { tab })
+    navigate(tab === 'overview' ? '/admin-dashboard' : `/admin-dashboard?tab=${tab}`)
     closeMobileMenu()
   }
 


### PR DESCRIPTION
## What & why

From an admin sub-page like **Mock Tests** or **Jobs** (`/admin/...`), clicking a sidebar tab (Overview, Content Builder, Reports, etc.) did nothing — the reverse direction worked fine.

**Cause:** tab items called `setSearchParams`, which only updates the query string of the *current* route. From `/admin/mock-tests` that produced `/admin/mock-tests?tab=content` and stayed on the page, since the dashboard tabs are only rendered at `/admin-dashboard`.

## Change

Tab items now `navigate('/admin-dashboard?tab=...')`, so they always land on the dashboard and show the right section regardless of where you click from. Active-highlight for tabs is scoped to the exact `/admin-dashboard` path.

## Verification

- `npm run build` passes