### PR TITLE
fix(courses): order curriculum subjects by their order field

### DIFF
--- a/backend/exams/serializers.py
+++ b/backend/exams/serializers.py
@@ -233,10 +233,14 @@ class CurriculumSubjectSerializer(SubjectSerializer):
 
 class CourseDetailSerializer(CourseSerializer):
     """Detailed course serializer with curriculum (subjects -> chapters)."""
-    subjects = CurriculumSubjectSerializer(many=True, read_only=True)
+    subjects = serializers.SerializerMethodField()
 
     class Meta(CourseSerializer.Meta):
         fields = CourseSerializer.Meta.fields + ['subjects']
+
+    def get_subjects(self, obj):
+        qs = obj.subjects.all().order_by('order', 'name')
+        return CurriculumSubjectSerializer(qs, many=True, context=self.context).data
 
 
 class SubjectWithChaptersSerializer(SubjectSerializer):


### PR DESCRIPTION
## Problem

In the course-detail **Curriculum** tab, subjects rendered in an arbitrary order — e.g. on the *Placement Oriented DSA Sheet* course, "Interview Prep & Revision" (the last subject) appeared **first**.

## Root cause

`Subject` extends `OrderedModel`, whose `Meta` declares `ordering = ['order', '-created_at']`. However, `Subject.Meta` redefines its own `Meta` (for `unique_together`/verbose names) **without** re-declaring `ordering`, so the inherited default sort is silently dropped. `CourseDetailSerializer` rendered `subjects` straight off the related manager, so the API returned them in arbitrary DB order.

Chapters and topics were unaffected because their serializer already sorts explicitly (`.order_by('order', 'name')`).

## Fix

`CourseDetailSerializer.subjects` is now a `SerializerMethodField` that sorts by `('order', 'name')`, mirroring the existing `get_chapters` pattern. This fixes subject ordering for **every** course, not just the DSA sheet.

- No migration required.
- No behavior change other than deterministic, intended ordering.

## Verification

Subject `order` values in the DB were already correct (Foundations=0 … Interview Prep=14); only the API response ordering was wrong. After this change the curriculum renders subjects in ascending `order`.