### PR TITLE
Show certificate badge on course cards

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -232,6 +232,7 @@ class AvailableCoursesForEnrollmentView(APIView):
                 'is_free': e.is_free,
                 'discount_percent': e.discount_percent,
                 'subtitle': e.subtitle or '',
+                'certificate_enabled': bool(getattr(e, 'certificate_enabled', False)),
                 'enroll_mode': (
                     request.tenant.enroll_mode_for(e)
                     if getattr(request, 'tenant', None) else 'request'

--- a/frontend/exam-frontend/src/pages/Courses.jsx
+++ b/frontend/exam-frontend/src/pages/Courses.jsx
@@ -7,7 +7,7 @@ import { contentBuilderService } from '../services/contentBuilderService'
 import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
-import { GraduationCap, CheckCircle2, Clock, ArrowRight, Settings2, Search, X } from 'lucide-react'
+import { GraduationCap, CheckCircle2, Clock, ArrowRight, Settings2, Search, X, Award } from 'lucide-react'
 import { stripHtml } from '../utils/html'
 
 const InstructorLine = ({ instructors = [] }) => {
@@ -303,6 +303,15 @@ const Courses = () => {
                   <div className="mt-3">
                     <CoursePrice course={course} />
                   </div>
+
+                  {course.certificate_enabled && (
+                    <div className="mt-3">
+                      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-semibold bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 ring-1 ring-amber-200/80 dark:ring-amber-800/60">
+                        <Award size={13} className="text-amber-500" />
+                        Certificate on completion
+                      </span>
+                    </div>
+                  )}
 
                   <div className="mt-auto pt-4">
                     {status === 'approved' ? (


### PR DESCRIPTION
## What
Highlight on each course card whether a certificate is included.

- **Frontend** (`pages/Courses.jsx`): adds a "🏅 Certificate on completion" badge below the price, shown only when `course.certificate_enabled` is true. Reuses the amber/Award styling already used on the `CourseDetail` page.
- **Backend** (`exams/views.py`): the `AvailableCoursesForEnrollmentView` response now includes `certificate_enabled` (its manually-built dict previously omitted it).

## Why
Requested: surface certificate availability directly on the course catalog cards.

## Testing
- `npm run build` passes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>