### PR TITLE
Add external-judge solving for coding problems (LeetCode et al.)

### DIFF
--- a/backend/coding/admin.py
+++ b/backend/coding/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import CodingProblem, TestCase, CodingSubmission
+from .models import CodingProblem, TestCase, CodingSubmission, CodingProblemCompletion
 
 
 class TestCaseInline(admin.TabularInline):
@@ -10,10 +10,18 @@ class TestCaseInline(admin.TabularInline):
 
 @admin.register(CodingProblem)
 class CodingProblemAdmin(admin.ModelAdmin):
-    list_display = ['title', 'course', 'topic', 'difficulty', 'status', 'max_marks']
-    list_filter = ['status', 'difficulty', 'course']
+    list_display = ['title', 'course', 'topic', 'difficulty', 'status', 'solve_mode', 'max_marks']
+    list_filter = ['status', 'difficulty', 'solve_mode', 'course']
     search_fields = ['title']
     inlines = [TestCaseInline]
+
+
+@admin.register(CodingProblemCompletion)
+class CodingProblemCompletionAdmin(admin.ModelAdmin):
+    list_display = ['problem', 'student', 'method', 'completed_at']
+    list_filter = ['method']
+    search_fields = ['problem__title']
+    readonly_fields = ['completed_at']
 
 
 @admin.register(CodingSubmission)

--- a/backend/coding/admin_serializers.py
+++ b/backend/coding/admin_serializers.py
@@ -27,10 +27,20 @@ class AdminCodingProblemSerializer(serializers.ModelSerializer):
             'id', 'course', 'subject', 'subject_name', 'topic', 'topic_name',
             'title', 'statement', 'difficulty', 'allowed_languages', 'starter_code',
             'time_limit_ms', 'memory_limit_mb', 'max_marks', 'status', 'order',
+            'solve_mode', 'external_url',
             'test_cases', 'submission_count', 'test_case_count',
             'created_at', 'updated_at',
         ]
         read_only_fields = ['created_at', 'updated_at']
+
+    def validate(self, attrs):
+        solve_mode = attrs.get('solve_mode', getattr(self.instance, 'solve_mode', 'in_app'))
+        external_url = attrs.get('external_url', getattr(self.instance, 'external_url', ''))
+        if solve_mode in ('external', 'both') and not (external_url or '').strip():
+            raise serializers.ValidationError({
+                'external_url': 'An external problem link is required when the solve mode is external or both.',
+            })
+        return attrs
 
     def get_submission_count(self, obj):
         return obj.submissions.count()

--- a/backend/coding/migrations/0002_solve_mode_external_completion.py
+++ b/backend/coding/migrations/0002_solve_mode_external_completion.py
@@ -1,0 +1,57 @@
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('coding', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='codingproblem',
+            name='solve_mode',
+            field=models.CharField(
+                choices=[
+                    ('in_app', 'Solve in app'),
+                    ('external', 'Solve on external platform'),
+                    ('both', 'Solve in app or external platform'),
+                ],
+                default='in_app',
+                max_length=10,
+            ),
+        ),
+        migrations.AddField(
+            model_name='codingproblem',
+            name='external_url',
+            field=models.URLField(blank=True, max_length=1000),
+        ),
+        migrations.CreateModel(
+            name='CodingProblemCompletion',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('method', models.CharField(choices=[('in_app', 'Solved in app'), ('external', 'Solved on external platform')], default='in_app', max_length=20)),
+                ('completed_at', models.DateTimeField(auto_now=True)),
+                ('problem', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='completions', to='coding.codingproblem')),
+                ('student', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='coding_completions', to='users.studentprofile')),
+                ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='coding_completions', to='core.tenant')),
+            ],
+            options={
+                'verbose_name': 'Coding Problem Completion',
+                'verbose_name_plural': 'Coding Problem Completions',
+            },
+        ),
+        migrations.AddIndex(
+            model_name='codingproblemcompletion',
+            index=models.Index(fields=['problem', 'student'], name='coding_completion_ps_idx'),
+        ),
+        migrations.AddConstraint(
+            model_name='codingproblemcompletion',
+            constraint=models.UniqueConstraint(fields=('problem', 'student'), name='uniq_problem_student_completion'),
+        ),
+    ]

--- a/backend/coding/models.py
+++ b/backend/coding/models.py
@@ -25,6 +25,15 @@ class CodingProblem(OrderedModel):
         ('medium', 'Medium'),
         ('hard', 'Hard'),
     ]
+    # Where a student is expected to solve this problem.
+    #   in_app   -> solved by passing all in-app test cases (default, legacy behaviour)
+    #   external -> solved only on an external judge (e.g. LeetCode); self-reported
+    #   both     -> either an in-app all-pass OR an external self-report completes it
+    SOLVE_MODE_CHOICES = [
+        ('in_app', 'Solve in app'),
+        ('external', 'Solve on external platform'),
+        ('both', 'Solve in app or external platform'),
+    ]
 
     tenant = models.ForeignKey(
         'core.Tenant', on_delete=models.CASCADE, related_name='coding_problems',
@@ -53,6 +62,12 @@ class CodingProblem(OrderedModel):
     max_marks = models.PositiveIntegerField(null=True, blank=True)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='draft')
 
+    # External-judge support (e.g. LeetCode / GeeksforGeeks / HackerRank).
+    solve_mode = models.CharField(max_length=10, choices=SOLVE_MODE_CHOICES, default='in_app')
+    # Optional link to the same problem on an external platform. Required when
+    # solve_mode is 'external' or 'both' (enforced in the authoring serializer).
+    external_url = models.URLField(max_length=1000, blank=True)
+
     class Meta:
         verbose_name = 'Coding Problem'
         verbose_name_plural = 'Coding Problems'
@@ -68,6 +83,14 @@ class CodingProblem(OrderedModel):
     def normalized_languages(self):
         langs = [l for l in (self.allowed_languages or []) if l in LANGUAGE_KEYS]
         return langs or list(LANGUAGE_KEYS)
+
+    @property
+    def allows_in_app(self):
+        return self.solve_mode in ('in_app', 'both')
+
+    @property
+    def allows_external(self):
+        return self.solve_mode in ('external', 'both') and bool(self.external_url)
 
 
 class TestCase(OrderedModel):
@@ -132,3 +155,43 @@ class CodingSubmission(OrderedModel):
     @property
     def all_passed(self):
         return self.total_count > 0 and self.passed_count == self.total_count
+
+
+class CodingProblemCompletion(TimeStampedModel):
+    """A definitive per-student completion record for a coding problem.
+
+    Written when a student either passes all in-app test cases (method="in_app")
+    or self-reports solving the problem on an external judge (method="external").
+    Exactly one row per (problem, student); the `method` reflects how it was most
+    recently completed. External completions are reversible (the student can
+    unmark), which deletes the row.
+    """
+    METHOD_CHOICES = [
+        ('in_app', 'Solved in app'),
+        ('external', 'Solved on external platform'),
+    ]
+
+    tenant = models.ForeignKey(
+        'core.Tenant', on_delete=models.CASCADE, related_name='coding_completions',
+    )
+    problem = models.ForeignKey(
+        CodingProblem, on_delete=models.CASCADE, related_name='completions',
+    )
+    student = models.ForeignKey(
+        'users.StudentProfile', on_delete=models.CASCADE, related_name='coding_completions',
+    )
+    method = models.CharField(max_length=20, choices=METHOD_CHOICES, default='in_app')
+    completed_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = 'Coding Problem Completion'
+        verbose_name_plural = 'Coding Problem Completions'
+        constraints = [
+            models.UniqueConstraint(fields=['problem', 'student'], name='uniq_problem_student_completion'),
+        ]
+        indexes = [
+            models.Index(fields=['problem', 'student'], name='coding_completion_ps_idx'),
+        ]
+
+    def __str__(self):
+        return f'{self.student_id} solved {self.problem_id} ({self.method})'

--- a/backend/coding/serializers.py
+++ b/backend/coding/serializers.py
@@ -1,7 +1,7 @@
 """Student-facing serializers for coding problems."""
 from rest_framework import serializers
 
-from .models import CodingProblem, TestCase, CodingSubmission
+from .models import CodingProblem, TestCase, CodingSubmission, CodingProblemCompletion
 from .languages import LANGUAGES
 
 
@@ -9,6 +9,32 @@ class SampleTestCaseSerializer(serializers.ModelSerializer):
     class Meta:
         model = TestCase
         fields = ['id', 'stdin', 'expected_output', 'explanation', 'points']
+
+
+class MyCompletionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CodingProblemCompletion
+        fields = ['method', 'completed_at']
+
+
+class SolvedStatusMixin:
+    """Shared helpers for exposing a unified solved status on a problem.
+
+    A problem counts as solved if the student has an explicit completion row
+    (in-app all-pass or external self-report) OR a best submission that passed
+    every test case (covers historical solves made before completions existed).
+    """
+
+    def get_my_completion(self, obj):
+        completion = getattr(obj, '_my_completion', None)
+        return MyCompletionSerializer(completion).data if completion else None
+
+    def get_is_solved(self, obj):
+        completion = getattr(obj, '_my_completion', None)
+        if completion:
+            return True
+        best = getattr(obj, '_my_best', None)
+        return bool(best and best.all_passed)
 
 
 class MySubmissionSummarySerializer(serializers.ModelSerializer):
@@ -22,16 +48,19 @@ class MySubmissionSummarySerializer(serializers.ModelSerializer):
         ]
 
 
-class CodingProblemListSerializer(serializers.ModelSerializer):
+class CodingProblemListSerializer(SolvedStatusMixin, serializers.ModelSerializer):
     """Compact list view; includes the student's best-so-far status."""
     my_best = serializers.SerializerMethodField()
+    my_completion = serializers.SerializerMethodField()
+    is_solved = serializers.SerializerMethodField()
     topic_name = serializers.CharField(source='topic.name', read_only=True)
 
     class Meta:
         model = CodingProblem
         fields = [
             'id', 'title', 'difficulty', 'max_marks', 'status', 'order',
-            'topic', 'topic_name', 'my_best',
+            'topic', 'topic_name', 'solve_mode', 'external_url',
+            'my_best', 'my_completion', 'is_solved',
         ]
 
     def get_my_best(self, obj):
@@ -39,12 +68,14 @@ class CodingProblemListSerializer(serializers.ModelSerializer):
         return MySubmissionSummarySerializer(best).data if best else None
 
 
-class CodingProblemDetailSerializer(serializers.ModelSerializer):
+class CodingProblemDetailSerializer(SolvedStatusMixin, serializers.ModelSerializer):
     """Full problem for the solve page. Only SAMPLE test cases are exposed."""
     sample_cases = serializers.SerializerMethodField()
     languages = serializers.SerializerMethodField()
     starter_code = serializers.SerializerMethodField()
     my_best = serializers.SerializerMethodField()
+    my_completion = serializers.SerializerMethodField()
+    is_solved = serializers.SerializerMethodField()
     topic_name = serializers.CharField(source='topic.name', read_only=True)
 
     class Meta:
@@ -52,7 +83,9 @@ class CodingProblemDetailSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'title', 'statement', 'difficulty', 'max_marks', 'status',
             'topic', 'topic_name', 'time_limit_ms', 'memory_limit_mb',
-            'languages', 'starter_code', 'sample_cases', 'my_best',
+            'solve_mode', 'external_url',
+            'languages', 'starter_code', 'sample_cases',
+            'my_best', 'my_completion', 'is_solved',
         ]
 
     def get_sample_cases(self, obj):

--- a/backend/coding/views.py
+++ b/backend/coding/views.py
@@ -9,7 +9,7 @@ from rest_framework.throttling import ScopedRateThrottle
 
 from users.models import CourseEnrollment
 
-from .models import CodingProblem, CodingSubmission
+from .models import CodingProblem, CodingSubmission, CodingProblemCompletion
 from .serializers import (
     CodingProblemListSerializer,
     CodingProblemDetailSerializer,
@@ -56,7 +56,7 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
         return qs.order_by('order', '-created_at')
 
     def _attach_best(self, problems):
-        """Attach each student's best submission (most tests passed, then latest)."""
+        """Attach each student's best submission + explicit completion record."""
         student = self._student()
         if not student:
             return
@@ -67,8 +67,13 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
         for s in subs:
             if s.problem_id not in best:
                 best[s.problem_id] = s
+        completions = {
+            c.problem_id: c
+            for c in CodingProblemCompletion.objects.filter(student=student, problem__in=problems)
+        }
         for p in problems:
             p._my_best = best.get(p.id)
+            p._my_completion = completions.get(p.id)
 
     def list(self, request, *args, **kwargs):
         problems = list(self.get_queryset())
@@ -174,29 +179,75 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
             marks=marks,
         )
 
-        # Award XP the first time the student fully solves this problem.
+        # Record a definitive completion + award XP the first time the student
+        # fully solves this problem in-app.
         xp_awarded = 0
         if submission.total_count > 0 and submission.passed_count == submission.total_count:
-            from gamification.models import XPTransaction
-            from gamification.services import GamificationService
-            from core.utils import calculate_xp_for_coding
-
-            already_awarded = XPTransaction.objects.filter(
-                student=student, transaction_type='coding_solved', reference_id=problem.id,
-            ).exists()
-            if not already_awarded:
-                xp_awarded = calculate_xp_for_coding(problem.difficulty)
-                GamificationService.award_xp(
-                    student,
-                    xp_awarded,
-                    'coding_solved',
-                    f'Solved coding problem: {problem.title}',
-                    str(problem.id),
-                )
+            CodingProblemCompletion.objects.update_or_create(
+                problem=problem, student=student,
+                defaults={'tenant': problem.tenant, 'method': 'in_app'},
+            )
+            xp_awarded = self._award_solve_xp(student, problem)
 
         data = SubmissionResultSerializer(submission).data
         data['xp_awarded'] = xp_awarded
         return Response(data, status=status.HTTP_201_CREATED)
+
+    def _award_solve_xp(self, student, problem):
+        """Award coding-solved XP once per problem (idempotent). Returns XP given."""
+        from gamification.models import XPTransaction
+        from gamification.services import GamificationService
+        from core.utils import calculate_xp_for_coding
+
+        already_awarded = XPTransaction.objects.filter(
+            student=student, transaction_type='coding_solved', reference_id=problem.id,
+        ).exists()
+        if already_awarded:
+            return 0
+        xp_awarded = calculate_xp_for_coding(problem.difficulty)
+        GamificationService.award_xp(
+            student,
+            xp_awarded,
+            'coding_solved',
+            f'Solved coding problem: {problem.title}',
+            str(problem.id),
+        )
+        return xp_awarded
+
+    @action(detail=True, methods=['post'], url_path='toggle-external-solved')
+    def toggle_external_solved(self, request, pk=None):
+        """Self-report (or un-report) solving this problem on an external judge.
+
+        Honour-based: only allowed when the problem is configured with an external
+        link (solve_mode 'external' or 'both'). Toggling on creates a completion
+        record (method='external') and awards solve XP once; toggling off removes
+        the external completion (in-app completions are never removed here).
+        """
+        problem = self.get_object()
+        student = self._student()
+        if not student:
+            return Response({'error': 'Student profile required.'}, status=400)
+        if not problem.allows_external:
+            return Response(
+                {'error': 'This problem is not set up for external solving.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        existing = CodingProblemCompletion.objects.filter(problem=problem, student=student).first()
+        if existing:
+            # Only external self-reports are reversible; an in-app solve stays.
+            if existing.method == 'external':
+                existing.delete()
+                return Response({'is_solved': False, 'method': None, 'xp_awarded': 0})
+            return Response({
+                'is_solved': True, 'method': existing.method, 'xp_awarded': 0,
+            })
+
+        CodingProblemCompletion.objects.create(
+            tenant=problem.tenant, problem=problem, student=student, method='external',
+        )
+        xp_awarded = self._award_solve_xp(student, problem)
+        return Response({'is_solved': True, 'method': 'external', 'xp_awarded': xp_awarded})
 
     @action(detail=True, methods=['get'], url_path='my-submissions')
     def my_submissions(self, request, pk=None):

--- a/frontend/exam-frontend/src/pages/CodingProblem.jsx
+++ b/frontend/exam-frontend/src/pages/CodingProblem.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useMemo, lazy, Suspense } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import toast from 'react-hot-toast'
 import {
   ArrowLeft, Play, Send, Loader2, Code2, CheckCircle2, XCircle,
-  Clock, AlertTriangle, Trophy, Terminal,
+  Clock, AlertTriangle, Trophy, Terminal, ExternalLink, Circle,
 } from 'lucide-react'
 import { codingService } from '../services/codingService'
 import Loading from '../components/common/Loading'
@@ -16,6 +16,24 @@ const DIFF_TINT = {
   easy: 'bg-emerald-50 text-emerald-600 dark:bg-emerald-900/20',
   medium: 'bg-amber-50 text-amber-600 dark:bg-amber-900/20',
   hard: 'bg-red-50 text-red-600 dark:bg-red-900/20',
+}
+
+// Friendly platform label from an external problem URL (e.g. leetcode.com -> LeetCode).
+const PLATFORM_LABELS = [
+  [/leetcode\.com/i, 'LeetCode'],
+  [/geeksforgeeks\.org/i, 'GeeksforGeeks'],
+  [/hackerrank\.com/i, 'HackerRank'],
+  [/hackerearth\.com/i, 'HackerEarth'],
+  [/codeforces\.com/i, 'Codeforces'],
+  [/codechef\.com/i, 'CodeChef'],
+  [/spoj\.com/i, 'SPOJ'],
+  [/atcoder\.jp/i, 'AtCoder'],
+  [/interviewbit\.com/i, 'InterviewBit'],
+]
+const platformName = (url) => {
+  if (!url) return 'the external platform'
+  const hit = PLATFORM_LABELS.find(([re]) => re.test(url))
+  return hit ? hit[1] : 'the external platform'
 }
 
 const VERDICT = {
@@ -48,6 +66,7 @@ const VerdictPill = ({ verdict }) => {
 const CodingProblem = () => {
   const { problemId } = useParams()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const { data: problem, isLoading } = useQuery({
     queryKey: ['codingProblem', problemId],
@@ -87,11 +106,25 @@ const CodingProblem = () => {
       setRunResult(null)
       if (data.all_passed) {
         toast.success(data.xp_awarded > 0 ? `All test cases passed! +${data.xp_awarded} XP 🎉` : 'All test cases passed! 🎉')
+        queryClient.invalidateQueries({ queryKey: ['codingProblem', problemId] })
       } else {
         toast(`${data.passed_count}/${data.total_count} test cases passed`)
       }
     },
     onError: (err) => toast.error(err?.response?.data?.error || 'Submission failed. Try again.'),
+  })
+
+  const toggleExternalMutation = useMutation({
+    mutationFn: () => codingService.toggleExternalSolved(problemId),
+    onSuccess: (data) => {
+      if (data.is_solved) {
+        toast.success(data.xp_awarded > 0 ? `Marked as solved! +${data.xp_awarded} XP 🎉` : 'Marked as solved 🎉')
+      } else {
+        toast('Marked as not solved')
+      }
+      queryClient.invalidateQueries({ queryKey: ['codingProblem', problemId] })
+    },
+    onError: (err) => toast.error(err?.response?.data?.error || 'Could not update. Try again.'),
   })
 
   if (isLoading) return <Loading fullScreen />
@@ -109,6 +142,12 @@ const CodingProblem = () => {
   const best = problem.my_best
   const busy = runMutation.isPending || submitMutation.isPending
 
+  const solveMode = problem.solve_mode || 'in_app'
+  const canExternal = (solveMode === 'external' || solveMode === 'both') && !!problem.external_url
+  const showEditor = solveMode === 'in_app' || solveMode === 'both'
+  const isSolved = !!problem.is_solved
+  const completion = problem.my_completion
+
   return (
     <div className="space-y-4">
       {/* Header */}
@@ -125,7 +164,12 @@ const CodingProblem = () => {
             {problem.difficulty && <span className={`px-2 py-0.5 rounded capitalize ${DIFF_TINT[problem.difficulty] || 'bg-surface-100 dark:bg-surface-800'}`}>{problem.difficulty}</span>}
             {problem.max_marks != null && <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800">{problem.max_marks} marks</span>}
             <span className="px-2 py-0.5 rounded bg-surface-100 dark:bg-surface-800 inline-flex items-center gap-1"><Clock className="w-3 h-3" /> {problem.time_limit_ms}ms</span>
-            {best && (
+            {isSolved && (
+              <span className="px-2 py-0.5 rounded bg-success-50 dark:bg-success-900/20 text-success-600 inline-flex items-center gap-1">
+                <CheckCircle2 className="w-3 h-3" /> Solved{completion?.method === 'external' ? ' (external)' : ''}
+              </span>
+            )}
+            {!isSolved && best && (
               <span className="px-2 py-0.5 rounded bg-success-50 dark:bg-success-900/20 text-success-600 inline-flex items-center gap-1">
                 <Trophy className="w-3 h-3" /> Best {best.passed_count}/{best.total_count}
               </span>
@@ -134,7 +178,17 @@ const CodingProblem = () => {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+      {canExternal && (
+        <ExternalSolveCard
+          url={problem.external_url}
+          isSolved={isSolved}
+          completion={completion}
+          onToggle={() => toggleExternalMutation.mutate()}
+          toggling={toggleExternalMutation.isPending}
+        />
+      )}
+
+      <div className={`grid grid-cols-1 gap-4 items-start ${showEditor ? 'lg:grid-cols-2' : ''}`}>
         {/* Left: statement + samples */}
         <div className="space-y-4">
           <div className="card p-5">
@@ -160,6 +214,7 @@ const CodingProblem = () => {
         </div>
 
         {/* Right: editor + actions + results */}
+        {showEditor && (
         <div className="space-y-3">
           <div className="flex items-center justify-between gap-2 flex-wrap">
             <div className="flex items-center gap-2">
@@ -196,6 +251,46 @@ const CodingProblem = () => {
           {/* Submit results */}
           {submitResult && (
             <SubmitResultPanel result={submitResult} maxMarks={problem.max_marks} />
+          )}
+        </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const ExternalSolveCard = ({ url, isSolved, completion, onToggle, toggling }) => {
+  const name = platformName(url)
+  const solvedExternally = isSolved && completion?.method === 'external'
+  const solvedInApp = isSolved && completion?.method === 'in_app'
+  return (
+    <div className="card p-4 sm:p-5 border border-primary-100 dark:border-primary-900/40 bg-primary-50/40 dark:bg-primary-900/10">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="text-sm font-bold flex items-center gap-1.5">
+            <ExternalLink className="w-4 h-4 text-primary-500" /> Solve on {name}
+          </h3>
+          <p className="text-xs text-surface-500 mt-1">
+            {solvedInApp
+              ? 'You already solved this in the app. Nice work!'
+              : `Open the problem on ${name}, solve it there, then mark it as solved here.`}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <a href={url} target="_blank" rel="noopener noreferrer" className="btn-secondary text-sm px-3 py-1.5 inline-flex items-center gap-1.5">
+            <ExternalLink className="w-4 h-4" /> Open on {name}
+          </a>
+          {!solvedInApp && (
+            <button
+              onClick={onToggle}
+              disabled={toggling}
+              className={`text-sm px-3 py-1.5 inline-flex items-center gap-1.5 disabled:opacity-50 ${solvedExternally ? 'btn-outline' : 'btn-primary'}`}
+            >
+              {toggling
+                ? <Loader2 className="w-4 h-4 animate-spin" />
+                : solvedExternally ? <Circle className="w-4 h-4" /> : <CheckCircle2 className="w-4 h-4" />}
+              {solvedExternally ? 'Mark as not solved' : 'Mark as solved'}
+            </button>
           )}
         </div>
       </div>

--- a/frontend/exam-frontend/src/pages/CourseManager.jsx
+++ b/frontend/exam-frontend/src/pages/CourseManager.jsx
@@ -514,6 +514,8 @@ const CodingProblemModal = ({ instance, onClose, onSubmit, saving }) => {
         max_marks: instance?.max_marks ?? '',
         time_limit_ms: instance?.time_limit_ms ?? 3000,
         memory_limit_mb: instance?.memory_limit_mb ?? 256,
+        solve_mode: instance?.solve_mode || 'in_app',
+        external_url: instance?.external_url || '',
         allowed_languages: instance?.allowed_languages?.length ? instance.allowed_languages : ['python'],
         starter_code: instance?.starter_code || {},
         test_cases: instance?.test_cases?.length ? instance.test_cases.map((c) => ({ ...c })) : [{ ...blankCase(), is_sample: true }],
@@ -532,8 +534,11 @@ const CodingProblemModal = ({ instance, onClose, onSubmit, saving }) => {
     const submit = (e) => {
         e.preventDefault()
         if (!form.title.trim()) return toast.error('Title is required')
-        if (!form.allowed_languages.length) return toast.error('Pick at least one language')
-        if (!form.test_cases.length) return toast.error('Add at least one test case')
+        const needsExternal = form.solve_mode === 'external' || form.solve_mode === 'both'
+        if (needsExternal && !form.external_url.trim()) return toast.error('Add the external problem link (required for external/both)')
+        const inAppRequired = form.solve_mode === 'in_app' || form.solve_mode === 'both'
+        if (inAppRequired && !form.allowed_languages.length) return toast.error('Pick at least one language')
+        if (inAppRequired && !form.test_cases.length) return toast.error('Add at least one test case')
         onSubmit({
             title: form.title.trim(),
             statement: form.statement,
@@ -542,6 +547,8 @@ const CodingProblemModal = ({ instance, onClose, onSubmit, saving }) => {
             max_marks: form.max_marks === '' ? null : Number(form.max_marks),
             time_limit_ms: Number(form.time_limit_ms) || 3000,
             memory_limit_mb: Number(form.memory_limit_mb) || 256,
+            solve_mode: form.solve_mode,
+            external_url: form.external_url.trim(),
             allowed_languages: form.allowed_languages,
             starter_code: Object.fromEntries(form.allowed_languages.map((k) => [k, form.starter_code[k] || ''])),
             test_cases: form.test_cases.map((c, i) => ({
@@ -577,6 +584,24 @@ const CodingProblemModal = ({ instance, onClose, onSubmit, saving }) => {
                         <textarea rows={6} className="input resize-y" value={form.statement} onChange={(e) => set('statement', e.target.value)} placeholder="Describe the problem, input format, output format, constraints…" />
                     </div>
 
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                        <div>
+                            <label className="block text-xs font-semibold text-surface-500 mb-1">Where to solve</label>
+                            <select className="input" value={form.solve_mode} onChange={(e) => set('solve_mode', e.target.value)}>
+                                <option value="in_app">In app only</option>
+                                <option value="external">External platform only</option>
+                                <option value="both">Both (in app or external)</option>
+                            </select>
+                        </div>
+                        {(form.solve_mode === 'external' || form.solve_mode === 'both') && (
+                            <div className="sm:col-span-2">
+                                <label className="block text-xs font-semibold text-surface-500 mb-1">External problem link</label>
+                                <input type="url" className="input" value={form.external_url} onChange={(e) => set('external_url', e.target.value)} placeholder="https://leetcode.com/problems/two-sum/" />
+                                <p className="text-[11px] text-surface-400 mt-1">Works with LeetCode, GeeksforGeeks, HackerRank, etc. Students get a link + a self-report “Mark as solved” button.</p>
+                            </div>
+                        )}
+                    </div>
+
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                         <div>
                             <label className="block text-xs font-semibold text-surface-500 mb-1">Difficulty</label>
@@ -600,6 +625,8 @@ const CodingProblemModal = ({ instance, onClose, onSubmit, saving }) => {
                         </div>
                     </div>
 
+                    {form.solve_mode !== 'external' && (
+                      <>
                     <div>
                         <label className="block text-xs font-semibold text-surface-500 mb-1.5">Allowed languages</label>
                         <div className="flex flex-wrap gap-2">
@@ -657,6 +684,8 @@ const CodingProblemModal = ({ instance, onClose, onSubmit, saving }) => {
                             </div>
                         ))}
                     </div>
+                      </>
+                    )}
 
                     <div className="flex justify-end gap-2 pt-2">
                         <button type="button" onClick={onClose} className="btn-secondary">Cancel</button>

--- a/frontend/exam-frontend/src/services/codingService.js
+++ b/frontend/exam-frontend/src/services/codingService.js
@@ -20,6 +20,8 @@ export const codingService = {
     (await api.post(`/coding/problems/${id}/submit/`, { language, source_code })).data,
   mySubmissions: async (id) =>
     (await api.get(`/coding/problems/${id}/my-submissions/`)).data,
+  toggleExternalSolved: async (id) =>
+    (await api.post(`/coding/problems/${id}/toggle-external-solved/`)).data,
   meta: async () => (await api.get('/coding/meta/')).data,
 }
 


### PR DESCRIPTION
## What & why

Coding problems can now be solved **in-app**, on an **external judge** (LeetCode, GeeksforGeeks, HackerRank, Codeforces, …), or **both**. This lets us curate a DSA sheet that links out to existing judges while still tracking completion inside DailyTaiyari.

Confirmed design decisions:
- Explicit `solve_mode` field (`in_app` / `external` / `both`).
- Generic external link (platform name auto-detected from URL in the UI).
- For `both`, **either** an in-app all-pass **or** an external self-report completes it.
- External mark is honour-based and a **reversible toggle**.
- We record **how** it was completed (in-app vs external) for later analytics/badges.

## Backend
- `CodingProblem.solve_mode` + `external_url` (migration `0002`).
- New `CodingProblemCompletion` model — one row per (problem, student), stores `method` (`in_app`|`external`) as the definitive solved record.
- `submit` upserts an `in_app` completion on all-pass; new `POST /coding/problems/{id}/toggle-external-solved/` creates/removes an `external` completion.
- `coding_solved` XP is awarded **once** per problem (idempotent) and never removed on unmark.
- Unified `is_solved` / `my_completion` on student serializers; admin serializer requires `external_url` when mode is external/both.
- Registered `CodingProblemCompletion` in Django admin.

## Frontend
- Solve page: external-solve card (open link + mark/unmark solved); in-app editor hidden for external-only problems.
- Authoring form: "Where to solve" selector + external link input; language/starter/test-case sections hidden for external-only problems.

## Validation
- Backend: `py_compile` on all changed modules.
- Frontend: `vite build` passes.
- Migration `0002` uses explicit, deterministic index/constraint names.

Requires a backend deploy (migration) after merge; frontend deploys via Netlify.