### PR TITLE
Rename Content Builder to Course Builder in admin UI

### DIFF
--- a/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/ContentBuilder.jsx
@@ -1008,7 +1008,7 @@ const ContentBuilder = () => {
             {/* Header */}
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
                 <div>
-                    <h2 className="text-xl font-bold text-surface-900 dark:text-white">Content Builder</h2>
+                    <h2 className="text-xl font-bold text-surface-900 dark:text-white">Course Builder</h2>
                     <p className="text-sm text-surface-500">Create and manage courses, subjects, chapters, topics, content &amp; quizzes</p>
                 </div>
                 <div className="flex items-center gap-2">

--- a/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
@@ -24,7 +24,7 @@ export const ADMIN_NAV_ITEMS = [
   { tab: 'enrollments', label: 'Enrollments', icon: GraduationCap },
   { tab: 'sales', label: 'Sales & Orders', icon: ShoppingCart },
   { tab: 'performance', label: 'Reports', icon: BarChart3 },
-  { tab: 'content', label: 'Content Builder', icon: Library },
+  { tab: 'content', label: 'Course Builder', icon: Library },
   { path: '/admin/mock-tests', label: 'Mock Tests', icon: ClipboardList },
   { path: '/admin/jobs', label: 'Jobs', icon: Briefcase },
   { tab: 'settings', label: 'Settings', icon: SlidersHorizontal },

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -2667,7 +2667,7 @@ const TABS = [
     { id: 'enrollments', label: 'Enrollments', icon: GraduationCap },
     { id: 'sales', label: 'Sales & Orders', icon: ShoppingCart },
     { id: 'performance', label: 'Reports', icon: BarChart3 },
-    { id: 'content', label: 'Content Builder', icon: Library },
+    { id: 'content', label: 'Course Builder', icon: Library },
     { id: 'settings', label: 'Settings', icon: SlidersIcon },
 ]
 


### PR DESCRIPTION
## Summary
Renames the user-facing "Content Builder" label to "Course Builder" in the admin console.

## Changes
- **Sidebar** (`AdminSidebar.jsx`) — nav item label
- **Header** (`AdminDashboard.jsx` TABS) — page title
- **Component heading** (`ContentBuilder.jsx`) — inner `<h2>`

Internal identifiers (tab id `content`, service/file names) were left unchanged since they are not user-visible.