### PR TITLE
Fix admin settings page jumping to top on each save

### DIFF
--- a/frontend/exam-frontend/src/context/tenantStore.js
+++ b/frontend/exam-frontend/src/context/tenantStore.js
@@ -44,7 +44,15 @@ export const useTenantStore = create((set, get) => ({
         }
 
         try {
-            set({ isLoading: true, error: null });
+            // Only show the full-screen loader on the very first load. Later
+            // refreshes (e.g. after an admin saves a setting) run silently so the
+            // app's route tree isn't unmounted/remounted — which would otherwise
+            // flash a spinner and reset the scroll position to the top.
+            if (!get().tenant) {
+                set({ isLoading: true, error: null });
+            } else {
+                set({ error: null });
+            }
             const response = await tenantApi.get(`/tenant/${tenantId}/`);
             set({ tenant: response.data, isLoading: false });
 


### PR DESCRIPTION
## Problem

On the Admin Dashboard **Settings** page, every setting change (feature toggle, theme, branding, logo/favicon) caused the whole page to jump back to the top, forcing the admin to scroll down again after each change.

## Root cause

Each save handler in `TenantSettings` calls `fetchTenantConfig()`. That store action set the global `isLoading: true` at the start of every refetch. `App.jsx` renders a full-screen spinner whenever `isLoading` is true, which **unmounts the entire route tree** (including the dashboard). When the refetch finished, the dashboard remounted and its `useEffect(() => window.scrollTo(0, 0), [activeTab])` fired on mount — snapping the viewport to the top.

## Fix

In `tenantStore.fetchTenantConfig`, only toggle the global loader on the **initial** load (when `tenant` is still `null`). Subsequent refreshes after a save run silently, so the route tree is no longer unmounted/remounted and the scroll position is preserved. First-load behavior and branding/theme/favicon updates are unchanged.

Frontend-only change — deploys via Netlify on merge; no backend/VM action needed.