### PR TITLE
Whitelist JoinLoop Netlify default URL for CORS

### DIFF
--- a/backend/dailytaiyari/settings.py
+++ b/backend/dailytaiyari/settings.py
@@ -307,8 +307,9 @@ CORS_ALLOW_CREDENTIALS = True
 # deploys) that must be allowed to call the public platform endpoints.
 CORS_ALLOWED_ORIGINS += [
     'https://testlaevacademy.netlify.app',
-    # JoinLoop tenant frontend (client-owned domain).
+    # JoinLoop tenant frontend (client-owned domain + Netlify default URL).
     'https://classroom.joinloop.co.in',
+    'https://dailytaiyari-joinloop.netlify.app',
 ]
 # Allow the marketing site + demo portal (any *.dailytaiyari.in / *.dailytaiyari.ai
 # subdomain, plus the apex) to call the public platform endpoints cross-origin.


### PR DESCRIPTION
Adds `https://dailytaiyari-joinloop.netlify.app` to `CORS_ALLOWED_ORIGINS` so the JoinLoop exam app on its Netlify default domain can call the prod API. Settings-only, no migration.