### PR TITLE
Fix 500 on profile update with empty nullable fields

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -177,6 +177,9 @@ class StudentProfileSerializer(serializers.ModelSerializer):
 
     
     def to_internal_value(self, data):
+        # Copy immutable QueryDicts (multipart/form-data) so we can normalize values
+        if hasattr(data, '_mutable'):
+            data = data.copy()
         # Convert empty strings to None for nullable fields
         if 'date_of_birth' in data and data['date_of_birth'] == '':
             data['date_of_birth'] = None


### PR DESCRIPTION
## Problem
Editing name/phone on the profile page returned **500**.

## Root cause
`StudentProfileSerializer.to_internal_value` mutates `data` to normalize empty `date_of_birth`/`target_year` to `None`. For `multipart/form-data` requests (used because avatar upload uses FormData), `data` is an **immutable** `QueryDict`, so the assignment raised `AttributeError: This QueryDict instance is immutable`.

This triggered reliably because the frontend sends `date_of_birth=''` whenever the stored value is `null` (`'' !== null`).

## Fix
Copy the `QueryDict` to a mutable one before normalizing values.

Verified via the full `ProfileView` request path (multipart) — now returns 200 for name/phone edits with empty `date_of_birth`/`target_year`, and with a real date value.