### PR TITLE
Make login screen panel content configurable per tenant

### DIFF
--- a/backend/core/admin_serializers.py
+++ b/backend/core/admin_serializers.py
@@ -104,6 +104,8 @@ class TenantSettingsSerializer(serializers.ModelSerializer):
             cleaned['stats'] = cleaned_stats
 
         return cleaned
+
+    def validate(self, attrs):
         # Paid courses may only skip the request/approve flow when an active
         # payment gateway is configured — otherwise there is no way to collect
         # payment. Free courses are independent and can be toggled freely.

--- a/backend/core/admin_serializers.py
+++ b/backend/core/admin_serializers.py
@@ -13,6 +13,7 @@ class TenantSettingsSerializer(serializers.ModelSerializer):
     """
 
     features = serializers.JSONField(required=False)
+    auth_panel = serializers.JSONField(required=False)
     logo = serializers.ImageField(required=False, allow_null=True)
     favicon = serializers.ImageField(required=False, allow_null=True)
 
@@ -20,7 +21,7 @@ class TenantSettingsSerializer(serializers.ModelSerializer):
         model = Tenant
         fields = [
             'id', 'name', 'tagline', 'subdomain', 'logo', 'favicon', 'theme',
-            'show_name', 'features',
+            'show_name', 'features', 'auth_panel',
             'request_enrollment_free', 'request_enrollment_paid',
         ]
         read_only_fields = ['id', 'subdomain']
@@ -61,7 +62,48 @@ class TenantSettingsSerializer(serializers.ModelSerializer):
             )
         return cleaned
 
-    def validate(self, attrs):
+    def validate_auth_panel(self, value):
+        """Sanitise the login/register branding panel content.
+
+        Accepts ``{heading, heading_highlight, subtitle, stats}``. Unknown keys
+        are dropped, text is trimmed, and ``stats`` is capped to a short list of
+        ``{value, label}`` pairs so a tenant can't inject arbitrary structures.
+        """
+        if not isinstance(value, dict):
+            raise serializers.ValidationError(
+                'auth_panel must be an object.'
+            )
+
+        cleaned = {}
+        for key in ('heading', 'heading_highlight', 'subtitle'):
+            if key in value:
+                text = value.get(key)
+                if text is None:
+                    text = ''
+                if not isinstance(text, str):
+                    raise serializers.ValidationError(
+                        f'{key} must be text.'
+                    )
+                cleaned[key] = text.strip()[:255]
+
+        if 'stats' in value:
+            stats = value.get('stats') or []
+            if not isinstance(stats, list):
+                raise serializers.ValidationError(
+                    'stats must be a list of {value, label} items.'
+                )
+            cleaned_stats = []
+            for item in stats[:4]:
+                if not isinstance(item, dict):
+                    continue
+                stat_value = str(item.get('value', '')).strip()[:32]
+                stat_label = str(item.get('label', '')).strip()[:48]
+                if not stat_value and not stat_label:
+                    continue
+                cleaned_stats.append({'value': stat_value, 'label': stat_label})
+            cleaned['stats'] = cleaned_stats
+
+        return cleaned
         # Paid courses may only skip the request/approve flow when an active
         # payment gateway is configured — otherwise there is no way to collect
         # payment. Free courses are independent and can be toggled freely.
@@ -116,6 +158,9 @@ class TenantSettingsSerializer(serializers.ModelSerializer):
         features = validated_data.pop('features', None)
         if features is not None:
             instance.features = {**(instance.features or {}), **features}
+        auth_panel = validated_data.pop('auth_panel', None)
+        if auth_panel is not None:
+            instance.auth_panel = {**(instance.auth_panel or {}), **auth_panel}
         return super().update(instance, validated_data)
 
 

--- a/backend/core/migrations/0017_tenant_auth_panel.py
+++ b/backend/core/migrations/0017_tenant_auth_panel.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0016_tenant_allowed_origins_platformannouncement'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='tenant',
+            name='auth_panel',
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -104,6 +104,14 @@ class Tenant(models.Model):
     # When False, the frontend hides the text name and shows the logo alone
     # (full-width) — useful when the logo already contains the institution name.
     show_name = models.BooleanField(default=True)
+
+    # Editable content for the branding panel on the login/register screens
+    # (the left-hand marketing column of the auth pages). Shape:
+    #   {heading, heading_highlight, subtitle, stats: [{value, label}, ...]}
+    # An empty dict means "use the platform's generic defaults" — the frontend
+    # merges any provided keys over those defaults, so tenants only override
+    # what they care about.
+    auth_panel = models.JSONField(default=dict, blank=True)
     is_active = models.BooleanField(default=True)
 
     # Per-tenant feature toggles: {feature_key: bool}. Missing keys default to

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -74,6 +74,7 @@ class TenantDetailView(APIView):
                 "favicon": request.build_absolute_uri(tenant.favicon.url) if tenant.favicon else None,
                 "theme": tenant.theme or Tenant.DEFAULT_THEME,
                 "show_name": tenant.show_name,
+                "auth_panel": tenant.auth_panel or {},
                 "features": tenant.get_features(),
                 "is_suspended": tenant.is_suspended,
                 "suspension_message": tenant.suspension_message,

--- a/frontend/exam-frontend/src/components/layout/AuthLayout.jsx
+++ b/frontend/exam-frontend/src/components/layout/AuthLayout.jsx
@@ -1,11 +1,13 @@
 import { Outlet } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useTenantStore } from '../../context/tenantStore'
+import { resolveAuthPanel } from '../../config/authPanel'
 
 const AuthLayout = () => {
   const { tenant } = useTenantStore()
   const tenantName = tenant?.name || 'DailyTaiyari'
   const tenantInitials = tenantName.substring(0, 2).toLowerCase()
+  const panel = resolveAuthPanel(tenant?.auth_panel)
 
   return (
     <div className="min-h-screen flex">
@@ -57,30 +59,25 @@ const AuthLayout = () => {
 
             {/* Tagline */}
             <h2 className="text-4xl font-display font-bold mb-4 leading-tight">
-              Your Daily Dose of<br />
-              <span className="text-white/90">Exam Success</span>
+              {panel.heading}<br />
+              <span className="text-white/90">{panel.heading_highlight}</span>
             </h2>
 
             <p className="text-white/80 text-lg mb-8 max-w-md">
-              Join thousands of students preparing for NEET and IIT JEE
-              with personalized study plans and AI-powered learning.
+              {panel.subtitle}
             </p>
 
             {/* Stats */}
-            <div className="flex gap-8">
-              <div>
-                <div className="text-3xl font-bold">50K+</div>
-                <div className="text-white/70">Students</div>
+            {panel.stats.length > 0 && (
+              <div className="flex gap-8">
+                {panel.stats.map((stat, i) => (
+                  <div key={i}>
+                    <div className="text-3xl font-bold">{stat.value}</div>
+                    <div className="text-white/70">{stat.label}</div>
+                  </div>
+                ))}
               </div>
-              <div>
-                <div className="text-3xl font-bold">100K+</div>
-                <div className="text-white/70">Questions</div>
-              </div>
-              <div>
-                <div className="text-3xl font-bold">95%</div>
-                <div className="text-white/70">Success Rate</div>
-              </div>
-            </div>
+            )}
           </motion.div>
         </div>
 

--- a/frontend/exam-frontend/src/config/authPanel.js
+++ b/frontend/exam-frontend/src/config/authPanel.js
@@ -1,0 +1,38 @@
+// Generic, brand-neutral defaults for the marketing panel shown on the
+// left-hand side of the login / register screens (see AuthLayout.jsx).
+//
+// A tenant admin can override any of these from Admin → Settings → General.
+// Only the keys they set are stored; everything else falls back to the values
+// here, so the auth screens always look complete out of the box.
+export const DEFAULT_AUTH_PANEL = {
+    heading: 'Your Learning Journey',
+    heading_highlight: 'Starts Here',
+    subtitle:
+        'Join a community of motivated learners with structured courses, '
+        + 'practice tests and personalised, AI-powered learning.',
+    stats: [],
+}
+
+// Merge a tenant's stored auth_panel (which may be empty or partial) over the
+// generic defaults so callers always get a complete, safe object to render.
+export const resolveAuthPanel = (panel) => {
+    const p = panel && typeof panel === 'object' ? panel : {}
+    const stats = Array.isArray(p.stats) ? p.stats : DEFAULT_AUTH_PANEL.stats
+    return {
+        heading:
+            typeof p.heading === 'string' && p.heading.trim()
+                ? p.heading
+                : DEFAULT_AUTH_PANEL.heading,
+        heading_highlight:
+            typeof p.heading_highlight === 'string' && p.heading_highlight.trim()
+                ? p.heading_highlight
+                : DEFAULT_AUTH_PANEL.heading_highlight,
+        subtitle:
+            typeof p.subtitle === 'string' && p.subtitle.trim()
+                ? p.subtitle
+                : DEFAULT_AUTH_PANEL.subtitle,
+        stats: stats
+            .filter((s) => s && (s.value || s.label))
+            .map((s) => ({ value: s.value || '', label: s.label || '' })),
+    }
+}

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -8,6 +8,7 @@ import { tenantAdminService } from '../services/tenantAdminService'
 import { courseService } from '../services/courseService'
 import { useTenantStore } from '../context/tenantStore'
 import { THEME_LIST, applyTheme, DEFAULT_THEME } from '../config/themes'
+import { DEFAULT_AUTH_PANEL } from '../config/authPanel'
 import CourseBuilder from '../components/admin/CourseBuilder'
 import LandingBuilder from '../components/admin/LandingBuilder'
 import MarketingPromotions from '../components/admin/MarketingPromotions'
@@ -65,6 +66,7 @@ import {
     ShoppingCart,
     Megaphone,
     UserPlus,
+    Plus,
     ArrowUpRight,
     ArrowDownRight,
     Minus,
@@ -1915,6 +1917,7 @@ const TenantSettings = () => {
     const [features, setFeatures] = useState({})
     const [name, setName] = useState('')
     const [tagline, setTagline] = useState('')
+    const [authPanel, setAuthPanel] = useState({ heading: '', heading_highlight: '', subtitle: '', stats: [] })
     const [subTab, setSubTab] = useState('general')
 
     useEffect(() => {
@@ -1922,6 +1925,13 @@ const TenantSettings = () => {
         if (settings) {
             setName(settings.name || '')
             setTagline(settings.tagline || '')
+            const ap = settings.auth_panel || {}
+            setAuthPanel({
+                heading: ap.heading || '',
+                heading_highlight: ap.heading_highlight || '',
+                subtitle: ap.subtitle || '',
+                stats: Array.isArray(ap.stats) ? ap.stats.map((s) => ({ value: s.value || '', label: s.label || '' })) : [],
+            })
         }
     }, [settings])
 
@@ -1954,6 +1964,16 @@ const TenantSettings = () => {
             toast.success('Branding updated')
         },
         onError: () => toast.error('Failed to update branding'),
+    })
+
+    const authPanelMutation = useMutation({
+        mutationFn: (payload) => tenantAdminService.updateAuthPanel(payload),
+        onSuccess: (data) => {
+            queryClient.setQueryData(['tenantSettings'], data)
+            fetchTenantConfig()
+            toast.success('Login screen updated')
+        },
+        onError: () => toast.error('Failed to update login screen'),
     })
 
     const logoMutation = useMutation({
@@ -2032,6 +2052,35 @@ const TenantSettings = () => {
 
     const brandingDirty =
         name.trim() !== (settings?.name || '') || tagline.trim() !== (settings?.tagline || '')
+
+    const updateAuthStat = (index, field, value) => {
+        setAuthPanel((prev) => {
+            const stats = prev.stats.map((s, i) => (i === index ? { ...s, [field]: value } : s))
+            return { ...prev, stats }
+        })
+    }
+
+    const addAuthStat = () => {
+        setAuthPanel((prev) => {
+            if (prev.stats.length >= 4) return prev
+            return { ...prev, stats: [...prev.stats, { value: '', label: '' }] }
+        })
+    }
+
+    const removeAuthStat = (index) => {
+        setAuthPanel((prev) => ({ ...prev, stats: prev.stats.filter((_, i) => i !== index) }))
+    }
+
+    const saveAuthPanel = () => {
+        authPanelMutation.mutate({
+            heading: authPanel.heading.trim(),
+            heading_highlight: authPanel.heading_highlight.trim(),
+            subtitle: authPanel.subtitle.trim(),
+            stats: authPanel.stats
+                .map((s) => ({ value: (s.value || '').trim(), label: (s.label || '').trim() }))
+                .filter((s) => s.value || s.label),
+        })
+    }
 
     const handleLogoChange = (e) => {
         const file = e.target.files?.[0]
@@ -2128,6 +2177,105 @@ const TenantSettings = () => {
                         className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-primary-500 hover:bg-primary-600 text-white text-sm font-semibold transition-colors disabled:opacity-60"
                     >
                         {brandingMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                        Save Changes
+                    </button>
+                </div>
+            </div>
+
+            {/* Login screen panel — heading, subtitle & stats */}
+            <div className="card p-6 space-y-4">
+                <div className="flex items-center gap-2">
+                    <ImageIcon className="w-5 h-5 text-primary-500" />
+                    <h3 className="text-lg font-bold text-surface-900 dark:text-white">Login Screen</h3>
+                </div>
+                <p className="text-sm text-surface-500">Customise the welcome panel students see on the login and register pages. Leave any field blank to use the default text.</p>
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                        <label className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1.5">Heading</label>
+                        <input
+                            type="text"
+                            value={authPanel.heading}
+                            onChange={(e) => setAuthPanel((p) => ({ ...p, heading: e.target.value }))}
+                            maxLength={255}
+                            placeholder={DEFAULT_AUTH_PANEL.heading}
+                            className="w-full px-3.5 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 text-surface-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        />
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1.5">Highlighted heading</label>
+                        <input
+                            type="text"
+                            value={authPanel.heading_highlight}
+                            onChange={(e) => setAuthPanel((p) => ({ ...p, heading_highlight: e.target.value }))}
+                            maxLength={255}
+                            placeholder={DEFAULT_AUTH_PANEL.heading_highlight}
+                            className="w-full px-3.5 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 text-surface-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                        />
+                    </div>
+                </div>
+                <div>
+                    <label className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-1.5">Subtitle</label>
+                    <textarea
+                        value={authPanel.subtitle}
+                        onChange={(e) => setAuthPanel((p) => ({ ...p, subtitle: e.target.value }))}
+                        maxLength={255}
+                        rows={2}
+                        placeholder={DEFAULT_AUTH_PANEL.subtitle}
+                        className="w-full px-3.5 py-2.5 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 text-surface-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    />
+                </div>
+                <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                        <label className="block text-sm font-medium text-surface-700 dark:text-surface-300">Highlight stats <span className="text-surface-400 font-normal">(optional, up to 4)</span></label>
+                        {authPanel.stats.length < 4 && (
+                            <button
+                                type="button"
+                                onClick={addAuthStat}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-500/10 transition-colors"
+                            >
+                                <Plus className="w-4 h-4" /> Add stat
+                            </button>
+                        )}
+                    </div>
+                    {authPanel.stats.length === 0 && (
+                        <p className="text-sm text-surface-400">No stats shown. Add a few (e.g. “10,000+ Students”) to display them on the login screen.</p>
+                    )}
+                    {authPanel.stats.map((stat, i) => (
+                        <div key={i} className="flex items-center gap-2">
+                            <input
+                                type="text"
+                                value={stat.value}
+                                onChange={(e) => updateAuthStat(i, 'value', e.target.value)}
+                                maxLength={32}
+                                placeholder="10,000+"
+                                className="w-32 px-3 py-2 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 text-surface-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                            />
+                            <input
+                                type="text"
+                                value={stat.label}
+                                onChange={(e) => updateAuthStat(i, 'label', e.target.value)}
+                                maxLength={48}
+                                placeholder="Students"
+                                className="flex-1 px-3 py-2 rounded-xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900 text-surface-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                            />
+                            <button
+                                type="button"
+                                onClick={() => removeAuthStat(i)}
+                                className="p-2 rounded-lg text-surface-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
+                                aria-label="Remove stat"
+                            >
+                                <Trash2 className="w-4 h-4" />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+                <div className="flex justify-end">
+                    <button
+                        onClick={saveAuthPanel}
+                        disabled={authPanelMutation.isPending}
+                        className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-primary-500 hover:bg-primary-600 text-white text-sm font-semibold transition-colors disabled:opacity-60"
+                    >
+                        {authPanelMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
                         Save Changes
                     </button>
                 </div>

--- a/frontend/exam-frontend/src/services/tenantAdminService.js
+++ b/frontend/exam-frontend/src/services/tenantAdminService.js
@@ -62,6 +62,12 @@ export const tenantAdminService = {
         return response.data
     },
 
+    // Login/register marketing panel content (heading, subtitle, stats).
+    updateAuthPanel: async (authPanel) => {
+        const response = await api.patch('/tenant-admin/settings/', { auth_panel: authPanel })
+        return response.data
+    },
+
     updateTheme: async (theme) => {
         const response = await api.patch('/tenant-admin/settings/', { theme })
         return response.data


### PR DESCRIPTION
## What & why

The left-hand marketing panel on the login/register screens (`AuthLayout`) had hardcoded, exam-specific copy — "Your Daily Dose of Exam Success", a NEET/IIT JEE subtitle, and fabricated `50K+ / 100K+ / 95%` stats. This makes it generic by default and lets each tenant customise it from **Admin → Settings → General**.

## Changes

**Backend**
- New `Tenant.auth_panel` JSONField (`{heading, heading_highlight, subtitle, stats[]}`) + migration `0017_tenant_auth_panel`.
- Public tenant config (`TenantDetailView`) now returns `auth_panel`.
- `TenantSettingsSerializer` accepts & sanitises `auth_panel` (trims text, caps stats at 4 `{value, label}` pairs) and merges partial updates onto the stored dict.

**Frontend**
- New `config/authPanel.js` — brand-neutral defaults (`Your Learning Journey / Starts Here`, generic subtitle, no fake stats) + a `resolveAuthPanel` merge helper.
- `AuthLayout.jsx` renders from the tenant's `auth_panel` merged over defaults; the stats row is hidden when empty.
- `AdminDashboard` gains a **"Login Screen"** settings card: heading, highlighted heading, subtitle, and add/edit/remove stats. Placeholders show the defaults; blank fields fall back to them.
- `tenantAdminService.updateAuthPanel` wired to the existing settings PATCH endpoint.

## Notes / deploy
- Requires running the DB migration in production (backend deploy).
- Verified: frontend `vite build` passes; backend files compile clean.