### PR TITLE
docs: branching strategy + deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,18 @@ VITE_API_URL=https://api.dailytaiyari.ai
 - 🔲 Advanced ML recommendations
 - 🔲 Payment & subscriptions
 
+## 📖 Documentation
+
+Project docs live in [`wiki/`](./wiki):
+
+- [Architecture](./wiki/architecture.md)
+- [Backend Guide](./wiki/backend-guide.md) · [Frontend Guide](./wiki/frontend-guide.md)
+- [API Reference](./wiki/api-reference.md)
+- [Environment Variables](./wiki/environment-variables.md)
+- [Tenant Setup](./wiki/tenant-setup.md)
+- **[Branching Strategy](./wiki/branching-strategy.md)** — `main` (pre-prod) → `production` (prod)
+- **[Deployment Guide](./wiki/deployment.md)** — how the backend is deployed & operated
+
 ## 🤝 Contributing
 
 This is a proprietary project. For partnership inquiries, contact support@dailytaiyari.ai

--- a/wiki/branching-strategy.md
+++ b/wiki/branching-strategy.md
@@ -1,0 +1,85 @@
+# Branching Strategy
+
+DailyTaiyari runs **two long-lived environments** from a **single repository**.
+Changes always flow one direction: feature → pre-prod → prod. This guarantees
+nothing reaches production without first being tested on pre-prod.
+
+```
+feature/*  ─PR─►  main  ──promote──►  production
+ (work)         (pre-prod)             (prod)
+                api.dailytaiyari.in    api-prod.dailytaiyari.in
+```
+
+## Long-lived branches
+
+| Branch        | Environment | Host                        | Deploys when            |
+| ------------- | ----------- | --------------------------- | ----------------------- |
+| `main`        | Pre-prod    | `api.dailytaiyari.in`       | every merge to `main`   |
+| `production`  | Prod        | `api-prod.dailytaiyari.in`  | after a promotion merge |
+
+Short-lived work branches (`feature/*`, `fix/*`, `chore/*`) exist only until
+their PR is squash-merged into `main`, then are deleted.
+
+## Everyday flow
+
+1. **Branch** off `main`:
+   ```bash
+   git checkout main && git pull --ff-only
+   git checkout -b feature/<short-name>
+   ```
+2. **Build**, commit, push, open a **PR into `main`**.
+3. **Squash-merge** the PR once reviewed and CI is green.
+4. **Deploy `main` to pre-prod** and test live on `api.dailytaiyari.in`
+   (see [deployment.md](./deployment.md)).
+5. When satisfied, **promote to production** (below).
+
+## Promotion (main → production)
+
+Production only ever moves forward to an already-tested `main`. Promote with a
+fast-forward-only merge so `production` is always a subset of `main`:
+
+```bash
+git checkout production
+git pull --ff-only
+git merge --ff-only origin/main
+git push origin production
+git tag -a prod-$(date +%Y.%m.%d) -m "Prod deploy <summary>"
+git push origin --tags
+```
+
+Then run the prod deploy (see [deployment.md](./deployment.md)).
+
+> Tag every prod deploy (`prod-YYYY.MM.DD`). Tags are your rollback points —
+> to roll back, deploy the previous tag.
+
+## Hotfixes (urgent prod fix)
+
+1. Branch off `production`: `git checkout -b fix/<name> production`.
+2. Fix, PR **into `production`**, review, merge, deploy prod.
+3. **Back-merge** so pre-prod doesn't regress:
+   ```bash
+   git checkout main && git pull --ff-only
+   git merge origin/production   # or cherry-pick the fix commit
+   git push origin main
+   ```
+
+## Migrations
+
+A DB migration merged to `main` runs on **pre-prod first** (each environment has
+its own separate database). Confirm it applied cleanly on pre-prod before
+promoting to `production`. Never point a migration at prod that hasn't run on
+pre-prod.
+
+## Branch protection (recommended settings)
+
+- `production`: require PR, require status checks, **no direct pushes**, no
+  force-push, no deletion.
+- `main`: require PR + passing checks before merge.
+
+## Rules of thumb
+
+- Never commit directly to `main` or `production` — always via PR.
+- Never merge `production → main` except when back-merging a hotfix.
+- `production` is always fast-forwardable from `main` (never diverges except for
+  in-flight hotfixes, which are back-merged immediately).
+- One change, one PR, squash-merged — keeps history and rollbacks clean.

--- a/wiki/deployment.md
+++ b/wiki/deployment.md
@@ -1,0 +1,141 @@
+# Deployment Guide
+
+How the DailyTaiyari backend is deployed and operated. The frontend (student
+app) and landing site deploy automatically via Netlify and are out of scope
+here.
+
+> **No secrets in this doc.** IPs, SSH keys, DB credentials, storage keys and
+> passwords live only on the VMs / in the secrets store — never in the repo.
+> Placeholders like `<prod-vm-ip>` are used below.
+
+## Environments
+
+DailyTaiyari runs two independent backend environments. They share **no data**
+and live in **separate Azure accounts / resource groups**.
+
+| Aspect         | Pre-prod (testing)            | Prod                              |
+| -------------- | ----------------------------- | --------------------------------- |
+| Branch         | `main`                        | `production`                      |
+| API hostname   | `api.dailytaiyari.in`         | `api-prod.dailytaiyari.in`        |
+| Purpose        | Validate every merge          | Live customer traffic             |
+| Database       | Its own Azure PostgreSQL      | Its own Azure PostgreSQL          |
+| Media storage  | Its own Azure Blob container  | Its own Azure Blob container      |
+
+See [branching-strategy.md](./branching-strategy.md) for how code flows between
+them and [environment-variables.md](./environment-variables.md) for the full
+list of required env keys.
+
+## Architecture (per environment)
+
+Each VM runs the same Docker Compose stack:
+
+| Service        | Role                                            |
+| -------------- | ----------------------------------------------- |
+| `web`          | Django + Gunicorn (API)                         |
+| `nginx`        | TLS termination + reverse proxy                 |
+| `redis`        | Celery broker / cache                           |
+| `celery-worker`| Async tasks (email, async code judging, etc.)   |
+| `piston`       | Sandboxed code execution engine                 |
+
+- **Database:** managed **Azure PostgreSQL Flexible Server** (SSL required). The
+  `db` service in `docker-compose.yml` is unused in cloud deploys.
+- **Media:** **Azure Blob Storage**, served as public blob URLs.
+- **TLS:** Let's Encrypt certs per hostname, auto-renewed via a certbot deploy
+  hook that reloads nginx.
+
+## Configuration
+
+All config is via `backend/.env` on the VM (never committed). Each environment
+has its own `.env` with its own `SECRET_KEY`, DB, storage, and `ALLOWED_HOSTS` /
+`CORS_ALLOWED_ORIGINS`. See [environment-variables.md](./environment-variables.md).
+
+## Which branch each VM tracks
+
+Each VM's checkout is pinned to its environment's branch, so a plain
+`git pull --ff-only` always pulls the right code:
+
+| VM        | Tracks branch |
+| --------- | ------------- |
+| Pre-prod  | `main`        |
+| Prod      | `production`  |
+
+One-time pin on the prod VM:
+
+```bash
+git fetch origin
+git checkout production
+git branch --set-upstream-to=origin/production
+```
+
+## Deploy procedure
+
+SSH to the target VM (use that environment's key), then in the repo root:
+
+```bash
+# 1. Pull the environment's branch
+git pull --ff-only
+
+# 2a. Code-only change (no new deps, no migration):
+docker compose restart web
+
+# 2b. Dependency change (requirements/Dockerfile):
+docker compose up -d --build web
+
+# 2c. Migration in the release:
+#     entrypoint.sh auto-runs migrate + collectstatic on web start,
+#     so a rebuild/restart applies them. To run manually:
+docker compose exec -T web python manage.py migrate
+```
+
+Deploy **pre-prod from `main`** first; deploy **prod from `production`** only
+after promotion (see branching doc). The canonical, secret-aware runbook lives
+in the `deploy-backend` skill under `.github/skills/`.
+
+## Verify a deploy
+
+```bash
+# API docs should return 200 over HTTPS
+curl -s -o /dev/null -w '%{http_code}\n' https://<hostname>/api/docs/
+
+# Containers healthy
+docker compose ps
+
+# Recent logs if anything is off
+docker compose logs web --tail=50
+```
+
+For prod, `<hostname>` is `api-prod.dailytaiyari.in`; for pre-prod,
+`api.dailytaiyari.in`.
+
+## TLS certificates
+
+- Issued per hostname via certbot (`--standalone`; nginx must be stopped briefly
+  to free port 80 on first issuance).
+- A deploy hook reloads nginx automatically on renewal; no manual action needed.
+
+## Rollback
+
+Every prod deploy is tagged `prod-YYYY.MM.DD`. To roll back, check out the
+previous tag on the prod VM and restart:
+
+```bash
+git checkout prod-<previous-date>
+docker compose up -d --build web
+```
+
+If the bad release included a migration, assess whether it is
+backward-compatible before rolling back the code.
+
+## First-time environment provisioning
+
+Standing up a brand-new environment (VM + Azure PostgreSQL + Blob + TLS + first
+tenant/admin) is documented step-by-step in the `deploy-backend` and
+`manage-tenants` skills under `.github/skills/`. High level:
+
+1. Create RG, VM (x64), open ports 22/80/443.
+2. Install Docker + Compose, clone the repo, check out the env branch.
+3. Create Azure PostgreSQL Flexible Server + database; allow the VM IP; SSL on.
+4. Create Storage account + `media` container (Blob public read).
+5. Write `backend/.env`; bring up app services (without nginx) so migrations run.
+6. Point DNS at the VM, issue Let's Encrypt cert, bring up nginx.
+7. Create the first tenant + admin (see `manage-tenants`).


### PR DESCRIPTION
Adds `wiki/branching-strategy.md` and `wiki/deployment.md` documenting the two-environment workflow:

- `main` → pre-prod (`api.dailytaiyari.in`)
- `production` → prod (`api-prod.dailytaiyari.in`)

Covers promotion (main→production), hotfix + back-merge, migrations, rollback via tags, deploy procedure, and per-env branch pinning. README links to both. No secrets/IPs/credentials included.