### PR TITLE
Raise Piston output cap to 64 KB for array-output problems

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -61,6 +61,11 @@ services:
     image: ghcr.io/engineer-man/piston
     privileged: true
     restart: unless-stopped
+    # Raise the program output cap from Piston's 1 KB default to 64 KB so
+    # array-returning problems (and students' correct solutions to them) can
+    # emit large outputs on big inputs without a spurious output_limit verdict.
+    environment:
+      - PISTON_OUTPUT_MAX_SIZE=65536
     volumes:
       - piston_data:/piston
     # No `ports:` on purpose — do NOT expose to host/internet.


### PR DESCRIPTION
## Problem

Piston runs student/reference code with a **1 KB program-output cap** (its built-in default, since we never set `PISTON_OUTPUT_MAX_SIZE`). Any coding problem whose answer is an **array** — e.g. *Move Zeroes*, *Remove Element*, *Remove Duplicates from Sorted Array* — emits more than 1 KB on large inputs (n ≈ 2000) and gets a spurious `output_limit` verdict.

This bites twice:
- **Authoring:** correct reference solutions (Python/C++/Java) fail their own large stress cases.
- **Students:** a learner's *correct* solution to any array-returning problem would be rejected on large inputs. Bad UX and looks like a judge bug.

Verified empirically on the VM: 1001-byte output passes, 2001-byte output → `OL`.

## Fix

Set `PISTON_OUTPUT_MAX_SIZE=65536` on the `piston` service so program output up to 64 KB is allowed. No change to timeouts, memory, or the isolation posture (still no published ports, still privileged for Isolate only).

## Deploy note

Requires recreating the `piston` container so the new env var takes effect (`docker compose up -d piston`), not just a `restart`.