### PR TITLE
Fix long tenant names overflowing the sidebar and auth headers

### DIFF
--- a/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
@@ -50,18 +50,18 @@ const AdminSidebar = () => {
       <div className="p-6 border-b border-surface-200 dark:border-surface-800">
         <div className="flex items-center gap-3">
           {tenant?.logo ? (
-            <div className="w-10 h-10 rounded-xl overflow-hidden flex items-center justify-center bg-surface-100 dark:bg-surface-800">
+            <div className="w-10 h-10 shrink-0 rounded-xl overflow-hidden flex items-center justify-center bg-surface-100 dark:bg-surface-800">
               <img src={tenant.logo} alt={tenant.name || 'Logo'} className="w-full h-full object-contain" />
             </div>
           ) : (
-            <div className="w-10 h-10 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
+            <div className="w-10 h-10 shrink-0 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
               <span className="text-white font-bold">
                 {(tenant?.name || 'dt').slice(0, 2).toLowerCase()}
               </span>
             </div>
           )}
-          <div>
-            <h1 className="font-display font-bold text-lg gradient-text">{tenant?.name || 'DailyTaiyari'}</h1>
+          <div className="min-w-0">
+            <h1 title={tenant?.name || 'DailyTaiyari'} className="font-display font-bold text-lg gradient-text leading-tight break-words line-clamp-2">{tenant?.name || 'DailyTaiyari'}</h1>
             <p className="text-xs text-surface-500">Admin Console</p>
           </div>
         </div>

--- a/frontend/exam-frontend/src/components/layout/AuthLayout.jsx
+++ b/frontend/exam-frontend/src/components/layout/AuthLayout.jsx
@@ -31,15 +31,15 @@ const AuthLayout = () => {
                 <img
                   src={tenant.logo}
                   alt={`${tenantName} Logo`}
-                  className="w-14 h-14 rounded-2xl object-contain bg-white/20 backdrop-blur-sm p-1"
+                  className="w-14 h-14 shrink-0 rounded-2xl object-contain bg-white/20 backdrop-blur-sm p-1"
                 />
               ) : (
-                <div className="w-14 h-14 bg-white/20 rounded-2xl flex items-center justify-center backdrop-blur-sm">
+                <div className="w-14 h-14 shrink-0 bg-white/20 rounded-2xl flex items-center justify-center backdrop-blur-sm">
                   <span className="text-2xl font-bold">{tenantInitials}</span>
                 </div>
               )}
-              <div>
-                <h1 className="text-2xl font-display font-bold">{tenantName}</h1>
+              <div className="min-w-0">
+                <h1 title={tenantName} className="text-2xl font-display font-bold leading-tight break-words line-clamp-2">{tenantName}</h1>
                 <p className="text-white/70 text-sm">{tenant?.tagline || 'Ace Your Exams'}</p>
               </div>
             </div>

--- a/frontend/exam-frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/Sidebar.jsx
@@ -53,18 +53,18 @@ const Sidebar = () => {
       <div className="p-6 border-b border-surface-200 dark:border-surface-800">
         <div className="flex items-center gap-3">
           {tenant?.logo ? (
-            <div className="w-10 h-10 rounded-xl overflow-hidden flex items-center justify-center bg-surface-100 dark:bg-surface-800">
+            <div className="w-10 h-10 shrink-0 rounded-xl overflow-hidden flex items-center justify-center bg-surface-100 dark:bg-surface-800">
               <img src={tenant.logo} alt={tenant.name || 'Logo'} className="w-full h-full object-contain" />
             </div>
           ) : (
-            <div className="w-10 h-10 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
+            <div className="w-10 h-10 shrink-0 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
               <span className="text-white font-bold">
                 {(tenant?.name || 'dt').slice(0, 2).toLowerCase()}
               </span>
             </div>
           )}
-          <div>
-            <h1 className="font-display font-bold text-lg gradient-text">{tenant?.name || 'DailyTaiyari'}</h1>
+          <div className="min-w-0">
+            <h1 title={tenant?.name || 'DailyTaiyari'} className="font-display font-bold text-lg gradient-text leading-tight break-words line-clamp-2">{tenant?.name || 'DailyTaiyari'}</h1>
             <p className="text-xs text-surface-500">{tenant?.tagline || 'Ace Your Exams'}</p>
           </div>
         </div>

--- a/frontend/exam-frontend/src/pages/auth/Login.jsx
+++ b/frontend/exam-frontend/src/pages/auth/Login.jsx
@@ -51,17 +51,17 @@ const Login = () => {
           <img
             src={tenant.logo}
             alt={`${tenant.name} Logo`}
-            className="w-12 h-12 rounded-xl object-contain bg-white dark:bg-surface-800 p-1"
+            className="w-12 h-12 shrink-0 rounded-xl object-contain bg-white dark:bg-surface-800 p-1"
           />
         ) : (
-          <div className="w-12 h-12 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
+          <div className="w-12 h-12 shrink-0 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
             <span className="text-white text-xl font-bold">
               {tenant?.name ? tenant.name.substring(0, 2).toLowerCase() : 'dt'}
             </span>
           </div>
         )}
-        <div>
-          <h1 className="font-display font-bold text-xl gradient-text">
+        <div className="min-w-0">
+          <h1 title={tenant?.name || 'DailyTaiyari'} className="font-display font-bold text-xl gradient-text leading-tight break-words line-clamp-2">
             {tenant?.name || 'DailyTaiyari'}
           </h1>
           <p className="text-xs text-surface-500">{tenant?.tagline || 'Ace Your Exams'}</p>

--- a/frontend/exam-frontend/src/pages/auth/Register.jsx
+++ b/frontend/exam-frontend/src/pages/auth/Register.jsx
@@ -61,17 +61,17 @@ const Register = () => {
           <img
             src={tenant.logo}
             alt={`${tenant.name} Logo`}
-            className="w-12 h-12 rounded-xl object-contain bg-white dark:bg-surface-800 p-1"
+            className="w-12 h-12 shrink-0 rounded-xl object-contain bg-white dark:bg-surface-800 p-1"
           />
         ) : (
-          <div className="w-12 h-12 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
+          <div className="w-12 h-12 shrink-0 bg-gradient-to-br from-primary-500 to-accent-500 rounded-xl flex items-center justify-center">
             <span className="text-white text-xl font-bold">
               {tenant?.name ? tenant.name.substring(0, 2).toLowerCase() : 'dt'}
             </span>
           </div>
         )}
-        <div>
-          <h1 className="font-display font-bold text-xl gradient-text">
+        <div className="min-w-0">
+          <h1 title={tenant?.name || 'DailyTaiyari'} className="font-display font-bold text-xl gradient-text leading-tight break-words line-clamp-2">
             {tenant?.name || 'DailyTaiyari'}
           </h1>
           <p className="text-xs text-surface-500">{tenant?.tagline || 'Ace Your Exams'}</p>


### PR DESCRIPTION
## Problem

When a client sets a longer institution name (e.g. **"TESLA EV Academy"**), the name wrapped awkwardly in the admin sidebar and pushed the logo/layout around — looking broken.

## Fix

Made the branding header robust for names of any length:
- Logo is now `shrink-0` so it never gets squeezed
- The text column is `min-w-0` so it can shrink within the flex row
- The name uses `leading-tight`, `break-words` and `line-clamp-2` — long names wrap into at most two tidy lines, with the full name available on hover (`title`)

Applied consistently to every place the tenant name renders:
- `components/layout/Sidebar.jsx` (student sidebar)
- `components/layout/AdminSidebar.jsx` (admin console)
- `components/layout/AuthLayout.jsx` (desktop auth branding)
- `pages/auth/Login.jsx` and `pages/auth/Register.jsx` (mobile headers)

## Notes
- Frontend-only, no backend/migration. Deploys via Netlify on merge.
- Build succeeds.