### PR TITLE
Allow enrolled students to view course details page

### DIFF
--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -306,14 +306,23 @@ const Courses = () => {
 
                   <div className="mt-auto pt-4">
                     {status === 'approved' ? (
-                      <button
-                        type="button"
-                        onClick={() => navigate(`/study/course/${course.id}`)}
-                        className="btn-primary w-full group/btn"
-                      >
-                        Enter course
-                        <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />
-                      </button>
+                      <div className="space-y-2">
+                        <button
+                          type="button"
+                          onClick={() => navigate(`/study/course/${course.id}`)}
+                          className="btn-primary w-full group/btn"
+                        >
+                          Enter course
+                          <ArrowRight size={16} className="transition-transform group-hover/btn:translate-x-0.5" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => navigate(`/courses/${course.id}`)}
+                          className="w-full inline-flex items-center justify-center gap-1.5 px-4 py-2 rounded-xl text-sm font-medium text-surface-600 dark:text-surface-300 bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors"
+                        >
+                          View details
+                        </button>
+                      </div>
                     ) : status === 'pending' ? (
                       <button
                         type="button"

--- a/frontend/exam-frontend/src/pages/Study.jsx
+++ b/frontend/exam-frontend/src/pages/Study.jsx
@@ -93,7 +93,7 @@ const Study = () => {
                   <p className="text-sm text-surface-500 mt-2.5 line-clamp-2">{stripHtml(course.description)}</p>
                 )}
 
-                <div className="mt-auto pt-4">
+                <div className="mt-auto pt-4 space-y-2">
                   <button
                     type="button"
                     onClick={() => navigate(`/study/course/${course.id}`)}
@@ -101,6 +101,13 @@ const Study = () => {
                   >
                     Enter course
                     <ArrowRight size={18} className="transition-transform group-hover/btn:translate-x-0.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/courses/${course.id}`)}
+                    className="w-full inline-flex items-center justify-center gap-1.5 px-4 py-2 rounded-xl text-sm font-medium text-surface-600 dark:text-surface-300 bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors"
+                  >
+                    View details
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Enrolled students previously had no way to reach a course's details page — enrolled course cards only exposed an **Enter course** action (→ `/study/course/:id`). This adds a secondary **View details** link (→ `/courses/:id`) so enrolled students can revisit the course detail/overview page.

## Changes
- **`Courses.jsx`** — For enrolled (`approved`) courses, added a secondary **View details** button below **Enter course**.
- **`Study.jsx`** — Each enrolled course card now has a **View details** link alongside **Enter course**.

## Notes
- The `/courses/:courseId` route is only feature-gated (no login/enrollment redirect), and `CourseDetail` already renders correctly for enrolled users, so no backend or routing changes were needed.
- Verified with `vite build` (compiles cleanly).