### PR TITLE
feat: allow JoinLoop client origin in CORS

### DIFF
--- a/backend/dailytaiyari/settings.py
+++ b/backend/dailytaiyari/settings.py
@@ -307,6 +307,8 @@ CORS_ALLOW_CREDENTIALS = True
 # deploys) that must be allowed to call the public platform endpoints.
 CORS_ALLOWED_ORIGINS += [
     'https://testlaevacademy.netlify.app',
+    # JoinLoop tenant frontend (client-owned domain).
+    'https://classroom.joinloop.co.in',
 ]
 # Allow the marketing site + demo portal (any *.dailytaiyari.in / *.dailytaiyari.ai
 # subdomain, plus the apex) to call the public platform endpoints cross-origin.


### PR DESCRIPTION
Whitelists `https://classroom.joinloop.co.in` (JoinLoop tenant's client-owned frontend) in `CORS_ALLOWED_ORIGINS` so it can call the public platform + API endpoints. Settings-only; no migration.