### PR TITLE
feat(superadmin): charts & visualizations for dashboard, tenants & support

### DIFF
--- a/backend/core/superadmin_views.py
+++ b/backend/core/superadmin_views.py
@@ -398,10 +398,13 @@ class LeadListView(APIView):
 
         items = []
         counts = {'demo': 0, 'contact': 0, 'job': 0, 'new': 0}
+        by_status = {'new': 0, 'contacted': 0, 'closed': 0}
         for key, (model, serializer_cls) in LEAD_REGISTRY.items():
             qs = model.objects.all()
             counts[key] = qs.count()
             counts['new'] += qs.filter(status='new').count()
+            for _st in by_status:
+                by_status[_st] += qs.filter(status=_st).count()
             if wanted_type and wanted_type != key:
                 continue
             if status_filter:
@@ -411,6 +414,7 @@ class LeadListView(APIView):
             items.extend(serializer_cls(qs, many=True).data)
 
         items.sort(key=lambda x: x['created_at'], reverse=True)
+        counts['by_status'] = by_status
         return Response({'results': items[:limit], 'total': len(items), 'counts': counts})
 
 

--- a/frontend/superadmin-frontend/package-lock.json
+++ b/frontend/superadmin-frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
         "react-router-dom": "^6.22.0",
+        "recharts": "^2.15.4",
         "zustand": "^4.5.0"
       },
       "devDependencies": {
@@ -277,6 +278,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1318,6 +1328,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2020,6 +2093,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2101,6 +2295,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2178,6 +2378,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2668,12 +2878,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -3269,6 +3494,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3896,6 +4130,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4088,7 +4328,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4580,7 +4819,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4674,7 +4912,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -4719,6 +4956,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4741,6 +5009,45 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5427,6 +5734,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5674,6 +5987,28 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/frontend/superadmin-frontend/package.json
+++ b/frontend/superadmin-frontend/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.22.0",
+    "recharts": "^2.15.4",
     "zustand": "^4.5.0"
   },
   "devDependencies": {

--- a/frontend/superadmin-frontend/src/components/charts.jsx
+++ b/frontend/superadmin-frontend/src/components/charts.jsx
@@ -1,0 +1,193 @@
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+
+export const CHART_COLORS = {
+  indigo: '#4f46e5',
+  indigoLight: '#818cf8',
+  emerald: '#10b981',
+  amber: '#f59e0b',
+  rose: '#f43f5e',
+  slate: '#94a3b8',
+  sky: '#0ea5e9',
+  violet: '#8b5cf6',
+}
+
+const AXIS = { fontSize: 12, fill: '#94a3b8' }
+
+export function ChartCard({ title, icon: Icon, action, children, className = '' }) {
+  return (
+    <div className={`bg-white rounded-xl border border-slate-200 p-5 ${className}`}>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          {Icon && <Icon className="w-4 h-4 text-brand-600" />}
+          <h2 className="font-semibold text-slate-900">{title}</h2>
+        </div>
+        {action}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export function MiniStat({ icon: Icon, label, value, tone = 'brand' }) {
+  const tones = {
+    brand: 'bg-brand-50 text-brand-600',
+    green: 'bg-emerald-50 text-emerald-600',
+    amber: 'bg-amber-50 text-amber-600',
+    rose: 'bg-rose-50 text-rose-600',
+    slate: 'bg-slate-100 text-slate-600',
+  }
+  return (
+    <div className="bg-white rounded-xl border border-slate-200 p-4 flex items-center gap-3">
+      <div className={`w-10 h-10 rounded-lg flex items-center justify-center shrink-0 ${tones[tone]}`}>
+        <Icon className="w-5 h-5" />
+      </div>
+      <div className="min-w-0">
+        <div className="text-xl font-bold text-slate-900 leading-none">{value}</div>
+        <div className="text-xs text-slate-500 mt-1 truncate">{label}</div>
+      </div>
+    </div>
+  )
+}
+
+function TooltipBox({ active, payload, label, valueLabel }) {
+  if (!active || !payload || !payload.length) return null
+  const row = payload[0]
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 shadow-lg text-xs">
+      <div className="font-medium text-slate-700">{row.payload.name ?? label}</div>
+      <div className="text-slate-500">
+        {valueLabel || 'Count'}: <span className="font-semibold text-slate-900">{row.value}</span>
+      </div>
+    </div>
+  )
+}
+
+/** Donut chart with a centered total and a compact legend. */
+export function DonutChart({ data, valueLabel, centerLabel, height = 200 }) {
+  const total = data.reduce((sum, d) => sum + d.value, 0)
+  const hasData = total > 0
+  return (
+    <div className="flex items-center gap-4">
+      <div className="relative shrink-0" style={{ width: height, height }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={hasData ? data : [{ name: 'No data', value: 1, color: '#e2e8f0' }]}
+              dataKey="value"
+              nameKey="name"
+              innerRadius="62%"
+              outerRadius="100%"
+              paddingAngle={hasData ? 2 : 0}
+              stroke="none"
+            >
+              {(hasData ? data : [{ color: '#e2e8f0' }]).map((entry, i) => (
+                <Cell key={i} fill={entry.color} />
+              ))}
+            </Pie>
+            {hasData && <Tooltip content={<TooltipBox valueLabel={valueLabel} />} />}
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+          <span className="text-2xl font-bold text-slate-900">{total}</span>
+          {centerLabel && <span className="text-xs text-slate-400">{centerLabel}</span>}
+        </div>
+      </div>
+      <ul className="space-y-1.5 text-sm min-w-0">
+        {data.map((d) => (
+          <li key={d.name} className="flex items-center gap-2">
+            <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: d.color }} />
+            <span className="text-slate-600 truncate">{d.name}</span>
+            <span className="ml-auto font-semibold text-slate-900 tabular-nums">{d.value}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/** Vertical bar chart (one series). */
+export function BarChartCompact({ data, valueLabel, height = 220 }) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f5f9" />
+        <XAxis dataKey="name" tick={AXIS} axisLine={false} tickLine={false} />
+        <YAxis tick={AXIS} axisLine={false} tickLine={false} allowDecimals={false} />
+        <Tooltip cursor={{ fill: '#f8fafc' }} content={<TooltipBox valueLabel={valueLabel} />} />
+        <Bar dataKey="value" radius={[6, 6, 0, 0]} maxBarSize={54}>
+          {data.map((d, i) => (
+            <Cell key={i} fill={d.color || CHART_COLORS.indigo} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+/** Horizontal bar chart, good for ranked lists (top tenants). */
+export function HBarChart({ data, valueLabel, height = 220 }) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ top: 4, right: 16, left: 8, bottom: 0 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#f1f5f9" />
+        <XAxis type="number" tick={AXIS} axisLine={false} tickLine={false} allowDecimals={false} />
+        <YAxis
+          type="category"
+          dataKey="name"
+          tick={AXIS}
+          axisLine={false}
+          tickLine={false}
+          width={120}
+        />
+        <Tooltip cursor={{ fill: '#f8fafc' }} content={<TooltipBox valueLabel={valueLabel} />} />
+        <Bar dataKey="value" radius={[0, 6, 6, 0]} maxBarSize={26} fill={CHART_COLORS.indigo} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+/** Smooth cumulative area chart for growth over time. */
+export function GrowthAreaChart({ data, valueLabel, height = 240 }) {
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart data={data} margin={{ top: 8, right: 12, left: -18, bottom: 0 }}>
+        <defs>
+          <linearGradient id="growthFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={CHART_COLORS.indigo} stopOpacity={0.28} />
+            <stop offset="100%" stopColor={CHART_COLORS.indigo} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#f1f5f9" />
+        <XAxis dataKey="name" tick={AXIS} axisLine={false} tickLine={false} />
+        <YAxis tick={AXIS} axisLine={false} tickLine={false} allowDecimals={false} />
+        <Tooltip content={<TooltipBox valueLabel={valueLabel} />} />
+        <Area
+          type="monotone"
+          dataKey="value"
+          stroke={CHART_COLORS.indigo}
+          strokeWidth={2.5}
+          fill="url(#growthFill)"
+          dot={{ r: 3, fill: CHART_COLORS.indigo, strokeWidth: 0 }}
+          activeDot={{ r: 5 }}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/superadmin-frontend/src/pages/Dashboard.jsx
+++ b/frontend/superadmin-frontend/src/pages/Dashboard.jsx
@@ -1,62 +1,139 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   Building2,
   CheckCircle2,
-  XCircle,
   Users,
-  GraduationCap,
   BookOpen,
   ArrowRight,
   Loader2,
-  AlertTriangle,
   CreditCard,
   Gauge,
+  PieChart as PieIcon,
+  UsersRound,
+  TrendingUp,
+  Trophy,
 } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { fetchStats, fetchTenants } from '../services/superadminService'
+import {
+  ChartCard,
+  DonutChart,
+  BarChartCompact,
+  HBarChart,
+  GrowthAreaChart,
+  CHART_COLORS,
+} from '../components/charts'
 
 const PLAN_ORDER = ['trial', 'starter', 'growth', 'enterprise']
-const PLAN_LABELS = {
-  trial: 'Trial',
-  starter: 'Starter',
-  growth: 'Growth',
-  enterprise: 'Enterprise',
+const PLAN_LABELS = { trial: 'Trial', starter: 'Starter', growth: 'Growth', enterprise: 'Enterprise' }
+const PLAN_COLORS = {
+  trial: CHART_COLORS.slate,
+  starter: CHART_COLORS.sky,
+  growth: CHART_COLORS.indigo,
+  enterprise: CHART_COLORS.violet,
 }
 
-function StatCard({ icon: Icon, label, value, tone = 'brand' }) {
+function KpiCard({ icon: Icon, label, value, sub, tone = 'brand' }) {
   const tones = {
     brand: 'bg-brand-50 text-brand-600',
     green: 'bg-emerald-50 text-emerald-600',
-    red: 'bg-rose-50 text-rose-600',
     amber: 'bg-amber-50 text-amber-600',
     slate: 'bg-slate-100 text-slate-600',
   }
   return (
     <div className="bg-white rounded-xl border border-slate-200 p-5">
-      <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-3 ${tones[tone]}`}>
-        <Icon className="w-5 h-5" />
+      <div className="flex items-start justify-between">
+        <div>
+          <div className="text-3xl font-bold text-slate-900 leading-none">{value}</div>
+          <div className="text-sm text-slate-500 mt-1.5">{label}</div>
+        </div>
+        <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${tones[tone]}`}>
+          <Icon className="w-5 h-5" />
+        </div>
       </div>
-      <div className="text-2xl font-bold text-slate-900">{value}</div>
-      <div className="text-sm text-slate-500">{label}</div>
+      {sub && <div className="text-xs text-slate-400 mt-3">{sub}</div>}
     </div>
   )
 }
 
+function buildGrowthSeries(tenants) {
+  // Cumulative tenant count by month, last 6 months.
+  const now = new Date()
+  const months = []
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    months.push({
+      key: `${d.getFullYear()}-${d.getMonth()}`,
+      name: d.toLocaleString('en', { month: 'short' }),
+      end: new Date(d.getFullYear(), d.getMonth() + 1, 1),
+      value: 0,
+    })
+  }
+  for (const t of tenants) {
+    if (!t.created_at) continue
+    const created = new Date(t.created_at)
+    for (const m of months) {
+      if (created < m.end) m.value += 1
+    }
+  }
+  return months.map(({ name, value }) => ({ name, value }))
+}
+
 export default function Dashboard() {
   const [stats, setStats] = useState(null)
-  const [recent, setRecent] = useState([])
+  const [tenants, setTenants] = useState([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    Promise.all([fetchStats(), fetchTenants()])
+    Promise.all([fetchStats(), fetchTenants({ page_size: 200 })])
       .then(([s, t]) => {
         setStats(s)
-        setRecent((t.results || t).slice(0, 5))
+        setTenants(t.results || t)
       })
       .catch(() => toast.error('Failed to load dashboard'))
       .finally(() => setLoading(false))
   }, [])
+
+  const statusData = useMemo(() => {
+    if (!stats) return []
+    return [
+      { name: 'Active', value: stats.active_tenants ?? 0, color: CHART_COLORS.emerald },
+      { name: 'Inactive', value: stats.inactive_tenants ?? 0, color: CHART_COLORS.slate },
+      { name: 'Suspended', value: stats.suspended_tenants ?? 0, color: CHART_COLORS.rose },
+    ]
+  }, [stats])
+
+  const userData = useMemo(() => {
+    if (!stats) return []
+    return [
+      { name: 'Students', value: stats.total_students ?? 0, color: CHART_COLORS.indigo },
+      { name: 'Faculty', value: stats.total_instructors ?? 0, color: CHART_COLORS.sky },
+      { name: 'Admins', value: stats.total_admins ?? 0, color: CHART_COLORS.amber },
+    ]
+  }, [stats])
+
+  const planData = useMemo(() => {
+    if (!stats) return []
+    return PLAN_ORDER.map((key) => ({
+      name: PLAN_LABELS[key],
+      value: stats.plan_distribution?.[key] ?? 0,
+      color: PLAN_COLORS[key],
+    }))
+  }, [stats])
+
+  const growthData = useMemo(() => buildGrowthSeries(tenants), [tenants])
+
+  const topTenants = useMemo(
+    () =>
+      [...tenants]
+        .sort((a, b) => (b.student_count ?? 0) - (a.student_count ?? 0))
+        .slice(0, 6)
+        .map((t) => ({ name: t.name, value: t.student_count ?? 0 })),
+    [tenants]
+  )
+
+  const recent = useMemo(() => tenants.slice(0, 5), [tenants])
 
   if (loading) {
     return (
@@ -66,8 +143,12 @@ export default function Dashboard() {
     )
   }
 
+  const activePct = stats.total_tenants
+    ? Math.round((stats.active_tenants / stats.total_tenants) * 100)
+    : 0
+
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-slate-900">Platform Overview</h1>
         <p className="text-slate-500 text-sm mt-1">
@@ -75,41 +156,70 @@ export default function Dashboard() {
         </p>
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard icon={Building2} label="Total Tenants" value={stats.total_tenants} tone="brand" />
-        <StatCard icon={CheckCircle2} label="Active" value={stats.active_tenants} tone="green" />
-        <StatCard icon={XCircle} label="Inactive" value={stats.inactive_tenants} tone="red" />
-        <StatCard icon={AlertTriangle} label="Suspended" value={stats.suspended_tenants ?? 0} tone="amber" />
-        <StatCard icon={BookOpen} label="Courses" value={stats.total_courses} tone="amber" />
-        <StatCard icon={Users} label="Total Users" value={stats.total_users} tone="slate" />
-        <StatCard icon={GraduationCap} label="Students" value={stats.total_students} tone="brand" />
-        <StatCard icon={Users} label="Tenant Admins" value={stats.total_admins} tone="slate" />
-        <StatCard icon={Users} label="Faculty" value={stats.total_instructors} tone="slate" />
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard
+          icon={Building2}
+          label="Total Tenants"
+          value={stats.total_tenants}
+          sub={`${activePct}% active`}
+          tone="brand"
+        />
+        <KpiCard
+          icon={Users}
+          label="Total Users"
+          value={stats.total_users}
+          sub={`${stats.total_students} students · ${stats.total_instructors} faculty`}
+          tone="slate"
+        />
+        <KpiCard
+          icon={BookOpen}
+          label="Courses"
+          value={stats.total_courses}
+          sub="Across all tenants"
+          tone="amber"
+        />
+        <KpiCard
+          icon={CheckCircle2}
+          label="Active Tenants"
+          value={stats.active_tenants}
+          sub={`${stats.suspended_tenants ?? 0} suspended`}
+          tone="green"
+        />
       </div>
 
-      {/* Plans & at-risk */}
-      <div className="grid md:grid-cols-3 gap-4">
-        <div className="md:col-span-2 bg-white rounded-xl border border-slate-200 p-5">
-          <div className="flex items-center gap-2 mb-4">
-            <CreditCard className="w-4 h-4 text-brand-600" />
-            <h2 className="font-semibold text-slate-900">Plan Distribution</h2>
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {PLAN_ORDER.map((key) => (
-              <div key={key} className="rounded-lg bg-slate-50 border border-slate-100 p-3">
-                <div className="text-2xl font-bold text-slate-900">
-                  {stats.plan_distribution?.[key] ?? 0}
-                </div>
-                <div className="text-xs text-slate-500 capitalize">{PLAN_LABELS[key]}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="bg-white rounded-xl border border-slate-200 p-5">
-          <div className="flex items-center gap-2 mb-4">
-            <Gauge className="w-4 h-4 text-brand-600" />
-            <h2 className="font-semibold text-slate-900">Needs Attention</h2>
-          </div>
+      {/* Charts row */}
+      <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+        <ChartCard title="Tenant Status" icon={PieIcon}>
+          <DonutChart data={statusData} valueLabel="Tenants" centerLabel="tenants" />
+        </ChartCard>
+        <ChartCard title="User Composition" icon={UsersRound}>
+          <DonutChart data={userData} valueLabel="Users" centerLabel="users" />
+        </ChartCard>
+        <ChartCard title="Plan Distribution" icon={CreditCard} className="md:col-span-2 xl:col-span-1">
+          <BarChartCompact data={planData} valueLabel="Tenants" />
+        </ChartCard>
+      </div>
+
+      {/* Growth + top tenants */}
+      <div className="grid lg:grid-cols-3 gap-4">
+        <ChartCard title="Tenant Growth" icon={TrendingUp} className="lg:col-span-2">
+          <GrowthAreaChart data={growthData} valueLabel="Total tenants" />
+        </ChartCard>
+        <ChartCard title="Top Tenants by Students" icon={Trophy}>
+          {topTenants.some((t) => t.value > 0) ? (
+            <HBarChart data={topTenants} valueLabel="Students" />
+          ) : (
+            <div className="h-[220px] flex items-center justify-center text-sm text-slate-400">
+              No enrolled students yet.
+            </div>
+          )}
+        </ChartCard>
+      </div>
+
+      {/* Needs attention + recent */}
+      <div className="grid lg:grid-cols-3 gap-4">
+        <ChartCard title="Needs Attention" icon={Gauge}>
           <ul className="space-y-2.5 text-sm">
             <li className="flex items-center justify-between">
               <span className="text-slate-600">Over quota</span>
@@ -132,52 +242,52 @@ export default function Dashboard() {
               <span className="font-semibold text-brand-600">{stats.new_leads ?? 0}</span>
             </li>
             <li className="flex items-center justify-between">
-              <Link to="/announcements" className="text-slate-600 hover:text-brand-600">Active announcements</Link>
+              <Link to="/announcements" className="text-slate-600 hover:text-brand-600">
+                Active announcements
+              </Link>
               <span className="font-semibold text-slate-700">{stats.active_announcements ?? 0}</span>
             </li>
           </ul>
-        </div>
-      </div>
+        </ChartCard>
 
-      <div className="bg-white rounded-xl border border-slate-200">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100">
-          <h2 className="font-semibold text-slate-900">Recent Tenants</h2>
-          <Link
-            to="/tenants"
-            className="text-sm text-brand-600 hover:text-brand-700 font-medium flex items-center gap-1"
-          >
-            View all <ArrowRight className="w-4 h-4" />
-          </Link>
-        </div>
-        <ul className="divide-y divide-slate-100">
-          {recent.map((t) => (
-            <li key={t.id}>
-              <Link
-                to={`/tenants/${t.id}`}
-                className="flex items-center justify-between px-5 py-3.5 hover:bg-slate-50 transition"
-              >
-                <div>
-                  <div className="font-medium text-slate-900">{t.name}</div>
-                  <div className="text-xs text-slate-500">
-                    {t.subdomain || 'no subdomain'} · {t.student_count} students · {t.course_count} courses
-                  </div>
-                </div>
-                <span
-                  className={`text-xs font-medium px-2.5 py-1 rounded-full ${
-                    t.is_active
-                      ? 'bg-emerald-50 text-emerald-700'
-                      : 'bg-rose-50 text-rose-700'
-                  }`}
+        <div className="lg:col-span-2 bg-white rounded-xl border border-slate-200">
+          <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100">
+            <h2 className="font-semibold text-slate-900">Recent Tenants</h2>
+            <Link
+              to="/tenants"
+              className="text-sm text-brand-600 hover:text-brand-700 font-medium flex items-center gap-1"
+            >
+              View all <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
+          <ul className="divide-y divide-slate-100">
+            {recent.map((t) => (
+              <li key={t.id}>
+                <Link
+                  to={`/tenants/${t.id}`}
+                  className="flex items-center justify-between px-5 py-3.5 hover:bg-slate-50 transition"
                 >
-                  {t.is_active ? 'Active' : 'Inactive'}
-                </span>
-              </Link>
-            </li>
-          ))}
-          {recent.length === 0 && (
-            <li className="px-5 py-6 text-sm text-slate-400 text-center">No tenants yet.</li>
-          )}
-        </ul>
+                  <div>
+                    <div className="font-medium text-slate-900">{t.name}</div>
+                    <div className="text-xs text-slate-500">
+                      {t.subdomain || 'no subdomain'} · {t.student_count} students · {t.course_count} courses
+                    </div>
+                  </div>
+                  <span
+                    className={`text-xs font-medium px-2.5 py-1 rounded-full ${
+                      t.is_active ? 'bg-emerald-50 text-emerald-700' : 'bg-rose-50 text-rose-700'
+                    }`}
+                  >
+                    {t.is_active ? 'Active' : 'Inactive'}
+                  </span>
+                </Link>
+              </li>
+            ))}
+            {recent.length === 0 && (
+              <li className="px-5 py-6 text-sm text-slate-400 text-center">No tenants yet.</li>
+            )}
+          </ul>
+        </div>
       </div>
     </div>
   )

--- a/frontend/superadmin-frontend/src/pages/Support.jsx
+++ b/frontend/superadmin-frontend/src/pages/Support.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import {
   Inbox,
   Loader2,
@@ -7,10 +7,13 @@ import {
   Building,
   Briefcase,
   ExternalLink,
+  PieChart as PieIcon,
+  Activity,
 } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 import toast from 'react-hot-toast'
 import { fetchLeads, updateLead } from '../services/superadminService'
+import { ChartCard, MiniStat, DonutChart, CHART_COLORS } from '../components/charts'
 
 const TYPE_META = {
   demo: { label: 'Demo request', icon: Building, color: 'bg-indigo-50 text-indigo-700' },
@@ -195,6 +198,24 @@ export default function Support() {
 
   const counts = data.counts || {}
 
+  const totalLeads = (counts.demo ?? 0) + (counts.contact ?? 0) + (counts.job ?? 0)
+  const typeData = useMemo(
+    () => [
+      { name: 'Demo requests', value: counts.demo ?? 0, color: CHART_COLORS.indigo },
+      { name: 'Contact messages', value: counts.contact ?? 0, color: CHART_COLORS.sky },
+      { name: 'Job applications', value: counts.job ?? 0, color: CHART_COLORS.amber },
+    ],
+    [counts.demo, counts.contact, counts.job]
+  )
+  const statusData = useMemo(() => {
+    const bs = counts.by_status || {}
+    return [
+      { name: 'New', value: bs.new ?? counts.new ?? 0, color: CHART_COLORS.indigo },
+      { name: 'Contacted', value: bs.contacted ?? 0, color: CHART_COLORS.amber },
+      { name: 'Closed', value: bs.closed ?? 0, color: CHART_COLORS.slate },
+    ]
+  }, [counts.by_status, counts.new])
+
   return (
     <div className="space-y-6">
       <div>
@@ -205,6 +226,24 @@ export default function Support() {
           Demo requests, contact messages and job applications from the marketing site.
         </p>
       </div>
+
+      {/* Analytics */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <MiniStat icon={Inbox} label="Total Leads" value={totalLeads} tone="brand" />
+        <MiniStat icon={Building} label="Demo Requests" value={counts.demo ?? 0} tone="brand" />
+        <MiniStat icon={Briefcase} label="Job Applications" value={counts.job ?? 0} tone="amber" />
+        <MiniStat icon={Mail} label="Awaiting Response" value={counts.new ?? 0} tone="rose" />
+      </div>
+      {totalLeads > 0 && (
+        <div className="grid md:grid-cols-2 gap-4">
+          <ChartCard title="Leads by Type" icon={PieIcon}>
+            <DonutChart data={typeData} valueLabel="Leads" centerLabel="leads" height={180} />
+          </ChartCard>
+          <ChartCard title="Leads by Status" icon={Activity}>
+            <DonutChart data={statusData} valueLabel="Leads" centerLabel="leads" height={180} />
+          </ChartCard>
+        </div>
+      )}
 
       <div className="flex flex-wrap gap-3">
         <select value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)} className="py-2 px-3 rounded-lg border border-slate-200 text-sm bg-white">

--- a/frontend/superadmin-frontend/src/pages/Tenants.jsx
+++ b/frontend/superadmin-frontend/src/pages/Tenants.jsx
@@ -1,8 +1,24 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { Search, Plus, Loader2, Building2, X } from 'lucide-react'
+import {
+  Search, Plus, Loader2, Building2, X,
+  Users as UsersIcon, BookOpen, GraduationCap,
+  PieChart as PieIcon, CreditCard, Trophy,
+} from 'lucide-react'
 import toast from 'react-hot-toast'
 import { fetchTenants, createTenant } from '../services/superadminService'
+import {
+  ChartCard, MiniStat, DonutChart, BarChartCompact, HBarChart, CHART_COLORS,
+} from '../components/charts'
+
+const PLAN_ORDER = ['trial', 'starter', 'growth', 'enterprise']
+const PLAN_LABELS = { trial: 'Trial', starter: 'Starter', growth: 'Growth', enterprise: 'Enterprise' }
+const PLAN_COLORS = {
+  trial: CHART_COLORS.slate,
+  starter: CHART_COLORS.sky,
+  growth: CHART_COLORS.indigo,
+  enterprise: CHART_COLORS.violet,
+}
 
 const THEMES = [
   'sunrise', 'ocean', 'emerald', 'violet', 'rose',
@@ -122,6 +138,7 @@ function CreateTenantModal({ onClose, onCreated }) {
 
 export default function Tenants() {
   const [tenants, setTenants] = useState([])
+  const [allTenants, setAllTenants] = useState([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
   const [showCreate, setShowCreate] = useState(false)
@@ -134,14 +151,46 @@ export default function Tenants() {
       .finally(() => setLoading(false))
   }, [])
 
+  // A full, unfiltered snapshot powers the summary charts (search shouldn't move them).
+  const loadSnapshot = useCallback(() => {
+    fetchTenants({ page_size: 200 })
+      .then((data) => setAllTenants(data.results || data))
+      .catch(() => {})
+  }, [])
+
   useEffect(() => {
     load()
-  }, [load])
+    loadSnapshot()
+  }, [load, loadSnapshot])
 
   useEffect(() => {
     const t = setTimeout(() => load(search ? { search } : {}), 300)
     return () => clearTimeout(t)
   }, [search, load])
+
+  const summary = useMemo(() => {
+    const list = allTenants
+    const active = list.filter((t) => t.is_active && !t.is_suspended).length
+    const suspended = list.filter((t) => t.is_suspended).length
+    const inactive = list.filter((t) => !t.is_active && !t.is_suspended).length
+    const students = list.reduce((n, t) => n + (t.student_count ?? 0), 0)
+    const courses = list.reduce((n, t) => n + (t.course_count ?? 0), 0)
+    const planDist = PLAN_ORDER.map((key) => ({
+      name: PLAN_LABELS[key],
+      value: list.filter((t) => t.plan === key).length,
+      color: PLAN_COLORS[key],
+    }))
+    const statusData = [
+      { name: 'Active', value: active, color: CHART_COLORS.emerald },
+      { name: 'Inactive', value: inactive, color: CHART_COLORS.slate },
+      { name: 'Suspended', value: suspended, color: CHART_COLORS.rose },
+    ]
+    const topTenants = [...list]
+      .sort((a, b) => (b.student_count ?? 0) - (a.student_count ?? 0))
+      .slice(0, 6)
+      .map((t) => ({ name: t.name, value: t.student_count ?? 0 }))
+    return { total: list.length, students, courses, planDist, statusData, topTenants }
+  }, [allTenants])
 
   return (
     <div className="space-y-6">
@@ -157,6 +206,40 @@ export default function Tenants() {
           <Plus className="w-4 h-4" /> New Tenant
         </button>
       </div>
+
+      {/* Summary snapshot */}
+      {allTenants.length > 0 && (
+        <>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <MiniStat icon={Building2} label="Total Tenants" value={summary.total} tone="brand" />
+            <MiniStat icon={GraduationCap} label="Total Students" value={summary.students} tone="green" />
+            <MiniStat icon={BookOpen} label="Total Courses" value={summary.courses} tone="amber" />
+            <MiniStat
+              icon={UsersIcon}
+              label="Avg Students / Tenant"
+              value={summary.total ? Math.round(summary.students / summary.total) : 0}
+              tone="slate"
+            />
+          </div>
+          <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+            <ChartCard title="Status" icon={PieIcon}>
+              <DonutChart data={summary.statusData} valueLabel="Tenants" centerLabel="tenants" height={170} />
+            </ChartCard>
+            <ChartCard title="Plans" icon={CreditCard}>
+              <BarChartCompact data={summary.planDist} valueLabel="Tenants" height={180} />
+            </ChartCard>
+            <ChartCard title="Top by Students" icon={Trophy} className="md:col-span-2 xl:col-span-1">
+              {summary.topTenants.some((t) => t.value > 0) ? (
+                <HBarChart data={summary.topTenants} valueLabel="Students" height={180} />
+              ) : (
+                <div className="h-[180px] flex items-center justify-center text-sm text-slate-400">
+                  No enrolled students yet.
+                </div>
+              )}
+            </ChartCard>
+          </div>
+        </>
+      )}
 
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
@@ -235,6 +318,7 @@ export default function Tenants() {
           onCreated={() => {
             setShowCreate(false)
             load(search ? { search } : {})
+            loadSnapshot()
           }}
         />
       )}


### PR DESCRIPTION
## Summary

The super admin dashboard was a flat grid of numbers. This PR turns it into an interactive, charted UI (using **recharts**, themed to the indigo brand) across the **Dashboard**, **Tenants**, and **Support Inbox** pages.

## What changed

### Dashboard (`pages/Dashboard.jsx`)
- **KPI strip** — Total Tenants, Users, Courses, Active (with context sub-labels).
- **Tenant Status donut** (Active / Inactive / Suspended).
- **User Composition donut** (Students / Faculty / Admins).
- **Plan Distribution bar** (Trial / Starter / Growth / Enterprise).
- **Tenant Growth area chart** — cumulative tenants over the last 6 months, derived client-side from `created_at`.
- **Top Tenants by Students** — horizontal ranking.
- Kept **Needs Attention** and **Recent Tenants**, restyled.

### Tenants (`pages/Tenants.jsx`)
- Summary snapshot above the table — loaded from a **full unfiltered fetch** so the search box doesn't move the charts.
- Mini stats (Total Tenants, Total Students, Total Courses, Avg Students/Tenant) + Status donut, Plan bar, Top-by-Students chart.

### Support Inbox (`pages/Support.jsx`)
- Mini stats (Total Leads, Demo Requests, Job Applications, Awaiting Response).
- **Leads by Type** and **Leads by Status** donuts.

### Shared
- New reusable chart primitives in `components/charts.jsx`: `ChartCard`, `MiniStat`, `DonutChart`, `BarChartCompact`, `HBarChart`, `GrowthAreaChart`.

### Backend (`core/superadmin_views.py`)
- `LeadListView` now returns `counts.by_status` (`new` / `contacted` / `closed`) to power the Support status donut. **Backward-compatible** — the frontend falls back gracefully if absent; the donut becomes fully accurate once the backend is deployed.

## Data sources
All charts read from existing endpoints (`/superadmin/stats/`, `/superadmin/tenants/`, `/superadmin/leads/`) plus the small additive `by_status` field. No schema/migration changes.

## Testing
- `npm run build` (superadmin-frontend) passes.
- `manage.py check` passes; `superadmin_views.py` compiles clean.
- Previewed locally against the live API.

## Deploy note
The frontend auto-deploys via Netlify. The `by_status` field needs the **backend redeployed** for the Support status donut to be exact (it shows New accurately and 0s for contacted/closed until then).