### PR TITLE
Allow public browsing of courses and jobs; gate rest behind login

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -196,9 +196,11 @@ class TenantContentExplorerView(APIView):
 
 class AvailableCoursesForEnrollmentView(APIView):
     """
-    Return active courses for the enrollment dropdown. Course must belong to the request tenant.
+    Return active courses for the enrollment dropdown / public catalog. Course
+    must belong to the request tenant. Public so anonymous visitors can browse
+    the course catalog before signing up.
     """
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.AllowAny]
 
     def get(self, request):
         qs = Course.objects.filter(status='active').order_by('name')

--- a/backend/jobs/views.py
+++ b/backend/jobs/views.py
@@ -22,6 +22,15 @@ class JobViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     parser_classes = [JSONParser, MultiPartParser, FormParser]
 
+    # Browsing the job board is public so anonymous visitors can explore
+    # openings before signing up. Only the write/apply actions require auth.
+    _public_actions = {'list', 'retrieve'}
+
+    def get_permissions(self):
+        if self.action in self._public_actions:
+            return [permissions.AllowAny()]
+        return [permissions.IsAuthenticated()]
+
     def get_serializer_class(self):
         return JobDetailSerializer if self.action == 'retrieve' else JobListSerializer
 

--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -8,6 +8,7 @@ import AuthLayout from './components/layout/AuthLayout'
 import AdminLayout from './components/layout/AdminLayout'
 import SuspensionOverlay from './components/layout/SuspensionOverlay'
 import VerificationGate from './components/layout/VerificationGate'
+import LoginGate from './components/auth/LoginGate'
 
 // Auth Pages
 import Login from './pages/auth/Login'
@@ -78,6 +79,27 @@ const ProtectedRoute = ({ children }) => {
   }
 
   return children
+}
+
+// App shell that renders for everyone, including anonymous visitors, so they can
+// explore public sections (courses, jobs). Authenticated-but-not-onboarded users
+// are still routed to onboarding. Pages that require login gate themselves via
+// <LoginGate>, which shows a blurred screen + login prompt to anonymous users.
+const AppShell = () => {
+  const { isAuthenticated, isOnboarded } = useAuthStore()
+
+  if (isAuthenticated && !isOnboarded) {
+    return <Navigate to="/onboarding" replace />
+  }
+
+  return <MainLayout />
+}
+
+// Root/catch-all redirect: send authenticated users to their dashboard and
+// anonymous visitors to the public course catalog.
+const RootRedirect = () => {
+  const { isAuthenticated } = useAuthStore()
+  return <Navigate to={isAuthenticated ? '/dashboard' : '/courses'} replace />
 }
 
 // Admin-only Route Component
@@ -188,50 +210,45 @@ function App() {
         </Route>
 
         {/* Main App Routes */}
-        <Route
-          element={
-            <ProtectedRoute>
-              <MainLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route path="/dashboard" element={<Dashboard />} />
+        <Route element={<AppShell />}>
+          <Route path="/dashboard" element={<LoginGate><Dashboard /></LoginGate>} />
+          {/* Public: anyone can browse the course catalog and course details */}
           <Route path="/courses" element={<FeatureRoute feature="courses"><Courses /></FeatureRoute>} />
           <Route path="/courses/:courseId" element={<FeatureRoute feature="courses"><CourseDetail /></FeatureRoute>} />
-          <Route path="/courses/:courseId/manage" element={<EditorRoute><CourseManager /></EditorRoute>} />
-          <Route path="/courses/:courseId/manage/assignments/:assignmentId" element={<EditorRoute><AssignmentGrading /></EditorRoute>} />
-          <Route path="/courses/:courseId/manage/assignments/:assignmentId/submissions/:submissionId" element={<EditorRoute><SubmissionReview /></EditorRoute>} />
-          <Route path="/courses/:courseId/manage/coding/:problemId" element={<EditorRoute><CodingGrading /></EditorRoute>} />
-          <Route path="/courses/:courseId/manage/coding/:problemId/submissions/:submissionId" element={<EditorRoute><CodingSubmissionReview /></EditorRoute>} />
-          <Route path="/study" element={<FeatureRoute feature="study"><Study /></FeatureRoute>} />
-          <Route path="/study/course/:courseId" element={<FeatureRoute feature="study"><StudyCourse /></FeatureRoute>} />
-          <Route path="/study/:subjectId" element={<FeatureRoute feature="study"><StudyChapters /></FeatureRoute>} />
-          <Route path="/study/chapter/:chapterId" element={<FeatureRoute feature="study"><StudyChapterTopics /></FeatureRoute>} />
-          <Route path="/study/chapter/:chapterId/topic/:topicId" element={<FeatureRoute feature="study"><StudyTopicContent /></FeatureRoute>} />
-          <Route path="/topic/:topicId" element={<FeatureRoute feature="study"><TopicView /></FeatureRoute>} />
-          <Route path="/content/:contentId" element={<FeatureRoute feature="study"><ContentViewer /></FeatureRoute>} />
-          <Route path="/assignment/:assignmentId" element={<AssignmentView />} />
-          <Route path="/coding/:problemId" element={<CodingProblem />} />
-          <Route path="/quiz" element={<FeatureRoute feature="quiz"><Quiz /></FeatureRoute>} />
-          <Route path="/quiz/:quizId" element={<FeatureRoute feature="quiz"><QuizAttempt /></FeatureRoute>} />
-          <Route path="/quiz/review/:attemptId" element={<FeatureRoute feature="quiz"><QuizReview /></FeatureRoute>} />
-          <Route path="/mock-test" element={<FeatureRoute feature="mock_tests"><MockTest /></FeatureRoute>} />
-          <Route path="/mock-test/live/:testId" element={<FeatureRoute feature="mock_tests"><RichMockAttempt /></FeatureRoute>} />
-          <Route path="/mock-test/live-review/:attemptId" element={<FeatureRoute feature="mock_tests"><RichMockReview /></FeatureRoute>} />
-          <Route path="/mock-test/:testId" element={<FeatureRoute feature="mock_tests"><MockTestAttempt /></FeatureRoute>} />
-          <Route path="/mock-test/review/:attemptId" element={<FeatureRoute feature="mock_tests"><MockTestReview /></FeatureRoute>} />
-          <Route path="/pyp" element={<FeatureRoute feature="pyq"><PreviousYearPapers /></FeatureRoute>} />
-          <Route path="/analytics" element={<FeatureRoute feature="analytics"><Analytics /></FeatureRoute>} />
-          <Route path="/leaderboard" element={<FeatureRoute feature="leaderboard"><Leaderboard /></FeatureRoute>} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/doubt-solver" element={<FeatureRoute feature="ai"><AIDoubtSolver /></FeatureRoute>} />
-          <Route path="/ai-doubt-solver" element={<FeatureRoute feature="ai"><AIDoubtSolver /></FeatureRoute>} />
-          <Route path="/ai-learning" element={<FeatureRoute feature="ai"><AILearning /></FeatureRoute>} />
-          <Route path="/ai-quiz-review/:attemptId" element={<FeatureRoute feature="ai"><AIQuizReview /></FeatureRoute>} />
-          <Route path="/community" element={<FeatureRoute feature="community"><Community /></FeatureRoute>} />
-          <Route path="/community/:id" element={<FeatureRoute feature="community"><CommunityPost /></FeatureRoute>} />
+          <Route path="/courses/:courseId/manage" element={<LoginGate><EditorRoute><CourseManager /></EditorRoute></LoginGate>} />
+          <Route path="/courses/:courseId/manage/assignments/:assignmentId" element={<LoginGate><EditorRoute><AssignmentGrading /></EditorRoute></LoginGate>} />
+          <Route path="/courses/:courseId/manage/assignments/:assignmentId/submissions/:submissionId" element={<LoginGate><EditorRoute><SubmissionReview /></EditorRoute></LoginGate>} />
+          <Route path="/courses/:courseId/manage/coding/:problemId" element={<LoginGate><EditorRoute><CodingGrading /></EditorRoute></LoginGate>} />
+          <Route path="/courses/:courseId/manage/coding/:problemId/submissions/:submissionId" element={<LoginGate><EditorRoute><CodingSubmissionReview /></EditorRoute></LoginGate>} />
+          <Route path="/study" element={<LoginGate><FeatureRoute feature="study"><Study /></FeatureRoute></LoginGate>} />
+          <Route path="/study/course/:courseId" element={<LoginGate><FeatureRoute feature="study"><StudyCourse /></FeatureRoute></LoginGate>} />
+          <Route path="/study/:subjectId" element={<LoginGate><FeatureRoute feature="study"><StudyChapters /></FeatureRoute></LoginGate>} />
+          <Route path="/study/chapter/:chapterId" element={<LoginGate><FeatureRoute feature="study"><StudyChapterTopics /></FeatureRoute></LoginGate>} />
+          <Route path="/study/chapter/:chapterId/topic/:topicId" element={<LoginGate><FeatureRoute feature="study"><StudyTopicContent /></FeatureRoute></LoginGate>} />
+          <Route path="/topic/:topicId" element={<LoginGate><FeatureRoute feature="study"><TopicView /></FeatureRoute></LoginGate>} />
+          <Route path="/content/:contentId" element={<LoginGate><FeatureRoute feature="study"><ContentViewer /></FeatureRoute></LoginGate>} />
+          <Route path="/assignment/:assignmentId" element={<LoginGate><AssignmentView /></LoginGate>} />
+          <Route path="/coding/:problemId" element={<LoginGate><CodingProblem /></LoginGate>} />
+          <Route path="/quiz" element={<LoginGate><FeatureRoute feature="quiz"><Quiz /></FeatureRoute></LoginGate>} />
+          <Route path="/quiz/:quizId" element={<LoginGate><FeatureRoute feature="quiz"><QuizAttempt /></FeatureRoute></LoginGate>} />
+          <Route path="/quiz/review/:attemptId" element={<LoginGate><FeatureRoute feature="quiz"><QuizReview /></FeatureRoute></LoginGate>} />
+          <Route path="/mock-test" element={<LoginGate><FeatureRoute feature="mock_tests"><MockTest /></FeatureRoute></LoginGate>} />
+          <Route path="/mock-test/live/:testId" element={<LoginGate><FeatureRoute feature="mock_tests"><RichMockAttempt /></FeatureRoute></LoginGate>} />
+          <Route path="/mock-test/live-review/:attemptId" element={<LoginGate><FeatureRoute feature="mock_tests"><RichMockReview /></FeatureRoute></LoginGate>} />
+          <Route path="/mock-test/:testId" element={<LoginGate><FeatureRoute feature="mock_tests"><MockTestAttempt /></FeatureRoute></LoginGate>} />
+          <Route path="/mock-test/review/:attemptId" element={<LoginGate><FeatureRoute feature="mock_tests"><MockTestReview /></FeatureRoute></LoginGate>} />
+          <Route path="/pyp" element={<LoginGate><FeatureRoute feature="pyq"><PreviousYearPapers /></FeatureRoute></LoginGate>} />
+          <Route path="/analytics" element={<LoginGate><FeatureRoute feature="analytics"><Analytics /></FeatureRoute></LoginGate>} />
+          <Route path="/leaderboard" element={<LoginGate><FeatureRoute feature="leaderboard"><Leaderboard /></FeatureRoute></LoginGate>} />
+          <Route path="/profile" element={<LoginGate><Profile /></LoginGate>} />
+          <Route path="/doubt-solver" element={<LoginGate><FeatureRoute feature="ai"><AIDoubtSolver /></FeatureRoute></LoginGate>} />
+          <Route path="/ai-doubt-solver" element={<LoginGate><FeatureRoute feature="ai"><AIDoubtSolver /></FeatureRoute></LoginGate>} />
+          <Route path="/ai-learning" element={<LoginGate><FeatureRoute feature="ai"><AILearning /></FeatureRoute></LoginGate>} />
+          <Route path="/ai-quiz-review/:attemptId" element={<LoginGate><FeatureRoute feature="ai"><AIQuizReview /></FeatureRoute></LoginGate>} />
+          <Route path="/community" element={<LoginGate><FeatureRoute feature="community"><Community /></FeatureRoute></LoginGate>} />
+          <Route path="/community/:id" element={<LoginGate><FeatureRoute feature="community"><CommunityPost /></FeatureRoute></LoginGate>} />
 
-          {/* Job Portal (students) */}
+          {/* Job Portal (students) — public browsing, login required to apply */}
           <Route path="/jobs" element={<FeatureRoute feature="jobs"><Jobs /></FeatureRoute>} />
           <Route path="/jobs/:jobId" element={<FeatureRoute feature="jobs"><JobDetail /></FeatureRoute>} />
 
@@ -266,8 +283,8 @@ function App() {
 
 
         {/* Redirects */}
-        <Route path="/" element={<Navigate to="/dashboard" replace />} />
-        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/" element={<RootRedirect />} />
+        <Route path="*" element={<RootRedirect />} />
       </Routes>
     </>
   )

--- a/frontend/exam-frontend/src/components/auth/LoginGate.jsx
+++ b/frontend/exam-frontend/src/components/auth/LoginGate.jsx
@@ -1,0 +1,115 @@
+import { useNavigate, useLocation, Navigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { Lock, LogIn, UserPlus } from 'lucide-react'
+import { useAuthStore } from '../../context/authStore'
+
+/**
+ * Decorative, non-interactive skeleton rendered blurred behind the login card
+ * so gated pages look like real (locked) content instead of a blank screen.
+ */
+const LockedSkeleton = () => (
+  <div aria-hidden className="select-none space-y-6">
+    <div className="space-y-2">
+      <div className="h-8 w-56 rounded-lg bg-surface-200 dark:bg-surface-800" />
+      <div className="h-4 w-80 max-w-full rounded bg-surface-200/70 dark:bg-surface-800/70" />
+    </div>
+
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="card p-5 space-y-3">
+          <div className="h-10 w-10 rounded-xl bg-surface-200 dark:bg-surface-800" />
+          <div className="h-6 w-16 rounded bg-surface-200 dark:bg-surface-800" />
+          <div className="h-3 w-24 rounded bg-surface-200/70 dark:bg-surface-800/70" />
+        </div>
+      ))}
+    </div>
+
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div className="lg:col-span-2 card p-6 space-y-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4">
+            <div className="h-10 w-10 rounded-full bg-surface-200 dark:bg-surface-800" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-3/4 rounded bg-surface-200 dark:bg-surface-800" />
+              <div className="h-3 w-1/2 rounded bg-surface-200/70 dark:bg-surface-800/70" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="card p-6 space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <div className="h-4 w-2/3 rounded bg-surface-200 dark:bg-surface-800" />
+            <div className="h-3 w-full rounded bg-surface-200/70 dark:bg-surface-800/70" />
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+)
+
+/**
+ * Gate that keeps a page's content visible-but-blurred for anonymous visitors
+ * and shows a login prompt overlay. Authenticated + onboarded users see the
+ * real page; authenticated-but-not-onboarded users are sent to onboarding.
+ */
+const LoginGate = ({
+  children,
+  title = 'Sign in to continue',
+  message = 'Log in or create a free account to unlock this section.',
+}) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { isAuthenticated, isOnboarded } = useAuthStore()
+
+  if (isAuthenticated && !isOnboarded) {
+    return <Navigate to="/onboarding" replace />
+  }
+
+  if (isAuthenticated) {
+    return children
+  }
+
+  const goLogin = () => navigate('/login', { state: { from: location.pathname } })
+  const goRegister = () => navigate('/register', { state: { from: location.pathname } })
+
+  return (
+    <div className="relative min-h-[70vh]">
+      {/* Blurred, non-interactive backdrop */}
+      <div className="pointer-events-none blur-sm opacity-60">
+        <LockedSkeleton />
+      </div>
+
+      {/* Login prompt overlay */}
+      <div className="absolute inset-0 flex items-start justify-center pt-16 sm:pt-24">
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          className="w-full max-w-sm mx-4 card p-8 text-center shadow-xl border border-surface-200/80 dark:border-surface-700/80 bg-white/90 dark:bg-surface-900/90 backdrop-blur-xl"
+        >
+          <div className="w-14 h-14 mx-auto rounded-2xl bg-gradient-to-br from-primary-500 to-accent-500 flex items-center justify-center">
+            <Lock className="w-7 h-7 text-white" />
+          </div>
+          <h2 className="mt-5 text-xl font-display font-bold">{title}</h2>
+          <p className="mt-2 text-sm text-surface-500">{message}</p>
+
+          <div className="mt-6 space-y-3">
+            <button onClick={goLogin} className="btn-primary w-full inline-flex items-center justify-center gap-2">
+              <LogIn className="w-4 h-4" /> Log in
+            </button>
+            <button onClick={goRegister} className="btn-secondary w-full inline-flex items-center justify-center gap-2">
+              <UserPlus className="w-4 h-4" /> Create free account
+            </button>
+          </div>
+
+          <p className="mt-5 text-xs text-surface-400">
+            You can keep browsing courses and jobs without an account.
+          </p>
+        </motion.div>
+      </div>
+    </div>
+  )
+}
+
+export default LoginGate

--- a/frontend/exam-frontend/src/components/layout/Header.jsx
+++ b/frontend/exam-frontend/src/components/layout/Header.jsx
@@ -10,7 +10,7 @@ import { analyticsService } from '../../services/analyticsService'
 const Header = () => {
   const navigate = useNavigate()
   const location = useLocation()
-  const { profile, logout } = useAuthStore()
+  const { profile, logout, isAuthenticated } = useAuthStore()
   const { sidebarOpen, toggleSidebar, toggleMobileMenu, darkMode, toggleDarkMode } = useAppStore()
   const [showUserMenu, setShowUserMenu] = useState(false)
 
@@ -23,6 +23,7 @@ const Header = () => {
     queryKey: ['currentStreak'],
     queryFn: () => analyticsService.getCurrentStreak(),
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+    enabled: isAuthenticated,
   })
 
   return (
@@ -104,12 +105,14 @@ const Header = () => {
           )}
 
           {/* XP */}
-          <div className="hidden sm:flex items-center gap-1 px-3 py-1.5 rounded-full bg-accent-50 dark:bg-accent-900/30">
-            <span className="text-lg">⚡</span>
-            <span className="font-semibold text-accent-600 dark:text-accent-400">
-              {profile?.total_xp?.toLocaleString() || 0}
-            </span>
-          </div>
+          {isAuthenticated && (
+            <div className="hidden sm:flex items-center gap-1 px-3 py-1.5 rounded-full bg-accent-50 dark:bg-accent-900/30">
+              <span className="text-lg">⚡</span>
+              <span className="font-semibold text-accent-600 dark:text-accent-400">
+                {profile?.total_xp?.toLocaleString() || 0}
+              </span>
+            </div>
+          )}
 
           {/* Dark Mode Toggle */}
           <button
@@ -129,16 +132,19 @@ const Header = () => {
           </button>
 
           {/* Notifications */}
-          <button className="btn-icon relative" aria-label="Notifications">
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-            </svg>
-            {/* Notification badge - shows when there are unread notifications */}
-            {/* TODO: Connect to notifications API when available */}
-          </button>
+          {isAuthenticated && (
+            <button className="btn-icon relative" aria-label="Notifications">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+              </svg>
+              {/* Notification badge - shows when there are unread notifications */}
+              {/* TODO: Connect to notifications API when available */}
+            </button>
+          )}
 
-          {/* User Menu */}
-          <div className="relative">
+          {/* User Menu (authenticated) or Log in (anonymous) */}
+          {isAuthenticated ? (
+            <div className="relative">
             <button
               onClick={() => setShowUserMenu(!showUserMenu)}
               className="flex items-center gap-2 p-1 rounded-xl hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors"
@@ -194,6 +200,22 @@ const Header = () => {
               </motion.div>
             )}
           </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => navigate('/login')}
+                className="btn-secondary text-sm px-3 py-2"
+              >
+                Log in
+              </button>
+              <button
+                onClick={() => navigate('/register')}
+                className="btn-primary text-sm px-3 py-2 hidden sm:inline-flex"
+              >
+                Sign up
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </header>

--- a/frontend/exam-frontend/src/components/layout/MainLayout.jsx
+++ b/frontend/exam-frontend/src/components/layout/MainLayout.jsx
@@ -10,11 +10,11 @@ import { useAuthStore } from '../../context/authStore'
 
 const MainLayout = () => {
   const { sidebarOpen, mobileMenuOpen } = useAppStore()
-  const { fetchProfile } = useAuthStore()
+  const { fetchProfile, isAuthenticated } = useAuthStore()
 
   useEffect(() => {
-    fetchProfile()
-  }, [])
+    if (isAuthenticated) fetchProfile()
+  }, [isAuthenticated])
 
   return (
     <div className="min-h-screen bg-surface-50 dark:bg-surface-950">

--- a/frontend/exam-frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/Sidebar.jsx
@@ -38,7 +38,7 @@ const navItems = [
 
 const Sidebar = () => {
   const location = useLocation()
-  const { profile } = useAuthStore()
+  const { profile, isAuthenticated } = useAuthStore()
   const { closeMobileMenu } = useAppStore()
   const tenant = useTenantStore((s) => s.tenant)
   const isFeatureEnabled = useTenantStore((s) => s.isFeatureEnabled)
@@ -69,6 +69,23 @@ const Sidebar = () => {
           </div>
         </div>
       </div>
+
+      {/* Guest CTA card */}
+      {!isAuthenticated && (
+        <div className="p-4 mx-4 mt-4 rounded-xl bg-gradient-to-br from-primary-50 to-accent-50 dark:from-primary-900/20 dark:to-accent-900/20">
+          <p className="text-sm font-medium">You're browsing as a guest</p>
+          <p className="text-xs text-surface-500 mt-1">
+            Log in to track progress, take quizzes and mock tests.
+          </p>
+          <NavLink
+            to="/login"
+            onClick={closeMobileMenu}
+            className="btn-primary w-full mt-3 text-sm justify-center"
+          >
+            Log in / Sign up
+          </NavLink>
+        </div>
+      )}
 
       {/* User Profile Card */}
       {profile && (

--- a/frontend/exam-frontend/src/pages/CourseDetail.jsx
+++ b/frontend/exam-frontend/src/pages/CourseDetail.jsx
@@ -92,7 +92,7 @@ const CourseDetail = () => {
   const { courseId } = useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { user, profile } = useAuthStore()
+  const { user, profile, isAuthenticated } = useAuthStore()
   const role = user?.role || profile?.user?.role
   const isAdmin = role === 'admin'
 
@@ -116,6 +116,7 @@ const CourseDetail = () => {
   const { data: studyData = { courses: [], pending: [] } } = useQuery({
     queryKey: ['studyCourses'],
     queryFn: () => courseService.getStudyCourses(),
+    enabled: isAuthenticated,
   })
 
   const status = useMemo(() => {
@@ -125,6 +126,10 @@ const CourseDetail = () => {
   }, [studyData, courseId])
 
   const requestEnroll = async () => {
+    if (!isAuthenticated) {
+      navigate('/login', { state: { from: `/courses/${courseId}` } })
+      return
+    }
     setRequesting(true)
     try {
       await courseService.requestEnrollment(courseId)
@@ -186,7 +191,13 @@ const CourseDetail = () => {
     return (
       <button onClick={requestEnroll} disabled={requesting} className="btn-primary w-full disabled:opacity-70">
         <PlusCircle size={18} />
-        {requesting ? 'Sending…' : isFree ? 'Request enrollment · Free' : 'Request enrollment'}
+        {!isAuthenticated
+          ? 'Log in to enroll'
+          : requesting
+          ? 'Sending…'
+          : isFree
+          ? 'Request enrollment · Free'
+          : 'Request enrollment'}
       </button>
     )
   }

--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -72,7 +72,7 @@ const CoursePrice = ({ course }) => {
 
 const Courses = () => {
   const navigate = useNavigate()
-  const { user, profile } = useAuthStore()
+  const { user, profile, isAuthenticated } = useAuthStore()
   const role = user?.role || profile?.user?.role
   const isAdmin = role === 'admin'
   const isInstructor = role === 'instructor'
@@ -95,6 +95,7 @@ const Courses = () => {
   const { data: studyData = { courses: [], pending: [] } } = useQuery({
     queryKey: ['studyCourses'],
     queryFn: () => courseService.getStudyCourses(),
+    enabled: isAuthenticated,
   })
 
   const statusById = useMemo(() => {
@@ -135,8 +136,12 @@ const Courses = () => {
 
   const filterTabs = [
     { key: 'all', label: 'All', count: counts.all },
-    { key: 'enrolled', label: 'Enrolled', count: counts.enrolled },
-    { key: 'pending', label: 'Pending', count: counts.pending },
+    ...(isAuthenticated
+      ? [
+          { key: 'enrolled', label: 'Enrolled', count: counts.enrolled },
+          { key: 'pending', label: 'Pending', count: counts.pending },
+        ]
+      : []),
   ]
 
   if (availLoading) return <Loading fullScreen />

--- a/frontend/exam-frontend/src/pages/JobDetail.jsx
+++ b/frontend/exam-frontend/src/pages/JobDetail.jsx
@@ -7,6 +7,7 @@ import {
   Loader2, CheckCircle2, FileText, Send, XCircle, Flag, AlertTriangle,
 } from 'lucide-react'
 import { jobService } from '../services/jobService'
+import { useAuthStore } from '../context/authStore'
 import { stageMeta, formatSalary, formatExperience, categoryMeta } from '../components/jobs/jobShared'
 import JobContent from '../components/jobs/JobContent'
 import Loading from '../components/common/Loading'
@@ -21,11 +22,21 @@ const JobDetail = () => {
   const { jobId } = useParams()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const [showApply, setShowApply] = useState(false)
   const [showReport, setShowReport] = useState(false)
   const [reportForm, setReportForm] = useState({ reason: 'closed', note: '' })
   const [form, setForm] = useState({ cover_letter: '', phone: '', portfolio_url: '', linkedin_url: '' })
   const [resume, setResume] = useState(null)
+
+  // Any action that writes (apply, withdraw, report) needs a logged-in user.
+  const requireAuth = (fn) => () => {
+    if (!isAuthenticated) {
+      navigate('/login', { state: { from: `/jobs/${jobId}` } })
+      return
+    }
+    fn()
+  }
 
   const { data: job, isLoading } = useQuery({
     queryKey: ['job', jobId],
@@ -176,16 +187,16 @@ const JobDetail = () => {
             <p className="text-sm text-surface-500">This position is no longer accepting applications.</p>
           ) : job.is_external ? (
             <button
-              onClick={() => externalMutation.mutate()}
+              onClick={requireAuth(() => externalMutation.mutate())}
               disabled={externalMutation.isPending}
               className="btn-primary inline-flex items-center gap-2"
             >
               {externalMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <ExternalLink className="w-4 h-4" />}
-              Apply on external site
+              {isAuthenticated ? 'Apply on external site' : 'Log in to apply'}
             </button>
           ) : (
-            <button onClick={() => setShowApply(true)} className="btn-primary inline-flex items-center gap-2">
-              <Send className="w-4 h-4" /> Apply now
+            <button onClick={requireAuth(() => setShowApply(true))} className="btn-primary inline-flex items-center gap-2">
+              <Send className="w-4 h-4" /> {isAuthenticated ? 'Apply now' : 'Log in to apply'}
             </button>
           )}
         </div>
@@ -228,7 +239,7 @@ const JobDetail = () => {
         <div className="flex items-center justify-between gap-3 flex-wrap px-1">
           <p className="text-xs text-surface-500">Is this opening no longer active?</p>
           <button
-            onClick={() => setShowReport(true)}
+            onClick={requireAuth(() => setShowReport(true))}
             className="text-sm inline-flex items-center gap-1.5 text-surface-500 hover:text-error-600 dark:hover:text-error-400 transition-colors"
           >
             <Flag className="w-4 h-4" /> Report as closed

--- a/frontend/exam-frontend/src/pages/Jobs.jsx
+++ b/frontend/exam-frontend/src/pages/Jobs.jsx
@@ -7,6 +7,7 @@ import {
   ArrowRight, ClipboardList, Search, SlidersHorizontal, X,
 } from 'lucide-react'
 import { jobService } from '../services/jobService'
+import { useAuthStore } from '../context/authStore'
 import {
   stageMeta, formatSalary, formatExperience, categoryMeta,
   CATEGORIES, WORK_MODES, EMPLOYMENT_TYPES,
@@ -127,6 +128,7 @@ const EMPTY_FILTERS = { category: [], job_type: [], work_mode: [], employment_ty
 
 const Jobs = () => {
   const navigate = useNavigate()
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const [tab, setTab] = useState('open')
   const [q, setQ] = useState('')
   const [filters, setFilters] = useState(EMPTY_FILTERS)
@@ -139,7 +141,7 @@ const Jobs = () => {
   const { data: mine = [], isLoading: mineLoading } = useQuery({
     queryKey: ['jobs', 'mine'],
     queryFn: () => jobService.myApplications(),
-    enabled: tab === 'mine',
+    enabled: tab === 'mine' && isAuthenticated,
   })
 
   const toggle = (key) => (value) =>
@@ -186,7 +188,13 @@ const Jobs = () => {
         {TABS.map((t) => (
           <button
             key={t.id}
-            onClick={() => setTab(t.id)}
+            onClick={() => {
+              if (t.id === 'mine' && !isAuthenticated) {
+                navigate('/login', { state: { from: '/jobs' } })
+                return
+              }
+              setTab(t.id)
+            }}
             className={`px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors ${
               tab === t.id
                 ? 'border-primary-500 text-primary-600 dark:text-primary-400'

--- a/frontend/exam-frontend/src/pages/auth/Login.jsx
+++ b/frontend/exam-frontend/src/pages/auth/Login.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useAuthStore } from '../../context/authStore'
 import { useTenantStore } from '../../context/tenantStore'
@@ -12,6 +12,9 @@ const Login = () => {
   const { login, isLoading, error, clearError } = useAuthStore()
   const { tenant } = useTenantStore()
   const navigate = useNavigate()
+  const location = useLocation()
+  // Return the user to the page they were gated out of, when provided.
+  const from = location.state?.from
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -24,7 +27,7 @@ const Login = () => {
       const { isOnboarded } = useAuthStore.getState()
       // Navigate based on onboarding status
       if (isOnboarded) {
-        navigate('/dashboard', { replace: true })
+        navigate(from || '/dashboard', { replace: true })
       } else {
         navigate('/onboarding', { replace: true })
       }


### PR DESCRIPTION
## Summary
Anonymous visitors can now explore the **course catalog** and **job board** without an account. Every other section renders behind a **blurred screen with a login prompt**, and login is only requested when an action actually needs it (enroll, apply, protected pages).

## Backend
- **exams**: course catalog (`available-for-enrollment`) is now `AllowAny`. Course/subject/topic/chapter reads were already public.
- **jobs**: `JobViewSet` `list`/`retrieve` are public; `apply`/`apply-external`/`withdraw`/`report`/`my-applications` remain authenticated.

## Frontend
- New `components/auth/LoginGate.jsx` — blurred content skeleton + "Sign in to continue" card for guests; redirects authed-but-not-onboarded users to onboarding.
- `App.jsx` — app shell renders for everyone; gated routes wrapped in `LoginGate`; `courses`/`jobs` (list + detail) left public; root/unknown routes send guests to `/courses`, logged-in users to `/dashboard`.
- `Header`/`Sidebar` — guest CTA + Log in / Sign up; streak/XP/notifications hidden for guests.
- `Login.jsx` — returns users to the page they were gated out of.
- `Courses`/`CourseDetail`/`Jobs`/`JobDetail` — skip protected queries for guests; enroll/apply/report route guests to login.

## Verification
- Frontend `npm run build` ✓
- Backend `manage.py check` ✓
- Anonymous requests: 200 for catalog/jobs list & detail, 401 for `my-applications` ✓
- Previewed locally as a logged-out visitor.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>