### PR TITLE
feat(marketing): show promo banner on tenant landing page with smart dismissal

### DIFF
--- a/backend/marketing/serializers.py
+++ b/backend/marketing/serializers.py
@@ -18,6 +18,7 @@ class PublicPromoBannerSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'title', 'message', 'cta_label', 'cta_url',
             'theme', 'bg_color', 'text_color', 'dismissible', 'coupon_code',
+            'updated_at',
         ]
 
     def get_coupon_code(self, obj):

--- a/frontend/exam-frontend/src/components/landing/LandingNavbar.jsx
+++ b/frontend/exam-frontend/src/components/landing/LandingNavbar.jsx
@@ -35,7 +35,8 @@ const LandingNavbar = ({ t, brand = {}, go, sections = [] }) => {
 
   return (
     <header
-      className={`fixed inset-x-0 top-0 z-50 transition-all ${scrolled ? `${t.navBg} shadow-sm` : 'bg-transparent'}`}
+      style={{ top: scrolled ? 0 : 'var(--promo-banner-height, 0px)' }}
+      className={`fixed inset-x-0 z-50 transition-all ${scrolled ? `${t.navBg} shadow-sm` : 'bg-transparent'}`}
     >
       <div className={`${t.container} flex h-16 items-center justify-between`}>
         <button onClick={() => onLink('#top')} className="flex items-center gap-2.5 min-w-0">

--- a/frontend/exam-frontend/src/components/layout/PromoBanner.jsx
+++ b/frontend/exam-frontend/src/components/layout/PromoBanner.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { X, Tag, ArrowRight } from 'lucide-react'
@@ -6,29 +6,74 @@ import { useTenantStore } from '../../context/tenantStore'
 import { bannerThemeStyle } from '../../config/bannerThemes'
 
 const DISMISS_KEY = 'dt_promo_banner_dismissed'
+// A dismissed banner reappears after this cooldown even if unchanged, so an
+// active promotion keeps surfacing without nagging on every page view.
+const REDISPLAY_AFTER_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+// A dismissal only sticks while the same banner *version* is live and within
+// the cooldown window. Editing/republishing the banner (new id or updated_at)
+// clears it immediately.
+const isDismissed = (banner) => {
+    try {
+        const raw = localStorage.getItem(DISMISS_KEY)
+        if (!raw) return false
+        const saved = JSON.parse(raw)
+        if (saved.id !== banner.id) return false
+        if (saved.updated_at !== banner.updated_at) return false
+        if (Date.now() - (saved.ts || 0) > REDISPLAY_AFTER_MS) return false
+        return true
+    } catch {
+        return false
+    }
+}
 
 /**
- * Sitewide promo banner shown at the very top of the app. Content comes from the
- * tenant config (`promo_banner`); a dismissible banner is remembered per id via
- * localStorage so it stays hidden until the admin publishes a different one.
+ * Sitewide promo banner shown at the very top of the app and the public landing
+ * page. Content comes from the tenant config (`promo_banner`). A dismissal is
+ * remembered per banner version for a 7-day cooldown, then the banner returns;
+ * it also returns immediately if the admin edits or republishes the banner.
  */
 const PromoBanner = () => {
     const banner = useTenantStore((s) => s.tenant?.promo_banner)
-    const [dismissed, setDismissed] = useState(() => {
-        if (!banner) return false
-        try {
-            return localStorage.getItem(DISMISS_KEY) === banner.id
-        } catch {
-            return false
-        }
-    })
+    const [dismissed, setDismissed] = useState(false)
+    const ref = useRef(null)
 
-    if (!banner || dismissed) return null
+    // Re-evaluate dismissal whenever the live banner (or its version) changes.
+    useEffect(() => {
+        setDismissed(banner ? isDismissed(banner) : false)
+    }, [banner?.id, banner?.updated_at])
+
+    const visible = Boolean(banner) && !dismissed
+
+    // Publish the banner height so a fixed header (e.g. the landing navbar) can
+    // sit right below it via `top: var(--promo-banner-height)`.
+    useLayoutEffect(() => {
+        const root = document.documentElement
+        const reset = () => root.style.setProperty('--promo-banner-height', '0px')
+        if (!visible || !ref.current) {
+            reset()
+            return reset
+        }
+        const update = () =>
+            root.style.setProperty('--promo-banner-height', `${ref.current.offsetHeight}px`)
+        update()
+        const ro = new ResizeObserver(update)
+        ro.observe(ref.current)
+        return () => {
+            ro.disconnect()
+            reset()
+        }
+    }, [visible, banner?.message, banner?.title])
+
+    if (!visible) return null
 
     const style = bannerThemeStyle(banner)
     const dismiss = () => {
         try {
-            localStorage.setItem(DISMISS_KEY, banner.id)
+            localStorage.setItem(
+                DISMISS_KEY,
+                JSON.stringify({ id: banner.id, updated_at: banner.updated_at, ts: Date.now() })
+            )
         } catch {
             /* ignore storage errors */
         }
@@ -51,6 +96,7 @@ const PromoBanner = () => {
     return (
         <AnimatePresence>
             <motion.div
+                ref={ref}
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: 'auto', opacity: 1 }}
                 exit={{ height: 0, opacity: 0 }}

--- a/frontend/exam-frontend/src/pages/LandingPage.jsx
+++ b/frontend/exam-frontend/src/pages/LandingPage.jsx
@@ -6,6 +6,7 @@ import { getTemplate } from '../components/landing/templateConfig'
 import LandingNavbar from '../components/landing/LandingNavbar'
 import LandingFooter from '../components/landing/LandingFooter'
 import SectionRenderer from '../components/landing/SectionRenderer'
+import PromoBanner from '../components/layout/PromoBanner'
 
 // Public, no-login landing page rendered at "/" for anonymous visitors. Fully
 // tenant-configurable: template, ordered sections and footer all come from the
@@ -64,6 +65,7 @@ const LandingPage = () => {
 
   return (
     <div id="top" className={`min-h-screen ${t.page}`}>
+      <PromoBanner />
       <LandingNavbar t={t} brand={data.brand || {}} go={go} sections={sections} />
       <main>
         {sections.map((section) => (


### PR DESCRIPTION
## Summary
Follow-up to #134. Extends the promo banner so it also appears on the **public tenant landing page (`/`)**, not just inside the authenticated app shell, and improves the dismissal re-show policy.

## Changes
- **Landing page (`/`) now renders `<PromoBanner />`** above the landing navbar, so anonymous visitors see active promotions.
- **No navbar overlap.** The banner publishes its height as a CSS variable `--promo-banner-height` (kept in sync via `ResizeObserver`). The fixed `LandingNavbar` offsets below the banner while at the top of the page, then snaps to `top: 0` once the in-flow banner scrolls away (tied to its existing `scrolled` state) — no gap.
- **Harmless in the app shell**, where `Header` is `sticky` and the banner is already in normal flow, so the CSS var is a no-op there.
- **Smarter dismissal.** Dismissal is stored in `localStorage` keyed by the banner's **id + `updated_at`** plus a timestamp. A dismissed banner reappears when:
  1. the admin **edits/republishes** it (`id` or `updated_at` changes),
  2. a **7-day cooldown** elapses, or
  3. a **different** banner goes live.
- **Backend:** `updated_at` exposed on `PublicPromoBannerSerializer` to support version-aware dismissal.

## Testing
- `npm run build` succeeds.
- Backend serializer change is read-only.