### PR TITLE
feat(admin): add growth metrics with period filters to dashboard

### DIFF
--- a/backend/analytics/services.py
+++ b/backend/analytics/services.py
@@ -373,17 +373,73 @@ class AnalyticsService:
         return report
 
     @staticmethod
-    def get_tenant_admin_stats(tenant):
+    def get_tenant_admin_stats(tenant, period_days=30):
         """
         Get aggregated statistics for all students in a tenant.
+
+        ``period_days`` controls the growth window (e.g. 7, 30, 90) used for
+        new-signup counts, active-user counts and the activity trend chart.
+        Growth metrics compare the selected window against the immediately
+        preceding window of the same length.
         """
         from users.models import StudentProfile
         from django.db.models import Count, Avg, Sum
-        
+
+        # Sanitise the requested window.
+        try:
+            period_days = int(period_days)
+        except (TypeError, ValueError):
+            period_days = 30
+        period_days = max(1, min(period_days, 365))
+
+        now = timezone.now()
+        today = now.date()
+        window_start = now - timedelta(days=period_days)
+        prev_window_start = now - timedelta(days=period_days * 2)
+
+        def _pct_change(current, previous):
+            """Percent change vs previous period (None when no baseline)."""
+            if previous:
+                return round(((current - previous) / previous) * 100, 1)
+            if current:
+                return None  # growth from zero baseline is undefined
+            return 0.0
+
         # Base queryset for students in this tenant
         students = StudentProfile.objects.filter(user__tenant=tenant)
         total_students = students.count()
-        
+
+        # New signups within the selected window vs the previous window.
+        new_signups = students.filter(user__date_joined__gte=window_start).count()
+        prev_new_signups = students.filter(
+            user__date_joined__gte=prev_window_start,
+            user__date_joined__lt=window_start,
+        ).count()
+        signup_change_pct = _pct_change(new_signups, prev_new_signups)
+
+        # Active students within the selected window vs the previous window.
+        active_in_period = DailyActivity.objects.filter(
+            student__user__tenant=tenant,
+            date__gte=window_start.date(),
+        ).values('student').distinct().count()
+        prev_active_in_period = DailyActivity.objects.filter(
+            student__user__tenant=tenant,
+            date__gte=prev_window_start.date(),
+            date__lt=window_start.date(),
+        ).values('student').distinct().count()
+        active_change_pct = _pct_change(active_in_period, prev_active_in_period)
+
+        growth = {
+            'period_days': period_days,
+            'new_signups': new_signups,
+            'prev_new_signups': prev_new_signups,
+            'signup_change_pct': signup_change_pct,
+            'active_in_period': active_in_period,
+            'prev_active_in_period': prev_active_in_period,
+            'active_change_pct': active_change_pct,
+            'total_students_start': max(total_students - new_signups, 0),
+        }
+
         if total_students == 0:
             return {
                 'total_students': 0,
@@ -391,11 +447,11 @@ class AnalyticsService:
                 'avg_accuracy': 0,
                 'total_xp': 0,
                 'level_distribution': {},
-                'activity_trend': []
+                'activity_trend': [],
+                'growth': growth,
             }
 
         # Active today (activity in last 24h)
-        today = timezone.now().date()
         active_today = DailyActivity.objects.filter(
             student__user__tenant=tenant,
             date=today
@@ -415,11 +471,11 @@ class AnalyticsService:
         level_dist = students.values('current_level').annotate(count=Count('id')).order_by('current_level')
         level_distribution = {str(item['current_level']): item['count'] for item in level_dist}
 
-        # Activity trend (last 30 days)
-        thirty_days_ago = today - timedelta(days=30)
+        # Activity trend (over the selected window)
+        trend_start = window_start.date()
         trend_data = DailyActivity.objects.filter(
             student__user__tenant=tenant,
-            date__gte=thirty_days_ago
+            date__gte=trend_start
         ).values('date').annotate(
             active_users=Count('student', distinct=True),
             total_questions=Sum('questions_attempted'),
@@ -442,7 +498,8 @@ class AnalyticsService:
             'avg_accuracy': round(avg_accuracy, 2),
             'total_xp': total_xp,
             'level_distribution': level_distribution,
-            'activity_trend': activity_trend
+            'activity_trend': activity_trend,
+            'growth': growth,
         }
 
     @staticmethod

--- a/backend/analytics/views.py
+++ b/backend/analytics/views.py
@@ -469,7 +469,12 @@ class TenantAdminStatsView(APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
         
-        stats = AnalyticsService.get_tenant_admin_stats(request.tenant)
+        try:
+            period_days = int(request.query_params.get('days', 30))
+        except (TypeError, ValueError):
+            period_days = 30
+
+        stats = AnalyticsService.get_tenant_admin_stats(request.tenant, period_days=period_days)
         return Response(stats)
 
 

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -59,6 +59,10 @@ import {
     Wallet,
     Calendar,
     ShoppingCart,
+    UserPlus,
+    ArrowUpRight,
+    ArrowDownRight,
+    Minus,
 } from 'lucide-react'
 
 /* ---------------------------------------------------------------------------
@@ -117,7 +121,31 @@ const roleBadgeClass = (role) =>
 /* ---------------------------------------------------------------------------
  * StatCard
  * ------------------------------------------------------------------------- */
-const StatCard = ({ title, value, icon: Icon, color, description }) => (
+const TrendBadge = ({ change }) => {
+    // change === null → growth from a zero baseline (no meaningful %)
+    if (change === null || change === undefined) {
+        return (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-bold bg-surface-100 dark:bg-surface-800 text-surface-500">
+                New
+            </span>
+        )
+    }
+    const isUp = change > 0
+    const isDown = change < 0
+    const Icon = isUp ? ArrowUpRight : isDown ? ArrowDownRight : Minus
+    const tone = isUp
+        ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400'
+        : isDown
+            ? 'bg-rose-50 dark:bg-rose-900/30 text-rose-600 dark:text-rose-400'
+            : 'bg-surface-100 dark:bg-surface-800 text-surface-500'
+    return (
+        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-bold ${tone}`}>
+            <Icon className="w-3 h-3" />{Math.abs(change)}%
+        </span>
+    )
+}
+
+const StatCard = ({ title, value, icon: Icon, color, description, change }) => (
     <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -127,7 +155,10 @@ const StatCard = ({ title, value, icon: Icon, color, description }) => (
             <div className="min-w-0">
                 <p className="text-sm font-medium text-surface-500 mb-1 truncate">{title}</p>
                 <h3 className="text-2xl sm:text-3xl font-bold text-surface-900 dark:text-white">{value}</h3>
-                {description && <p className="mt-2 text-xs sm:text-sm text-surface-500">{description}</p>}
+                <div className="mt-2 flex items-center gap-2 flex-wrap">
+                    {change !== undefined && <TrendBadge change={change} />}
+                    {description && <p className="text-xs sm:text-sm text-surface-500">{description}</p>}
+                </div>
             </div>
             <div className={`p-3 rounded-xl shrink-0 ${color}`}>
                 <Icon className="w-6 h-6 text-white" />
@@ -1727,13 +1758,72 @@ const SalesDashboard = () => {
 /* ---------------------------------------------------------------------------
  * Overview
  * ------------------------------------------------------------------------- */
-const Overview = ({ stats }) => (
+const RANGE_OPTIONS = [
+    { value: 7, label: '7 days' },
+    { value: 30, label: '30 days' },
+    { value: 90, label: '90 days' },
+]
+
+const Overview = ({ stats, range, onRangeChange }) => {
+    const growth = stats?.growth || {}
+    const rangeLabel = RANGE_OPTIONS.find((o) => o.value === range)?.label || `${range} days`
+    return (
     <div className="space-y-6 sm:space-y-8">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6">
             <StatCard title="Total Students" value={stats?.total_students || 0} icon={Users} color="bg-blue-500" description="Registered locally" />
             <StatCard title="Active Today" value={stats?.active_today || 0} icon={Zap} color="bg-amber-500" description="Student engagement" />
             <StatCard title="Avg. Accuracy" value={`${stats?.avg_accuracy || 0}%`} icon={CheckCircle2} color="bg-emerald-500" description="Target score performance" />
             <StatCard title="Total XP Distributed" value={stats?.total_xp?.toLocaleString() || 0} icon={TrendingUp} color="bg-purple-500" description="Collective progress" />
+        </div>
+
+        {/* Growth section --------------------------------------------------- */}
+        <div className="space-y-4">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <div>
+                    <h3 className="text-lg font-bold text-surface-900 dark:text-white">Growth</h3>
+                    <p className="text-sm text-surface-500">Compared to the previous {rangeLabel}</p>
+                </div>
+                <div className="inline-flex items-center gap-1 p-1 rounded-xl bg-surface-100 dark:bg-surface-800">
+                    {RANGE_OPTIONS.map((opt) => (
+                        <button
+                            key={opt.value}
+                            onClick={() => onRangeChange(opt.value)}
+                            className={`px-3 py-1.5 rounded-lg text-sm font-semibold transition-colors ${
+                                range === opt.value
+                                    ? 'bg-white dark:bg-surface-700 text-primary-600 dark:text-primary-400 shadow-sm'
+                                    : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-200'
+                            }`}
+                        >
+                            {opt.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
+                <StatCard
+                    title="New Signups"
+                    value={growth.new_signups || 0}
+                    icon={UserPlus}
+                    color="bg-indigo-500"
+                    change={growth.signup_change_pct}
+                    description={`${growth.prev_new_signups || 0} in prior period`}
+                />
+                <StatCard
+                    title={`Active (${rangeLabel})`}
+                    value={growth.active_in_period || 0}
+                    icon={Zap}
+                    color="bg-amber-500"
+                    change={growth.active_change_pct}
+                    description={`${growth.prev_active_in_period || 0} in prior period`}
+                />
+                <StatCard
+                    title="Total Students"
+                    value={stats?.total_students || 0}
+                    icon={Users}
+                    color="bg-blue-500"
+                    description={`Up from ${growth.total_students_start ?? 0} at period start`}
+                />
+            </div>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8">
@@ -1762,7 +1852,7 @@ const Overview = ({ stats }) => (
 
             <div className="card p-5 sm:p-6">
                 <h3 className="text-lg font-bold mb-6 flex items-center justify-between">
-                    <span>30-Day Student Activity</span>
+                    <span>{rangeLabel} Student Activity</span>
                     <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-surface-400 font-bold">
                         <div className="w-2 h-2 rounded-full bg-primary-500"></div> Active Users
                     </div>
@@ -1800,7 +1890,8 @@ const Overview = ({ stats }) => (
             </div>
         </div>
     </div>
-)
+    )
+}
 
 /* ---------------------------------------------------------------------------
  * TenantSettings — branding (logo) + feature toggles
@@ -2587,10 +2678,13 @@ const AdminDashboard = () => {
 
     const activeMeta = TABS.find((t) => t.id === activeTab) || TABS[0]
 
+    const [growthRange, setGrowthRange] = useState(30)
+
     const { data: stats, isLoading, error, isFetching } = useQuery({
-        queryKey: ['tenantAdminStats'],
-        queryFn: () => analyticsService.getTenantAdminStats(),
+        queryKey: ['tenantAdminStats', growthRange],
+        queryFn: () => analyticsService.getTenantAdminStats(growthRange),
         refetchInterval: 60000,
+        keepPreviousData: true,
     })
 
     useEffect(() => { window.scrollTo(0, 0) }, [activeTab])
@@ -2638,7 +2732,7 @@ const AdminDashboard = () => {
 
             <AnimatePresence mode="wait">
                 <motion.div key={activeTab} initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.2 }}>
-                    {activeTab === 'overview' && <Overview stats={stats} />}
+                    {activeTab === 'overview' && <Overview stats={stats} range={growthRange} onRangeChange={setGrowthRange} />}
                     {activeTab === 'students' && <StudentManagement />}
                     {activeTab === 'enrollments' && <EnrollmentRequests />}
                     {activeTab === 'sales' && <SalesDashboard />}

--- a/frontend/exam-frontend/src/services/analyticsService.js
+++ b/frontend/exam-frontend/src/services/analyticsService.js
@@ -109,8 +109,10 @@ export const analyticsService = {
   },
 
   // Tenant Admin Stats
-  getTenantAdminStats: async () => {
-    const response = await api.get('/analytics/tenant-admin-stats/')
+  getTenantAdminStats: async (days = 30) => {
+    const response = await api.get('/analytics/tenant-admin-stats/', {
+      params: { days },
+    })
     return response.data
   },
 


### PR DESCRIPTION
## Summary
Adds growth numbers to the admin dashboard Overview so admins can track how the institution is growing over time.

### What's new
- **Growth section** on the Overview with **7 / 30 / 90 day** filter pills.
- **New Signups** card — new students in the window, with **% change** vs the prior period.
- **Active (period)** card — distinct active students in the window, with % change.
- **Total Students** card showing growth from the count at the start of the period.
- **↑/↓ % change badges** (green up / red down; a "New" badge when growing from a zero baseline).
- The activity trend chart now spans the **selected window** instead of a fixed 30 days, and its title updates accordingly.

### Implementation
**Backend** (`analytics/services.py`, `views.py`)
- `get_tenant_admin_stats(tenant, period_days=30)` returns a new `growth` object (new/prev signups, active/prev active, % changes, students-at-start). `period_days` is sanitized to 1–365.
- `TenantAdminStatsView` reads `?days=` from the query string.

**Frontend** (`AdminDashboard.jsx`, `analyticsService.js`)
- `getTenantAdminStats(days)` passes the range as a query param; the range is part of the React Query key with `keepPreviousData` for smooth switching.
- `StatCard` gained an optional `change` prop rendering a `TrendBadge`.

### Testing
- `vite build` passes.
- Backend files pass syntax checks.

_Note: the repo's `npm run lint` fails due to a pre-existing missing ESLint config, unrelated to this change._