### PR TITLE
fix(community): enforce tenant isolation on posts and comments

### DIFF
--- a/backend/community/migrations/0009_backfill_tenant.py
+++ b/backend/community/migrations/0009_backfill_tenant.py
@@ -1,0 +1,87 @@
+"""
+Backfill the ``tenant`` field on community records created before tenant
+stamping was enforced in the API layer.
+
+Historically ``PostViewSet``/``CommentViewSet`` saved records without a tenant,
+so existing rows have ``tenant=NULL``. Once the read queries filter by tenant,
+those rows would disappear from their rightful tenant's feed. We recover the
+correct tenant from each record's author (``author.user.tenant``) and cascade it
+to dependent rows (likes, poll options/votes, quizzes, events, attempts).
+"""
+from django.db import migrations
+
+
+def backfill_tenant(apps, schema_editor):
+    Post = apps.get_model('community', 'Post')
+    Comment = apps.get_model('community', 'Comment')
+    Like = apps.get_model('community', 'Like')
+    PollOption = apps.get_model('community', 'PollOption')
+    PollVote = apps.get_model('community', 'PollVote')
+    CommunityQuiz = apps.get_model('community', 'CommunityQuiz')
+    CommunityEvent = apps.get_model('community', 'CommunityEvent')
+    QuizAttempt = apps.get_model('community', 'QuizAttempt')
+    CommunityStats = apps.get_model('community', 'CommunityStats')
+
+    # Posts & comments: tenant comes from the author's user.
+    for post in Post.objects.filter(tenant__isnull=True).select_related('author__user'):
+        tenant_id = getattr(post.author.user, 'tenant_id', None)
+        if tenant_id:
+            Post.objects.filter(pk=post.pk).update(tenant_id=tenant_id)
+
+    for comment in Comment.objects.filter(tenant__isnull=True).select_related('author__user'):
+        tenant_id = getattr(comment.author.user, 'tenant_id', None)
+        if tenant_id:
+            Comment.objects.filter(pk=comment.pk).update(tenant_id=tenant_id)
+
+    # Dependent rows: derive tenant from their parent post.
+    for opt in PollOption.objects.filter(tenant__isnull=True).select_related('post'):
+        if opt.post.tenant_id:
+            PollOption.objects.filter(pk=opt.pk).update(tenant_id=opt.post.tenant_id)
+
+    for quiz in CommunityQuiz.objects.filter(tenant__isnull=True).select_related('post'):
+        if quiz.post.tenant_id:
+            CommunityQuiz.objects.filter(pk=quiz.pk).update(tenant_id=quiz.post.tenant_id)
+
+    for event in CommunityEvent.objects.filter(tenant__isnull=True).select_related('post'):
+        if event.post.tenant_id:
+            CommunityEvent.objects.filter(pk=event.pk).update(tenant_id=event.post.tenant_id)
+
+    for like in Like.objects.filter(tenant__isnull=True).select_related('post', 'comment'):
+        tenant_id = None
+        if like.post_id and like.post.tenant_id:
+            tenant_id = like.post.tenant_id
+        elif like.comment_id and like.comment.tenant_id:
+            tenant_id = like.comment.tenant_id
+        if tenant_id:
+            Like.objects.filter(pk=like.pk).update(tenant_id=tenant_id)
+
+    for vote in PollVote.objects.filter(tenant__isnull=True).select_related('option__post'):
+        tenant_id = getattr(vote.option.post, 'tenant_id', None)
+        if tenant_id:
+            PollVote.objects.filter(pk=vote.pk).update(tenant_id=tenant_id)
+
+    for attempt in QuizAttempt.objects.filter(tenant__isnull=True).select_related('quiz__post'):
+        tenant_id = getattr(attempt.quiz.post, 'tenant_id', None)
+        if tenant_id:
+            QuizAttempt.objects.filter(pk=attempt.pk).update(tenant_id=tenant_id)
+
+    for stats in CommunityStats.objects.filter(tenant__isnull=True).select_related('user__user'):
+        tenant_id = getattr(stats.user.user, 'tenant_id', None)
+        if tenant_id:
+            CommunityStats.objects.filter(pk=stats.pk).update(tenant_id=tenant_id)
+
+
+def noop_reverse(apps, schema_editor):
+    # Non-reversible data backfill; nothing to undo.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('community', '0008_alter_post_post_type_communityevent'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_tenant, noop_reverse),
+    ]

--- a/backend/community/serializers.py
+++ b/backend/community/serializers.py
@@ -388,6 +388,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
             for i, option_text in enumerate(poll_options):
                 PollOption.objects.create(
                     post=post,
+                    tenant=post.tenant,
                     option_text=option_text,
                     order=i
                 )
@@ -396,6 +397,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
         if quiz_data:
             CommunityQuiz.objects.create(
                 post=post,
+                tenant=post.tenant,
                 question=quiz_data['question'],
                 options=quiz_data['options'],
                 correct_answer=quiz_data['correct_answer'],
@@ -406,6 +408,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
         if event_data:
             CommunityEvent.objects.create(
                 post=post,
+                tenant=post.tenant,
                 start_at=event_data['start_at'],
                 end_at=event_data.get('end_at') or None,
                 meeting_url=event_data['meeting_url'],
@@ -476,6 +479,7 @@ class QuizAttemptSerializer(serializers.ModelSerializer):
         attempt = QuizAttempt.objects.create(
             user=user,
             quiz=quiz,
+            tenant=getattr(quiz, 'tenant', None) or getattr(quiz.post, 'tenant', None),
             selected_answer=selected,
             is_correct=is_correct,
             xp_earned=5 if is_correct else 0

--- a/backend/community/tests.py
+++ b/backend/community/tests.py
@@ -17,6 +17,7 @@ class PostLikeXPTests(TestCase):
         self.liker, _ = StudentProfile.objects.get_or_create(user=self.liker_user)
         self.post = Post.objects.create(
             author=self.author,
+            tenant=self.tenant,
             post_type='question',
             title='A valid question title',
             content='Some sufficiently long content body.',
@@ -43,4 +44,42 @@ class PostLikeXPTests(TestCase):
         self._like(self.author_user)
         self.author.refresh_from_db()
         self.assertEqual(self.author.total_xp, 0)
+
+
+class PostTenantIsolationTests(TestCase):
+    """Posts must never leak across tenants."""
+
+    def setUp(self):
+        self.tenant_a = Tenant.objects.create(name='A', subdomain='a')
+        self.tenant_b = Tenant.objects.create(name='B', subdomain='b')
+
+        self.user_a = User.objects.create_user(email='a@x.com', tenant=self.tenant_a, password='x')
+        self.profile_a, _ = StudentProfile.objects.get_or_create(user=self.user_a)
+        self.user_b = User.objects.create_user(email='b@x.com', tenant=self.tenant_b, password='x')
+        self.profile_b, _ = StudentProfile.objects.get_or_create(user=self.user_b)
+
+        self.post_a = Post.objects.create(
+            author=self.profile_a, tenant=self.tenant_a, post_type='question',
+            title='Tenant A only post title', content='Content body for tenant A only.',
+        )
+        self.factory = APIRequestFactory()
+        self.list_view = PostViewSet.as_view({'get': 'list'})
+
+    def _list(self, user, tenant):
+        request = self.factory.get('/posts/')
+        force_authenticate(request, user=user)
+        request.tenant = tenant
+        return self.list_view(request)
+
+    def test_other_tenant_cannot_see_post(self):
+        response = self._list(self.user_b, self.tenant_b)
+        self.assertEqual(response.status_code, 200)
+        ids = [p['id'] for p in response.data.get('results', response.data)]
+        self.assertNotIn(str(self.post_a.id), ids)
+
+    def test_same_tenant_sees_own_post(self):
+        response = self._list(self.user_a, self.tenant_a)
+        self.assertEqual(response.status_code, 200)
+        ids = [p['id'] for p in response.data.get('results', response.data)]
+        self.assertIn(str(self.post_a.id), ids)
 

--- a/backend/community/views.py
+++ b/backend/community/views.py
@@ -70,9 +70,15 @@ class PostViewSet(TenantAwareViewSet):
     permission_classes = [IsAuthenticated]
     
     def get_queryset(self):
+        # Tenant isolation: never leak posts across tenants. If the request has
+        # no resolved tenant, return nothing rather than every post.
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            return Post.objects.none()
+
         is_staff = _is_staff_user(self.request.user)
 
-        queryset = Post.objects.all().select_related(
+        queryset = Post.objects.filter(tenant=tenant).select_related(
             'author__user', 'course', 'subject'
         ).prefetch_related('poll_options', 'quiz', 'event', 'courses')
 
@@ -217,7 +223,12 @@ class PostViewSet(TenantAwareViewSet):
         return Response({'status': 'active', 'id': str(post.id)})
     
     def perform_create(self, serializer):
-        post = serializer.save()
+        # Stamp the post with the current tenant so it stays isolated.
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            from rest_framework.exceptions import PermissionDenied
+            raise PermissionDenied("A valid Tenant is required to create a post.")
+        post = serializer.save(tenant=tenant)
         
         # Award XP based on post type
         action_map = {
@@ -242,7 +253,7 @@ class PostViewSet(TenantAwareViewSet):
         
         like, created = Like.objects.get_or_create(
             user=user, post=post,
-            defaults={'is_active': True}
+            defaults={'is_active': True, 'tenant': post.tenant}
         )
         
         if created or not like.is_active:
@@ -361,7 +372,7 @@ class PostViewSet(TenantAwareViewSet):
             existing_vote.save()
         else:
             # New vote
-            PollVote.objects.create(user=user, option=option)
+            PollVote.objects.create(user=user, option=option, tenant=post.tenant)
             CommunityXPService.award_xp(
                 user,
                 'vote_poll',
@@ -384,7 +395,12 @@ class CommentViewSet(TenantAwareViewSet):
     permission_classes = [IsAuthenticated]
     
     def get_queryset(self):
-        queryset = Comment.objects.select_related('author__user', 'post')
+        # Tenant isolation: only comments belonging to the current tenant.
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            return Comment.objects.none()
+
+        queryset = Comment.objects.filter(tenant=tenant).select_related('author__user', 'post')
         
         post_id = self.request.query_params.get('post')
         if post_id:
@@ -414,7 +430,12 @@ class CommentViewSet(TenantAwareViewSet):
         return super().destroy(request, *args, **kwargs)
     
     def perform_create(self, serializer):
-        comment = serializer.save()
+        # Stamp the comment with the current tenant so it stays isolated.
+        tenant = getattr(self.request, 'tenant', None)
+        if not tenant:
+            from rest_framework.exceptions import PermissionDenied
+            raise PermissionDenied("A valid Tenant is required to comment.")
+        comment = serializer.save(tenant=tenant)
         
         # Update post comment count
         Post.objects.filter(pk=comment.post_id).update(
@@ -441,7 +462,7 @@ class CommentViewSet(TenantAwareViewSet):
         
         like, created = Like.objects.get_or_create(
             user=user, comment=comment,
-            defaults={'is_active': True}
+            defaults={'is_active': True, 'tenant': comment.tenant}
         )
         
         if created or not like.is_active:
@@ -485,14 +506,15 @@ class CommunityStatsViewSet(viewsets.GenericViewSet):
     def my_stats(self, request):
         """Get current user's community stats."""
         stats, created = CommunityStats.objects.get_or_create(
-            user=request.user.profile
+            user=request.user.profile,
+            defaults={'tenant': getattr(request, 'tenant', None)}
         )
         serializer = CommunityStatsSerializer(stats)
         return Response(serializer.data)
     
     @action(detail=False, methods=['get'])
     def user_stats(self, request):
-        """Get another user's community stats."""
+        """Get another user's community stats (same tenant only)."""
         user_id = request.query_params.get('user_id')
         if not user_id:
             return Response(
@@ -500,7 +522,10 @@ class CommunityStatsViewSet(viewsets.GenericViewSet):
                 status=status.HTTP_400_BAD_REQUEST
             )
         
-        stats = get_object_or_404(CommunityStats, user_id=user_id)
+        tenant = getattr(request, 'tenant', None)
+        stats = get_object_or_404(
+            CommunityStats, user_id=user_id, user__user__tenant=tenant
+        )
         serializer = CommunityStatsSerializer(stats)
         return Response(serializer.data)
 


### PR DESCRIPTION
## Problem (serious data leak)

Community posts and comments were visible across tenants. Posts created in the Test Academy tenant showed up in a newly onboarded client's community feed.

## Root cause

`PostViewSet` and `CommentViewSet` extend `TenantAwareViewSet` (which filters querysets by `request.tenant`), but both **fully overrode `get_queryset()`** starting from `Post.objects.all()` / `Comment.objects...` and never re-applied the tenant filter. Additionally, their `perform_create()` called `serializer.save()` **without a tenant**, so existing community records were stored with `tenant=NULL`.

## Changes

- **`views.py`**: `get_queryset()` on both viewsets now filters by `request.tenant` (returns empty when no tenant resolved). `perform_create()` stamps `tenant=request.tenant`. Tenant also stamped on likes and poll votes. `CommunityStats` `my_stats`/`user_stats` are tenant-scoped (fixes a cross-tenant stats leak).
- **`serializers.py`**: poll options, quizzes, events and quiz attempts inherit the post's tenant.
- **`migrations/0009_backfill_tenant.py`**: backfills `tenant` on existing `NULL` records from the author's `user.tenant` and cascades to dependent rows. Required so existing posts don't disappear once filtering is enforced.
- **`tests.py`**: added `PostTenantIsolationTests` verifying a tenant cannot see another tenant's posts.

## Testing

`python manage.py test community` — all 4 tests pass, including new isolation tests.

## Deploy note

Requires running `migrate community` on production (handled by the deploy) so existing posts get their correct tenant assigned.