### PR TITLE
chore: gitignore local credential/reference files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -296,6 +296,11 @@ secrets.json
 credentials.json
 *.pem
 *.key
+# Local-only credential/reference copies (never commit real .env secrets)
+credentials/
+*-credentials.txt
+*.env.txt
+env-*.txt
 *.crt
 *.cert
 


### PR DESCRIPTION
Adds ignore rules so local-only credential reference copies can never be committed:

```
credentials/
*-credentials.txt
*.env.txt
env-*.txt
```

Only `.gitignore` changes — no secrets, no other files.