### PR TITLE
fix(admin): remove duplicate "Sales & Orders" heading

### DIFF
--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -1540,10 +1540,7 @@ const SalesDashboard = () => {
 
     return (
         <div className="space-y-6">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="text-xl font-bold flex items-center gap-2">
-                    <ShoppingCart className="w-5 h-5 text-primary-500" /> Sales & Orders
-                </h2>
+            <div className="flex flex-wrap items-center justify-end gap-3">
                 <div className="flex items-center gap-2">
                     <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-lg">
                         {RANGE_PRESETS.map((r) => (


### PR DESCRIPTION
## Summary

Minor UI fix: the **Sales & Orders** section rendered its title twice — once in the shared admin page header (with the section icon) and again in the `SalesDashboard` component's own `<h2>`.

This removes the redundant inner heading and keeps the date-range presets + refresh toolbar right-aligned.

Frontend-only; deploys via Netlify on merge. `vite build` passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>