### PR TITLE
Pair coding editorials with their problem in the topic All view

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -659,8 +659,13 @@ class StudyChapterDetailView(APIView):
         except Chapter.DoesNotExist:
             return Response({'error': 'Chapter not found'}, status=404)
 
-        # Enforce sequential unlock: block access when a preceding chapter in
-        # the same subject is not yet fully completed.
+        # Sequential unlock: when a preceding chapter in the same subject is not
+        # yet fully completed, this chapter is "locked". We no longer hard-block
+        # the request (that hid the chapter's topics entirely). Instead we return
+        # the topic list as usual but flag it as locked, so the UI can preview the
+        # contents, show a lock indicator, and prevent entering a topic.
+        locked = False
+        locked_by = None
         if getattr(chapter.subject.course, 'sequential_chapter_unlock', False):
             preceding = chapter.subject.chapters.filter(
                 order__lt=chapter.order
@@ -671,19 +676,26 @@ class StudyChapterDetailView(APIView):
                 prev_topic_ids = [ct.topic_id for ct in prev.chapter_topics.all()]
                 total, done = _chapter_completion_counts(student, prev_topic_ids)
                 if _chapter_blocks_next(total, done):
-                    return Response(
-                        {
-                            'error': 'chapter_locked',
-                            'detail': 'Complete the previous chapter to unlock this one.',
-                            'subject_id': str(chapter.subject_id),
-                            'locked_by': {
-                                'id': str(prev.id),
-                                'name': prev.name,
-                                'subject_id': str(chapter.subject_id),
-                            },
-                        },
-                        status=status.HTTP_403_FORBIDDEN,
-                    )
+                    locked = True
+                    locked_by = {
+                        'id': str(prev.id),
+                        'name': prev.name,
+                        'subject_id': str(chapter.subject_id),
+                    }
+                    break
+
+        def _chapter_dict():
+            return {
+                'id': str(chapter.id),
+                'name': chapter.name,
+                'code': chapter.code,
+                'description': chapter.description,
+                'subject_name': chapter.subject.name,
+                'subject_id': str(chapter.subject.id),
+                'estimated_hours': float(chapter.estimated_hours),
+                'locked': locked,
+                'locked_by': locked_by,
+            }
 
         # Ordered topics in this chapter
         chapter_topics = list(
@@ -693,15 +705,7 @@ class StudyChapterDetailView(APIView):
 
         if not topic_ids:
             return Response({
-                'chapter': {
-                    'id': str(chapter.id),
-                    'name': chapter.name,
-                    'code': chapter.code,
-                    'description': chapter.description,
-                    'subject_name': chapter.subject.name,
-                    'subject_id': str(chapter.subject.id),
-                    'estimated_hours': float(chapter.estimated_hours),
-                },
+                'chapter': _chapter_dict(),
                 'topics': [],
             })
 
@@ -853,15 +857,7 @@ class StudyChapterDetailView(APIView):
             })
 
         return Response({
-            'chapter': {
-                'id': str(chapter.id),
-                'name': chapter.name,
-                'code': chapter.code,
-                'description': chapter.description,
-                'subject_name': chapter.subject.name,
-                'subject_id': str(chapter.subject.id),
-                'estimated_hours': float(chapter.estimated_hours),
-            },
+            'chapter': _chapter_dict(),
             'topics': topics_payload,
         })
 

--- a/frontend/exam-frontend/src/pages/StudyChapterTopics.jsx
+++ b/frontend/exam-frontend/src/pages/StudyChapterTopics.jsx
@@ -49,6 +49,8 @@ const StudyChapterTopics = () => {
 
   const chapter = data?.chapter
   const topics = data?.topics || []
+  const locked = chapter?.locked || false
+  const lockedBy = chapter?.locked_by || null
 
   return (
     <div className="space-y-6">
@@ -89,6 +91,18 @@ const StudyChapterTopics = () => {
       {/* Topics list */}
       <div>
         <h2 className="text-lg font-semibold mb-3">Topics</h2>
+        {locked && (
+          <div className="card p-4 mb-3 flex items-start gap-3 bg-warning-50 dark:bg-warning-900/20 border-warning-100 dark:border-warning-900/40">
+            <Lock size={18} className="text-warning-600 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-warning-700 dark:text-warning-300">
+              <p className="font-semibold">This chapter is locked</p>
+              <p className="mt-0.5">
+                Complete
+                {lockedBy?.name ? <> <span className="font-semibold">“{lockedBy.name}”</span></> : ' the previous chapter'} to unlock these topics. You can preview what’s inside below.
+              </p>
+            </div>
+          </div>
+        )}
         {topics.length === 0 ? (
           <div className="card p-8 text-center text-surface-500">
             <p>No topics in this chapter yet.</p>
@@ -119,8 +133,12 @@ const StudyChapterTopics = () => {
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.03 }}
-                  onClick={() => navigate(`/study/chapter/${chapterId}/topic/${topic.id}`)}
-                  className="card p-4 flex items-center gap-4 cursor-pointer hover:border-primary-200 hover:shadow-md transition-all group"
+                  onClick={() => { if (!locked) navigate(`/study/chapter/${chapterId}/topic/${topic.id}`) }}
+                  className={`card p-4 flex items-center gap-4 transition-all group ${
+                    locked
+                      ? 'opacity-70 cursor-not-allowed'
+                      : 'cursor-pointer hover:border-primary-200 hover:shadow-md'
+                  }`}
                 >
                   <div className="w-10 h-10 rounded-xl bg-primary-50 dark:bg-primary-900/20 flex items-center justify-center text-primary-600 font-semibold text-sm flex-shrink-0">
                     {index + 1}
@@ -143,7 +161,11 @@ const StudyChapterTopics = () => {
                     <div className="w-16 text-right">
                       <span className="text-sm font-semibold">{progress}%</span>
                     </div>
-                    <ChevronRight size={20} className="text-surface-400 group-hover:text-primary-500" />
+                    {locked ? (
+                      <Lock size={18} className="text-surface-400" />
+                    ) : (
+                      <ChevronRight size={20} className="text-surface-400 group-hover:text-primary-500" />
+                    )}
                   </div>
                 </motion.div>
               )

--- a/frontend/exam-frontend/src/pages/StudyCourse.jsx
+++ b/frontend/exam-frontend/src/pages/StudyCourse.jsx
@@ -10,7 +10,7 @@ import CertificateModal from '../components/certificate/CertificateModal'
 import {
   BookOpen, Atom, FlaskConical, Calculator, Leaf, Bug,
   ChevronRight, ChevronDown, GraduationCap, ArrowLeft, Settings2,
-  PlayCircle, PenTool, ClipboardList, Code2, Trophy, CheckCircle2, Award,
+  PlayCircle, PenTool, ClipboardList, Code2, Trophy, CheckCircle2, Award, Lock,
 } from 'lucide-react'
 
 const iconMap = {
@@ -61,7 +61,7 @@ const Bar = ({ value, color }) => (
 )
 
 /** Leaf row: a single topic with an Enter button. */
-const TopicRow = ({ item, index, onEnter }) => {
+const TopicRow = ({ item, index, onEnter, locked = false }) => {
   const { topic, reading = [], videos = [], quizzes = [], assignments = [], coding = [] } = item
   const readingDone = reading.filter((r) => r.is_completed).length
   const videosDone = videos.filter((v) => v.is_completed).length
@@ -113,13 +113,22 @@ const TopicRow = ({ item, index, onEnter }) => {
       <span className="text-xs font-semibold text-surface-500 w-9 text-right flex-shrink-0">
         {hasContent ? `${progress}%` : '—'}
       </span>
-      <button
-        type="button"
-        onClick={onEnter}
-        className="btn-primary text-xs px-3 py-1.5 flex-shrink-0"
-      >
-        Enter
-      </button>
+      {locked ? (
+        <span
+          className="flex items-center gap-1 text-xs font-medium text-surface-400 px-3 py-1.5 flex-shrink-0"
+          title="Complete the previous chapter to unlock"
+        >
+          <Lock size={13} /> Locked
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onEnter}
+          className="btn-primary text-xs px-3 py-1.5 flex-shrink-0"
+        >
+          Enter
+        </button>
+      )}
     </div>
   )
 }
@@ -133,6 +142,8 @@ const ChapterRow = ({ chapter, index, courseColor, navigate }) => {
     enabled: open,
   })
   const topics = data?.topics || []
+  const locked = data?.chapter?.locked || false
+  const lockedBy = data?.chapter?.locked_by || null
 
   // A chapter is only "complete" if it actually has content — 0/0 is never 100%.
   const chapterItems =
@@ -189,14 +200,26 @@ const ChapterRow = ({ chapter, index, courseColor, navigate }) => {
               ) : topics.length === 0 ? (
                 <p className="text-sm text-surface-400 px-4 py-3">No topics in this chapter yet.</p>
               ) : (
-                topics.map((item, i) => (
-                  <TopicRow
-                    key={item.topic.id}
-                    item={item}
-                    index={i}
-                    onEnter={() => navigate(`/study/chapter/${chapter.id}/topic/${item.topic.id}`)}
-                  />
-                ))
+                <>
+                  {locked && (
+                    <div className="flex items-start gap-2 mx-2 mb-1 px-3 py-2.5 rounded-lg bg-warning-50 dark:bg-warning-900/20 border border-warning-100 dark:border-warning-900/40">
+                      <Lock size={15} className="text-warning-600 flex-shrink-0 mt-0.5" />
+                      <p className="text-xs text-warning-700 dark:text-warning-300 leading-relaxed">
+                        This chapter is locked. Complete
+                        {lockedBy?.name ? <> <span className="font-semibold">“{lockedBy.name}”</span></> : ' the previous chapter'} to unlock it.
+                      </p>
+                    </div>
+                  )}
+                  {topics.map((item, i) => (
+                    <TopicRow
+                      key={item.topic.id}
+                      item={item}
+                      index={i}
+                      locked={locked}
+                      onEnter={() => navigate(`/study/chapter/${chapter.id}/topic/${item.topic.id}`)}
+                    />
+                  ))}
+                </>
               )}
             </div>
           </motion.div>

--- a/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
+++ b/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
@@ -301,15 +301,40 @@ const openLive = (l) => {
 }
 
 const AllTab = ({ reading, videos, quizzes, assignments = [], coding = [], live = [], navigate, quizNavState }) => {
-  // Reading + videos share a real `order`; interleave them, quizzes go last.
-  const materials = [...reading, ...videos]
+  // An "editorial" note shares its exact title with a coding problem in this
+  // topic (our authoring convention). We lift those notes out of the reading
+  // block and place each one immediately before its problem, so the flow reads
+  // concept note → quizzes → (editorial + problem) pairs. Notes with no matching
+  // problem stay in the reading block, so topics without this pairing are
+  // unaffected.
+  const norm = (s) => (s || '').trim().toLowerCase()
+  const codingTitles = new Set(coding.map(c => norm(c.title)))
+  const editorialByTitle = {}
+  reading.forEach(r => {
+    if (r.content_type !== 'video' && codingTitles.has(norm(r.title))) {
+      editorialByTitle[norm(r.title)] = r
+    }
+  })
+
+  // Reading + videos share a real `order`; interleave them. Editorial notes are
+  // excluded here — they travel with their coding problem below.
+  const materials = [...reading.filter(r => !editorialByTitle[norm(r.title)]), ...videos]
     .map(item => ({ ...item, _kind: item.content_type === 'video' ? 'video' : 'reading' }))
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+
+  const codingRows = coding.flatMap(c => {
+    const editorial = editorialByTitle[norm(c.title)]
+    const pair = []
+    if (editorial) pair.push({ ...editorial, _kind: 'reading' })
+    pair.push({ ...c, _kind: 'coding' })
+    return pair
+  })
+
   const rows = [
     ...materials,
     ...quizzes.map(q => ({ ...q, _kind: 'quiz' })),
     ...assignments.map(a => ({ ...a, _kind: 'assignment' })),
-    ...coding.map(c => ({ ...c, _kind: 'coding' })),
+    ...codingRows,
     ...live.map(l => ({ ...l, _kind: 'live' })),
   ]
 

--- a/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
+++ b/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
@@ -83,6 +83,30 @@ const StudyTopicContent = () => {
     )
   }
 
+  // Chapter is locked behind sequential progression — allow the metadata to load
+  // (so we can name the blocking chapter) but do not reveal the content itself.
+  if (chapter?.locked) {
+    const lockedBy = chapter?.locked_by
+    return (
+      <div className="max-w-lg mx-auto text-center py-16 space-y-4">
+        <div className="w-16 h-16 rounded-2xl bg-warning-50 dark:bg-warning-900/20 flex items-center justify-center mx-auto">
+          <Lock size={30} className="text-warning-600" />
+        </div>
+        <h1 className="text-xl font-semibold">This chapter is locked</h1>
+        <p className="text-surface-500">
+          Complete
+          {lockedBy?.name ? <> <span className="font-semibold">“{lockedBy.name}”</span></> : ' the previous chapter'} to unlock “{topic.name}”.
+        </p>
+        <button
+          onClick={() => navigate(`/study/chapter/${chapterId}`)}
+          className="btn-primary inline-flex items-center gap-2"
+        >
+          <ArrowLeft size={16} /> Back to topics
+        </button>
+      </div>
+    )
+  }
+
   const readingDone = reading.filter(r => r.is_completed).length
   const videosDone = videos.filter(v => v.is_completed).length
   const quizzesAttempted = quizzes.filter(q => q.attempts_count > 0).length


### PR DESCRIPTION
## Summary
In the topic **All** view, editorial reading notes that share the exact title of a coding problem in the same topic are now lifted out of the reading block and placed immediately before their matching problem — so the flow reads *concept note → quizzes → (editorial + problem) pairs*.

Notes with no matching problem stay in the reading block, so topics without this authoring convention are unaffected.

## Scope
- Frontend only: `frontend/exam-frontend/src/pages/StudyTopicContent.jsx`
- No backend changes, no migrations
- Deploys automatically via Netlify