### PR TITLE
Render course thumbnails on the landing page carousel

### DIFF
--- a/backend/exams/serializers.py
+++ b/backend/exams/serializers.py
@@ -53,11 +53,23 @@ class CourseSerializer(serializers.ModelSerializer):
 
 
 class CourseListSerializer(serializers.ModelSerializer):
-    """Lightweight serializer for course listings."""
-    
+    """Lightweight serializer for course listings.
+
+    Includes the handful of display fields course cards need (thumbnail,
+    short description, type and pricing) so listings — including the public
+    landing page carousel — can render rich tiles without a detail fetch.
+    """
+    is_free = serializers.ReadOnlyField()
+    discount_percent = serializers.ReadOnlyField()
+
     class Meta:
         model = Course
-        fields = ['id', 'name', 'code', 'icon', 'color', 'status', 'is_featured']
+        fields = [
+            'id', 'name', 'code', 'icon', 'color', 'status', 'is_featured',
+            'thumbnail', 'subtitle', 'description', 'course_type',
+            'total_students', 'pricing_type', 'price', 'original_price',
+            'currency', 'is_free', 'discount_percent',
+        ]
 
 
 class TopicSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Problem
On the public landing page, the Courses carousel always showed the letter-on-gradient placeholder instead of real course thumbnails (and always displayed "Free").

## Cause
The public `GET /api/v1/courses/` list uses `CourseListSerializer`, which only returned `id, name, code, icon, color, status, is_featured` — so `thumbnail` (and pricing/description) never reached the frontend. `CourseThumbnail` therefore always fell back to the placeholder, and the price chip defaulted to "Free" because `price` was undefined.

## Fix
Add the display fields course cards need to `CourseListSerializer`:
- `thumbnail` (the fix — returns an absolute media URL)
- `subtitle`, `description`, `course_type`, `total_students`
- pricing: `pricing_type`, `price`, `original_price`, `currency`, `is_free`, `discount_percent`

Backward-compatible — only adds fields to the list payload. Courses without an uploaded thumbnail still render the styled placeholder (by design).

## Verification
- `django check` clean
- Public `/courses/` now returns `thumbnail` as an absolute URL (verified against a running server; courses without an image return `null` and keep the fallback), plus real `price`/`is_free`

Backend-only; goes live on backend deploy (no frontend change needed).