### PR TITLE
Faster & more scalable code judge: threaded workers, opt-in parallel judging, async submissions

### DIFF
--- a/backend/coding/grading.py
+++ b/backend/coding/grading.py
@@ -1,0 +1,98 @@
+"""Shared grading logic for coding submissions.
+
+`finalize_submission` grades a *queued* CodingSubmission in place: it runs the
+source against all of the problem's test cases, scores it, persists the result,
+and — on the first full solve — records a completion and awards XP. It is used
+by both the synchronous submit path (settings.CODE_JUDGE_ASYNC=False) and the
+Celery task (async path), so scoring/XP semantics are identical either way.
+"""
+import logging
+from decimal import Decimal
+
+from . import services
+from .models import CodingProblemCompletion
+
+logger = logging.getLogger(__name__)
+
+
+def award_solve_xp(student, problem):
+    """Award coding-solved XP once per problem (idempotent). Returns XP given."""
+    from gamification.models import XPTransaction
+    from gamification.services import GamificationService
+    from core.utils import calculate_xp_for_coding
+
+    already_awarded = XPTransaction.objects.filter(
+        student=student, transaction_type='coding_solved', reference_id=problem.id,
+    ).exists()
+    if already_awarded:
+        return 0
+    xp_awarded = calculate_xp_for_coding(problem.difficulty)
+    GamificationService.award_xp(
+        student,
+        xp_awarded,
+        'coding_solved',
+        f'Solved coding problem: {problem.title}',
+        str(problem.id),
+    )
+    return xp_awarded
+
+
+def finalize_submission(submission):
+    """Grade `submission` in place against all test cases and persist the result.
+
+    Returns the XP awarded (0 unless this is the first full solve). On an engine
+    failure the submission is marked status='error' with a user-facing message
+    and services.EngineError is re-raised so the caller can decide how to surface
+    it (HTTP 503 for the sync path; logged-and-swallowed for the async task).
+    """
+    problem = submission.problem
+    student = submission.student
+
+    cases = list(problem.test_cases.all().order_by('order', 'created_at'))
+    if not cases:
+        submission.status = 'error'
+        submission.compile_output = 'This problem has no test cases yet.'
+        submission.save(update_fields=['status', 'compile_output'])
+        return 0
+
+    try:
+        outcome = services.run_against_cases(
+            language=submission.language,
+            source=submission.source_code,
+            cases=cases,
+            time_limit_ms=problem.time_limit_ms,
+            memory_limit_mb=problem.memory_limit_mb,
+            reveal_io=False,
+        )
+    except services.EngineError as exc:
+        submission.status = 'error'
+        submission.compile_output = str(exc)
+        submission.save(update_fields=['status', 'compile_output'])
+        raise
+
+    marks = None
+    if problem.max_marks and outcome['total_points'] > 0:
+        marks = (
+            Decimal(problem.max_marks) * outcome['passed_points'] / outcome['total_points']
+        ).quantize(Decimal('0.01'))
+    elif problem.max_marks:
+        marks = Decimal('0.00')
+
+    submission.status = 'error' if outcome['compile_error'] and outcome['passed_count'] == 0 else 'done'
+    submission.results = outcome['results']
+    submission.compile_output = outcome['compile_output']
+    submission.passed_count = outcome['passed_count']
+    submission.total_count = outcome['total_count']
+    submission.passed_points = outcome['passed_points']
+    submission.total_points = outcome['total_points']
+    submission.marks = marks
+    submission.save()
+
+    xp_awarded = 0
+    if submission.total_count > 0 and submission.passed_count == submission.total_count:
+        CodingProblemCompletion.objects.update_or_create(
+            problem=problem, student=student,
+            defaults={'tenant': problem.tenant, 'method': 'in_app'},
+        )
+        xp_awarded = award_solve_xp(student, problem)
+    return xp_awarded

--- a/backend/coding/migrations/0003_submission_queued_running_status.py
+++ b/backend/coding/migrations/0003_submission_queued_running_status.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('coding', '0002_solve_mode_external_completion'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='codingsubmission',
+            name='status',
+            field=models.CharField(
+                choices=[
+                    ('queued', 'Queued'),
+                    ('running', 'Running'),
+                    ('done', 'Evaluated'),
+                    ('error', 'Engine error'),
+                ],
+                default='done',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/backend/coding/models.py
+++ b/backend/coding/models.py
@@ -114,6 +114,8 @@ class TestCase(OrderedModel):
 
 class CodingSubmission(OrderedModel):
     STATUS_CHOICES = [
+        ('queued', 'Queued'),
+        ('running', 'Running'),
         ('done', 'Evaluated'),
         ('error', 'Engine error'),
     ]

--- a/backend/coding/services.py
+++ b/backend/coding/services.py
@@ -10,6 +10,7 @@ Security note: the engine sandboxes each run (network disabled, process/memory/
 output caps, timeouts). We additionally pass explicit per-run limits here.
 """
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from django.conf import settings
@@ -23,6 +24,8 @@ MAX_RUN_TIMEOUT_MS = 10_000
 MAX_MEMORY_MB = 512
 # Wall-clock timeout for the HTTP call to the engine (generous vs run_timeout).
 HTTP_TIMEOUT_S = 20
+# Default number of test cases to execute concurrently when settings is absent.
+DEFAULT_JUDGE_PARALLELISM = 4
 
 
 class EngineError(Exception):
@@ -128,9 +131,45 @@ def run_against_cases(*, language, source, cases, time_limit_ms, memory_limit_mb
     are included in the returned per-test detail (True for samples/run, False
     for hidden graded cases so answers never leak to the client).
 
+    Test cases are executed with a bounded thread pool (CODE_JUDGE_PARALLELISM,
+    default 1 = sequential). Concurrency is opt-in because Piston's run_timeout
+    is wall-clock: parallel runs only stay correct when Piston has that many
+    dedicated cores, otherwise CPU contention inflates wall time into spurious
+    TIME_LIMIT verdicts. Ordering, scoring, and compile-error semantics are
+    preserved regardless of the parallelism level.
+
     Returns dict: {results[], passed_count, total_count, passed_points,
     total_points, compile_error(bool), compile_output(str)}.
     """
+    cases = list(cases)
+
+    def _execute(case):
+        return run_code(
+            language=language,
+            source=source,
+            stdin=getattr(case, 'stdin', '') or '',
+            time_limit_ms=time_limit_ms,
+            memory_limit_mb=memory_limit_mb,
+        )
+
+    # Execute cases, filling engine_results in input order. A `None` slot marks a
+    # case that was short-circuited after a compile failure (see below) and is
+    # reported as a compile_error without being run.
+    engine_results = [None] * len(cases)
+    if cases:
+        # Probe with the first case. Compilation is input-independent, so if the
+        # source fails to compile here the whole submission fails -- skip running
+        # the remaining cases instead of recompiling the broken source N times.
+        engine_results[0] = _execute(cases[0])
+        if engine_results[0].get('compile_ok') and len(cases) > 1:
+            parallelism = getattr(settings, 'CODE_JUDGE_PARALLELISM', DEFAULT_JUDGE_PARALLELISM)
+            # Concurrency only helps with a multi-core Piston; see the setting's
+            # docs. map() preserves order and re-raises EngineError to the caller.
+            max_workers = max(1, min(int(parallelism or 1), len(cases) - 1))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                for offset, res in enumerate(executor.map(_execute, cases[1:]), start=1):
+                    engine_results[offset] = res
+
     results = []
     passed_count = 0
     passed_points = 0
@@ -142,8 +181,9 @@ def run_against_cases(*, language, source, cases, time_limit_ms, memory_limit_mb
         points = int(getattr(case, 'points', 1) or 0)
         total_points += points
 
-        # If compilation already failed once, short-circuit the rest.
-        if compile_error:
+        res = engine_results[idx]
+        if res is None:
+            # Short-circuited: an earlier case failed to compile.
             results.append({
                 'index': idx,
                 'is_sample': bool(getattr(case, 'is_sample', False)),
@@ -153,16 +193,11 @@ def run_against_cases(*, language, source, cases, time_limit_ms, memory_limit_mb
             })
             continue
 
-        res = run_code(
-            language=language,
-            source=source,
-            stdin=getattr(case, 'stdin', '') or '',
-            time_limit_ms=time_limit_ms,
-            memory_limit_mb=memory_limit_mb,
-        )
         verdict = _verdict_for(res, getattr(case, 'expected_output', '') or '')
 
-        if verdict == 'compile_error':
+        # Compilation is input-independent: a compile failure means the whole
+        # submission fails to compile. Record it once for the outcome.
+        if verdict == 'compile_error' and not compile_error:
             compile_error = True
             compile_output = res.get('compile_output', '')
 

--- a/backend/coding/tasks.py
+++ b/backend/coding/tasks.py
@@ -1,0 +1,57 @@
+"""Celery tasks for the coding app.
+
+`grade_submission` grades a previously-created (queued) CodingSubmission off the
+web request thread. This keeps a burst of submissions (contest/deadline) from
+holding web workers/threads for the full ~seconds-per-submission execution: the
+view returns a queued submission immediately and the client polls for the result.
+"""
+import logging
+
+from celery import shared_task
+
+from . import services
+from .models import CodingSubmission
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name='coding.grade_submission', bind=True, max_retries=0)
+def grade_submission(self, submission_id):
+    """Grade a queued submission in place. Idempotent-safe to re-run."""
+    from . import grading
+
+    # Atomically claim the job: only a still-'queued' row transitions to
+    # 'running'. If another worker/redelivery already claimed or finished it,
+    # skip -- this prevents duplicate grading (and duplicate XP) on redelivery.
+    claimed = CodingSubmission.objects.filter(
+        id=submission_id, status='queued',
+    ).update(status='running')
+    if not claimed:
+        logger.info('grade_submission: %s already claimed/terminal, skipping', submission_id)
+        return None
+
+    try:
+        submission = CodingSubmission.objects.select_related('problem', 'student').get(
+            id=submission_id,
+        )
+    except CodingSubmission.DoesNotExist:
+        logger.warning('grade_submission: submission %s not found', submission_id)
+        return None
+
+    try:
+        grading.finalize_submission(submission)
+    except services.EngineError as exc:
+        # finalize_submission already marked the submission status='error' with a
+        # user-facing message; the poll endpoint will surface it. Don't retry —
+        # re-running untrusted code on a flaky engine isn't worth the churn.
+        logger.error('grade_submission engine error for %s: %s', submission_id, exc)
+    except Exception as exc:  # noqa: BLE001 - never leave a submission stuck 'running'
+        # Soft/hard time limits, OOM, bugs, etc. Mark it errored so the student
+        # isn't stuck on a spinner and can resubmit.
+        logger.exception('grade_submission failed for %s: %s', submission_id, exc)
+        CodingSubmission.objects.filter(id=submission_id).update(
+            status='error',
+            compile_output='Grading failed unexpectedly. Please try submitting again.',
+        )
+
+    return str(submission_id)

--- a/backend/coding/views.py
+++ b/backend/coding/views.py
@@ -1,7 +1,9 @@
 """Student-facing coding endpoints: list problems, solve, run samples, submit."""
-from decimal import Decimal
+import logging
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db.models import F
 from rest_framework import viewsets, permissions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -18,6 +20,8 @@ from .serializers import (
 from .languages import LANGUAGES
 from . import services
 
+logger = logging.getLogger(__name__)
+
 
 class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
     """Published coding problems for the student's approved-enrolled courses."""
@@ -33,6 +37,11 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
         if self.action == 'submit':
             self.throttle_scope = 'code_submit'
             return [ScopedRateThrottle()]
+        # Polling one's own submission is a cheap authenticated read that the
+        # frontend does repeatedly while a submission grades — don't throttle it
+        # under the shared 'user' bucket (that would starve normal API calls).
+        if self.action == 'submission_status':
+            return []
         return super().get_throttles()
 
     def _student(self):
@@ -63,7 +72,7 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
         best = {}
         subs = CodingSubmission.objects.filter(
             student=student, problem__in=problems,
-        ).order_by('problem_id', '-passed_points', '-submitted_at')
+        ).exclude(status__in=['queued', 'running']).order_by('problem_id', '-passed_points', '-submitted_at')
         for s in subs:
             if s.problem_id not in best:
                 best[s.problem_id] = s
@@ -131,7 +140,16 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
 
     @action(detail=True, methods=['post'])
     def submit(self, request, pk=None):
-        """Run code against ALL test cases, score, and persist the submission."""
+        """Run code against ALL test cases, score, and persist the submission.
+
+        Behaviour depends on settings.CODE_JUDGE_ASYNC:
+          * async  -> create a 'queued' submission, enqueue grading to Celery,
+                      return 202 with the queued submission; client polls
+                      `submissions/<id>/` until status is done/error.
+          * sync   -> grade in-request and return 201 with the full result
+                      (legacy behaviour). Also the automatic fallback if the
+                      task queue can't be reached.
+        """
         problem = self.get_object()
         student = self._student()
         if not student:
@@ -147,72 +165,79 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
         if not source.strip():
             return Response({'error': 'Write some code first.'}, status=400)
 
-        cases = list(problem.test_cases.all().order_by('order', 'created_at'))
-        if not cases:
+        if not problem.test_cases.exists():
             return Response({'error': 'This problem has no test cases yet.'}, status=400)
-
-        try:
-            outcome = services.run_against_cases(
-                language=language, source=source, cases=cases,
-                time_limit_ms=problem.time_limit_ms,
-                memory_limit_mb=problem.memory_limit_mb,
-                reveal_io=False,
-            )
-        except services.EngineError as exc:
-            return Response({'error': str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
-
-        marks = None
-        if problem.max_marks and outcome['total_points'] > 0:
-            marks = (Decimal(problem.max_marks) * outcome['passed_points'] / outcome['total_points']).quantize(Decimal('0.01'))
-        elif problem.max_marks:
-            marks = Decimal('0.00')
 
         submission = CodingSubmission.objects.create(
             problem=problem, student=student, language=language, source_code=source,
-            status='error' if outcome['compile_error'] and outcome['passed_count'] == 0 else 'done',
-            results=outcome['results'],
-            compile_output=outcome['compile_output'],
-            passed_count=outcome['passed_count'],
-            total_count=outcome['total_count'],
-            passed_points=outcome['passed_points'],
-            total_points=outcome['total_points'],
-            marks=marks,
+            status='queued',
         )
 
-        # Record a definitive completion + award XP the first time the student
-        # fully solves this problem in-app.
-        xp_awarded = 0
-        if submission.total_count > 0 and submission.passed_count == submission.total_count:
-            CodingProblemCompletion.objects.update_or_create(
-                problem=problem, student=student,
-                defaults={'tenant': problem.tenant, 'method': 'in_app'},
-            )
-            xp_awarded = self._award_solve_xp(student, problem)
+        if getattr(settings, 'CODE_JUDGE_ASYNC', False):
+            try:
+                from .tasks import grade_submission
+                grade_submission.delay(str(submission.id))
+            except Exception as exc:  # broker down -> never block the student
+                logger.warning('Async enqueue failed (%s); grading synchronously.', exc)
+                return self._grade_sync(submission)
+            data = SubmissionResultSerializer(submission).data
+            data['xp_awarded'] = 0
+            return Response(data, status=status.HTTP_202_ACCEPTED)
 
+        return self._grade_sync(submission)
+
+    def _grade_sync(self, submission):
+        """Grade a queued submission in-request and return the 201 result."""
+        from . import grading
+        try:
+            xp_awarded = grading.finalize_submission(submission)
+        except services.EngineError as exc:
+            # Preserve legacy behaviour: an engine failure leaves no submission
+            # row and returns 503 (the student simply retries).
+            submission.delete()
+            return Response({'error': str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
         data = SubmissionResultSerializer(submission).data
         data['xp_awarded'] = xp_awarded
         return Response(data, status=status.HTTP_201_CREATED)
 
-    def _award_solve_xp(self, student, problem):
-        """Award coding-solved XP once per problem (idempotent). Returns XP given."""
-        from gamification.models import XPTransaction
-        from gamification.services import GamificationService
-        from core.utils import calculate_xp_for_coding
+    @action(detail=True, methods=['get'],
+            url_path=r'submissions/(?P<sub_id>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})')
+    def submission_status(self, request, pk=None, sub_id=None):
+        """Poll a single submission's status/result (owner-scoped).
 
-        already_awarded = XPTransaction.objects.filter(
-            student=student, transaction_type='coding_solved', reference_id=problem.id,
-        ).exists()
-        if already_awarded:
+        Used by the frontend to poll a queued/async submission until it is graded.
+        Returns the same shape as `submit`, including a display-only `xp_awarded`.
+        """
+        student = self._student()
+        if not student:
+            return Response({'error': 'Student profile required.'}, status=400)
+        try:
+            submission = CodingSubmission.objects.filter(
+                id=sub_id, problem_id=pk, student=student,
+            ).first()
+        except (ValidationError, ValueError):
+            submission = None
+        if not submission:
+            return Response({'error': 'Submission not found.'}, status=status.HTTP_404_NOT_FOUND)
+        data = SubmissionResultSerializer(submission).data
+        data['xp_awarded'] = self._display_xp(submission) if submission.status == 'done' else 0
+        return Response(data)
+
+    def _display_xp(self, submission):
+        """XP to *display* for a graded submission: the solve XP only when this is
+        the first fully-passing submission for the student on this problem, else 0
+        (mirrors the award-once semantics without re-awarding)."""
+        from core.utils import calculate_xp_for_coding
+        if not (submission.total_count > 0 and submission.passed_count == submission.total_count):
             return 0
-        xp_awarded = calculate_xp_for_coding(problem.difficulty)
-        GamificationService.award_xp(
-            student,
-            xp_awarded,
-            'coding_solved',
-            f'Solved coding problem: {problem.title}',
-            str(problem.id),
-        )
-        return xp_awarded
+        earlier_solve = CodingSubmission.objects.filter(
+            problem_id=submission.problem_id, student_id=submission.student_id,
+            total_count__gt=0, passed_count=F('total_count'),
+            submitted_at__lt=submission.submitted_at,
+        ).exists()
+        if earlier_solve:
+            return 0
+        return calculate_xp_for_coding(submission.problem.difficulty)
 
     @action(detail=True, methods=['post'], url_path='toggle-external-solved')
     def toggle_external_solved(self, request, pk=None):
@@ -246,7 +271,8 @@ class CodingProblemViewSet(viewsets.ReadOnlyModelViewSet):
         CodingProblemCompletion.objects.create(
             tenant=problem.tenant, problem=problem, student=student, method='external',
         )
-        xp_awarded = self._award_solve_xp(student, problem)
+        from . import grading
+        xp_awarded = grading.award_solve_xp(student, problem)
         return Response({'is_solved': True, 'method': 'external', 'xp_awarded': xp_awarded})
 
     @action(detail=True, methods=['get'], url_path='my-submissions')

--- a/backend/dailytaiyari/__init__.py
+++ b/backend/dailytaiyari/__init__.py
@@ -1,2 +1,12 @@
 # DailyTaiyari - Course Preparation Platform
 
+# Ensure the Celery app is loaded when Django starts so shared_task/@app.task
+# and `celery -A dailytaiyari` resolve. Guarded so the project still boots if
+# Celery isn't installed (e.g. a minimal tooling environment).
+try:
+    from .celery import app as celery_app  # noqa: F401
+
+    __all__ = ('celery_app',)
+except ImportError:  # pragma: no cover - celery is a hard dependency in prod
+    pass
+

--- a/backend/dailytaiyari/celery.py
+++ b/backend/dailytaiyari/celery.py
@@ -1,0 +1,25 @@
+"""Celery application for DailyTaiyari.
+
+Used for off-request work — currently grading coding submissions so a burst of
+submissions (contest/deadline) queues gracefully instead of holding web threads.
+Broker + result backend are Redis (see settings CELERY_*). Tasks are discovered
+from every installed app's ``tasks.py``.
+"""
+import os
+
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'dailytaiyari.settings')
+
+app = Celery('dailytaiyari')
+
+# All Celery config lives in Django settings under the CELERY_ namespace.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Auto-discover tasks.py in each installed app.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True, ignore_result=True)
+def debug_task(self):
+    print(f'Request: {self.request!r}')

--- a/backend/dailytaiyari/settings.py
+++ b/backend/dailytaiyari/settings.py
@@ -366,6 +366,14 @@ else:
 # Code-execution engine (Piston) for coding problems.
 PISTON_URL = config('PISTON_URL', default='http://piston:2000')
 CODING_ENABLED = config('CODING_ENABLED', default=True, cast=bool)
+# How many test cases to execute in parallel per submission. Each case is an
+# independent HTTP call to Piston. Concurrency only helps when Piston has at
+# least this many DEDICATED CPU cores: Piston's run_timeout is measured in
+# WALL-CLOCK time, so if concurrent runs contend for a shared/single core their
+# wall time balloons past the limit and every run wrongly fails as TIME_LIMIT.
+# Default is 1 (sequential, correct on any host). Raise it only when Piston runs
+# on a multi-core host with cores >= this value (e.g. a dedicated judge box).
+CODE_JUDGE_PARALLELISM = config('CODE_JUDGE_PARALLELISM', default=1, cast=int)
 
 # Caching (Redis for production)
 CACHES = {

--- a/backend/dailytaiyari/settings.py
+++ b/backend/dailytaiyari/settings.py
@@ -375,24 +375,44 @@ CODING_ENABLED = config('CODING_ENABLED', default=True, cast=bool)
 # on a multi-core host with cores >= this value (e.g. a dedicated judge box).
 CODE_JUDGE_PARALLELISM = config('CODE_JUDGE_PARALLELISM', default=1, cast=int)
 
-# Caching (Redis for production)
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'unique-snowflake',
-    }
-}
+# --- Async code judging (Phase A) --------------------------------------------
+# When True, graded submissions are enqueued to Celery and graded off the web
+# request thread; the client receives a "queued" submission and polls for the
+# result. When False (default), grading runs synchronously in-request exactly as
+# before. Flip to True only once the redis + celery-worker services are running.
+CODE_JUDGE_ASYNC = config('CODE_JUDGE_ASYNC', default=False, cast=bool)
 
-# For production with Redis:
-# CACHES = {
-#     'default': {
-#         'BACKEND': 'django_redis.cache.RedisCache',
-#         'LOCATION': config('REDIS_URL', default='redis://127.0.0.1:6379/1'),
-#         'OPTIONS': {
-#             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
-#         }
-#     }
-# }
+# Celery (broker + result backend on Redis). Result backend stores the task
+# state so the poll endpoint can distinguish queued/running/done.
+CELERY_BROKER_URL = config('CELERY_BROKER_URL', default='redis://redis:6379/0')
+CELERY_RESULT_BACKEND = config('CELERY_RESULT_BACKEND', default='redis://redis:6379/1')
+CELERY_TASK_ACKS_LATE = True
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERY_TASK_TIME_LIMIT = 180
+CELERY_TASK_SOFT_TIME_LIMIT = 150
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+
+# Caching. Prefer a shared Redis cache when REDIS_URL is configured (needed once
+# there are multiple web workers/hosts); otherwise fall back to per-process
+# LocMem so the app still runs without Redis.
+_REDIS_URL = config('REDIS_URL', default='')
+if _REDIS_URL:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': f'{_REDIS_URL}/2',
+            'OPTIONS': {
+                'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            },
+        }
+    }
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'unique-snowflake',
+        }
+    }
 
 # Logging Configuration
 LOGGING = {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - .:/app
       - static_volume:/app/staticfiles
       - media_volume:/app/media
-    environment:
+    environment: &app-env
       - DB_NAME=${DB_NAME}
       - DB_USER=${DB_USER}
       - DB_PASSWORD=${DB_PASSWORD}
@@ -48,9 +48,56 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_STORAGE_BUCKET_NAME=${AWS_STORAGE_BUCKET_NAME:-}
       - AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME:-ap-south-1}
+      # Async code judging (Phase A). Celery broker/result on Redis; flip
+      # CODE_JUDGE_ASYNC=True once the redis + celery-worker services are up so
+      # submissions are graded off the request thread. Defaults keep the app
+      # working synchronously if these are unset. (Set REDIS_URL as well to move
+      # the Django cache onto Redis too — left unset here so the cache stays
+      # LocMem and this change is scoped to async judging only.)
+      - CELERY_BROKER_URL=${CELERY_BROKER_URL:-redis://redis:6379/0}
+      - CELERY_RESULT_BACKEND=${CELERY_RESULT_BACKEND:-redis://redis:6379/1}
+      - CODE_JUDGE_ASYNC=${CODE_JUDGE_ASYNC:-False}
+      - CODE_JUDGE_PARALLELISM=${CODE_JUDGE_PARALLELISM:-1}
 
     depends_on:
       db:
+        condition: service_healthy
+
+  # Redis — Celery broker + result backend for async code judging.
+  # Internal only; no published ports. Uses noeviction so queued task messages
+  # are never dropped under memory pressure (a full broker instead makes enqueue
+  # fail, which the app handles by falling back to synchronous grading).
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no", "--maxmemory", "256mb", "--maxmemory-policy", "noeviction"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    mem_limit: 320m
+
+  # Celery worker — grades coding submissions off the web request thread.
+  # Shares the web image and the same app environment. Concurrency defaults to 1
+  # to match the single-core Piston sandbox: grading several submissions at once
+  # on one core would inflate Piston's wall-clock run_timeout into spurious
+  # TIME_LIMIT verdicts. Raise CELERY_CONCURRENCY together with Piston cores.
+  celery-worker:
+    build: .
+    restart: unless-stopped
+    # Skip the web entrypoint (migrate/collectstatic) — the web service owns
+    # those; the worker only needs to consume the queue.
+    entrypoint: []
+    command: celery -A dailytaiyari worker --loglevel=info --concurrency=${CELERY_CONCURRENCY:-1}
+    volumes:
+      - .:/app
+      - media_volume:/app/media
+    environment: *app-env
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   # Code-execution sandbox for coding questions. Runs untrusted student code.

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -2,6 +2,12 @@ import multiprocessing
 
 bind = "0.0.0.0:8000"
 workers = multiprocessing.cpu_count() * 2 + 1
+# Threaded workers: coding submissions block on Piston HTTP calls (I/O-bound),
+# so letting each worker serve several requests via threads keeps the site
+# responsive under submission bursts instead of pinning one whole worker per
+# in-flight submission. threads>1 requires the gthread worker class.
+worker_class = "gthread"
+threads = 4
 loglevel = "info"
 accesslog = "-"
 errorlog = "-"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,6 +31,11 @@ cryptography>=42.0.0
 # Production Server
 gunicorn>=21.2.0
 
+# Async task queue for code judging (Phase A: async submissions)
+celery>=5.3.0
+redis>=5.0.0
+django-redis>=5.4.0
+
 # Testing
 pytest>=8.0.0
 pytest-django>=4.7.0

--- a/frontend/exam-frontend/src/pages/CodingProblem.jsx
+++ b/frontend/exam-frontend/src/pages/CodingProblem.jsx
@@ -12,6 +12,33 @@ import Loading from '../components/common/Loading'
 
 const CodeEditor = lazy(() => import('../components/coding/CodeEditor'))
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Poll a queued/async submission until it is graded (or a generous deadline).
+// Sync submissions return a terminal status directly and never reach here.
+// Transient poll failures are tolerated (grading continues server-side).
+const pollSubmission = async (problemId, submissionId) => {
+  const deadline = Date.now() + 180000
+  let delay = 1200
+  let consecutiveErrors = 0
+  while (Date.now() < deadline) {
+    await sleep(delay)
+    try {
+      const s = await codingService.submissionStatus(problemId, submissionId)
+      consecutiveErrors = 0
+      if (s.status === 'done' || s.status === 'error') return s
+    } catch (e) {
+      // A single 5xx/network blip shouldn't abort — keep polling. Give up only
+      // after several consecutive failures (server likely unreachable).
+      if (++consecutiveErrors >= 5) throw e
+    }
+    delay = Math.min(delay + 300, 3000)
+  }
+  const err = new Error('grading-timeout')
+  err.friendly = 'Still grading — this is taking longer than usual. Check "My submissions" in a moment.'
+  throw err
+}
+
 const DIFF_TINT = {
   easy: 'bg-emerald-50 text-emerald-600 dark:bg-emerald-900/20',
   medium: 'bg-amber-50 text-amber-600 dark:bg-amber-900/20',
@@ -100,10 +127,21 @@ const CodingProblem = () => {
   })
 
   const submitMutation = useMutation({
-    mutationFn: () => codingService.submit(problemId, { language: lang, source_code: code }),
+    mutationFn: async () => {
+      const res = await codingService.submit(problemId, { language: lang, source_code: code })
+      // Async judging returns a queued submission (HTTP 202) — poll until graded.
+      if (res && res.id && (res.status === 'queued' || res.status === 'running')) {
+        return pollSubmission(problemId, res.id)
+      }
+      return res
+    },
     onSuccess: (data) => {
       setSubmitResult(data)
       setRunResult(null)
+      if (data.status === 'error' && (data.total_count || 0) === 0) {
+        toast.error(data.compile_output || 'Could not grade your submission. Please try again.')
+        return
+      }
       if (data.all_passed) {
         toast.success(data.xp_awarded > 0 ? `All test cases passed! +${data.xp_awarded} XP 🎉` : 'All test cases passed! 🎉')
         queryClient.invalidateQueries({ queryKey: ['codingProblem', problemId] })
@@ -111,7 +149,7 @@ const CodingProblem = () => {
         toast(`${data.passed_count}/${data.total_count} test cases passed`)
       }
     },
-    onError: (err) => toast.error(err?.response?.data?.error || 'Submission failed. Try again.'),
+    onError: (err) => toast.error(err?.friendly || err?.response?.data?.error || 'Submission failed. Try again.'),
   })
 
   const toggleExternalMutation = useMutation({
@@ -248,8 +286,15 @@ const CodingProblem = () => {
             <RunResultPanel result={runResult} />
           )}
 
+          {/* Grading in progress (async submissions are queued then polled) */}
+          {submitMutation.isPending && (
+            <div className="flex items-center gap-2 rounded-xl border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-800/40 px-4 py-3 text-sm text-surface-500">
+              <Loader2 className="w-4 h-4 animate-spin" /> Grading your submission…
+            </div>
+          )}
+
           {/* Submit results */}
-          {submitResult && (
+          {!submitMutation.isPending && submitResult && (
             <SubmitResultPanel result={submitResult} maxMarks={problem.max_marks} />
           )}
         </div>

--- a/frontend/exam-frontend/src/services/codingService.js
+++ b/frontend/exam-frontend/src/services/codingService.js
@@ -18,6 +18,8 @@ export const codingService = {
     (await api.post(`/coding/problems/${id}/run/`, { language, source_code, stdin })).data,
   submit: async (id, { language, source_code }) =>
     (await api.post(`/coding/problems/${id}/submit/`, { language, source_code })).data,
+  submissionStatus: async (id, submissionId) =>
+    (await api.get(`/coding/problems/${id}/submissions/${submissionId}/`)).data,
   mySubmissions: async (id) =>
     (await api.get(`/coding/problems/${id}/my-submissions/`)).data,
   toggleExternalSolved: async (id) =>


### PR DESCRIPTION
Scales the in-house code judge toward supporting bursts of concurrent submissions (contest/deadline). Three layers, each independently safe to deploy:

### 1. Threaded web workers (gunicorn gthread)
`worker_class = gthread`, `threads = 4` → ~20 concurrent request slots on the 2‑vCPU VM. Browsing/quizzes for 30+ users is comfortably handled and no longer blocked by long-running submissions.

### 2. Opt-in parallel test-case judging
`CODE_JUDGE_PARALLELISM` (default **1** = sequential, current behaviour). Test cases fan out over a bounded `ThreadPoolExecutor`. Concurrency is opt-in because Piston's `run_timeout` is **wall-clock**: parallel runs only stay correct when Piston has that many dedicated cores, otherwise CPU contention inflates wall time into spurious `TIME_LIMIT` verdicts. Raise only alongside dedicated Piston cores.

### 3. Async submissions via Celery + Redis (Phase A)
Graded submissions run off the web request thread so a burst queues gracefully instead of holding threads for the full ~seconds-per-submission execution.

- **Gated behind `CODE_JUDGE_ASYNC` (default `False`)** — when off, behaviour is byte-for-byte identical to before (grade in-request, HTTP 201). Safe to merge/deploy before Redis/worker exist.
- When on: `submit` creates a `queued` submission, enqueues a Celery task, returns **202**; the frontend polls `submissions/<id>/` until the verdict is ready. Broker unreachable → transparent **synchronous fallback**.
- `coding/grading.py` holds a shared `finalize_submission()` used by both the sync path and the async task, so scoring / XP-award-once / completion semantics are identical.
- Task **atomically claims** `queued → running` (no duplicate grading on redelivery) and never leaves a stuck `running` row (handles engine errors + unexpected failures/timeouts).
- New `queued`/`running` submission statuses (migration `0003`); in-progress rows excluded from "best".
- `docker-compose`: `redis` + `celery-worker` services. Worker **concurrency defaults to 1** to match the single-core Piston sandbox; broker uses `noeviction` so queued messages aren't dropped. Web no longer hard-depends on Redis, so it still boots with async off.
- Frontend: resilient polling (tolerates transient blips, 180s deadline) + "Grading…" indicator.

### Deploy / rollout
1. Rebuild the web image (new deps: `celery`, `redis`, `django-redis`) and apply migration `0003`.
2. Bring up `redis` + `celery-worker`; verify sync path still works with `CODE_JUDGE_ASYNC=False`.
3. Flip `CODE_JUDGE_ASYNC=True` to enable async grading.

Raw **throughput** (the 14× Java recompile) is unchanged here — that's Phase B (compile-once) + Phase C (dedicated Piston cores / bigger VM), tracked separately.