### PR TITLE
feat(landing): creator-first marketing site redesign

### DIFF
--- a/backend/core/migrations/0018_alter_demobooking_organization_type.py
+++ b/backend/core/migrations/0018_alter_demobooking_organization_type.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0017_tenant_auth_panel'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='demobooking',
+            name='organization_type',
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ('creator', 'Independent Creator'),
+                    ('coaching', 'Coaching Institute'),
+                    ('school', 'School'),
+                    ('college', 'College'),
+                    ('edtech', 'EdTech / Online Academy'),
+                    ('other', 'Other'),
+                ],
+                max_length=20,
+            ),
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -575,9 +575,11 @@ class PlatformLead(models.Model):
 class DemoBooking(PlatformLead):
     """A 'Book a Demo' request submitted from the marketing site."""
     ORG_TYPE_CHOICES = [
+        ('creator', 'Independent Creator'),
         ('coaching', 'Coaching Institute'),
         ('school', 'School'),
         ('college', 'College'),
+        ('edtech', 'EdTech / Online Academy'),
         ('other', 'Other'),
     ]
 

--- a/frontend/landing-page/main/src/app/globals.css
+++ b/frontend/landing-page/main/src/app/globals.css
@@ -110,3 +110,20 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans);
 }
+
+/* Seamless infinite auto-scroll marquees (see components/creators/Marquee.tsx).
+   The track holds two identical copies, so translating by -50% loops with no
+   visible seam. */
+@keyframes dt-marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@keyframes dt-marquee-reverse {
+  from { transform: translateX(-50%); }
+  to { transform: translateX(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [style*="dt-marquee"] {
+    animation: none !important;
+  }
+}

--- a/frontend/landing-page/main/src/app/page.tsx
+++ b/frontend/landing-page/main/src/app/page.tsx
@@ -1,28 +1,37 @@
-import InstituteNav from "@/components/institutes/InstituteNav";
-import InstituteFooter from "@/components/institutes/InstituteFooter";
-import Hero from "@/components/institutes/Hero";
+import CreatorNav from "@/components/creators/CreatorNav";
+import CreatorHero from "@/components/creators/CreatorHero";
+import {
+  PlatformsMarquee,
+  ImpactStats,
+  StudentExperience,
+  CreatorConsole,
+  HowItWorks,
+  CourseShowcase,
+  TestimonialsMarquee,
+  Audience,
+  FinalCTA,
+} from "@/components/creators/CreatorSections";
+import Pricing from "@/components/institutes/Pricing";
 import FAQ from "@/components/institutes/FAQ";
-import ProductTour from "@/components/institutes/ProductTour";
+import InstituteFooter from "@/components/institutes/InstituteFooter";
 import JsonLd from "@/components/institutes/JsonLd";
 import LeadDialogs from "@/components/institutes/LeadDialogs";
-import Pricing from "@/components/institutes/Pricing";
-import { Audience, Pillars, Hooks, OfflineBatches, Features, HowItWorks, Grow, FinalCTA } from "@/components/institutes/Sections";
 
 export default function Home() {
   return (
     <>
       <JsonLd />
-      <InstituteNav />
+      <CreatorNav />
       <main className="flex-1 flex flex-col">
-        <Hero />
-        <Hooks />
-        <Audience />
-        <Pillars />
-        <ProductTour />
-        <OfflineBatches />
-        <Features />
+        <CreatorHero />
+        <PlatformsMarquee />
+        <ImpactStats />
+        <StudentExperience />
+        <CreatorConsole />
+        <CourseShowcase />
         <HowItWorks />
-        <Grow />
+        <TestimonialsMarquee />
+        <Audience />
         <Pricing />
         <FAQ />
         <FinalCTA />

--- a/frontend/landing-page/main/src/components/creators/BrandIcons.tsx
+++ b/frontend/landing-page/main/src/components/creators/BrandIcons.tsx
@@ -1,0 +1,58 @@
+import type { SVGProps } from "react";
+
+/**
+ * Minimal brand glyphs as inline SVGs. This project's lucide-react version does
+ * not ship brand icons, so we provide recognizable platform marks here. Each
+ * accepts standard SVG props (className, etc.) and uses currentColor.
+ */
+type IconProps = SVGProps<SVGSVGElement> & { className?: string };
+
+export function Youtube({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true" {...props}>
+      <path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8ZM9.6 15.6V8.4l6.2 3.6-6.2 3.6Z" />
+    </svg>
+  );
+}
+
+export function Instagram({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true" {...props}>
+      <rect x="2" y="2" width="20" height="20" rx="5" />
+      <circle cx="12" cy="12" r="4" />
+      <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+    </svg>
+  );
+}
+
+export function Linkedin({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true" {...props}>
+      <path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.42v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.46v6.28ZM5.34 7.43a2.07 2.07 0 1 1 0-4.14 2.07 2.07 0 0 1 0 4.14ZM7.12 20.45H3.56V9h3.56v11.45ZM22.22 0H1.77C.79 0 0 .77 0 1.73v20.54C0 23.23.79 24 1.77 24h20.45C23.2 24 24 23.23 24 22.27V1.73C24 .77 23.2 0 22.22 0Z" />
+    </svg>
+  );
+}
+
+export function Telegram({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true" {...props}>
+      <path d="M21.94 4.3 18.6 20.02c-.25 1.11-.9 1.38-1.82.86l-5.03-3.7-2.43 2.34c-.27.27-.5.5-1.01.5l.36-5.12L16.9 7.4c.4-.36-.09-.56-.63-.2L6.75 13.1l-4.96-1.55c-1.08-.34-1.1-1.08.23-1.6L20.53 2.7c.9-.34 1.68.2 1.4 1.6Z" />
+    </svg>
+  );
+}
+
+export function Whatsapp({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true" {...props}>
+      <path d="M12.04 2C6.58 2 2.13 6.45 2.13 11.9c0 1.76.46 3.45 1.34 4.95L2 22l5.3-1.39a9.9 9.9 0 0 0 4.74 1.2h.01c5.46 0 9.9-4.44 9.9-9.9 0-2.64-1.03-5.13-2.9-7C17.18 3.03 14.68 2 12.04 2Zm5.8 14.15c-.24.68-1.4 1.3-1.94 1.34-.5.05-.97.24-3.26-.68-2.75-1.08-4.5-3.87-4.64-4.05-.14-.18-1.12-1.49-1.12-2.84s.71-2.02.96-2.29c.25-.27.55-.34.73-.34.18 0 .37 0 .53.01.17.01.4-.06.62.48.24.55.79 1.9.86 2.04.07.14.12.3.02.48-.09.18-.14.3-.28.46-.14.16-.29.36-.42.48-.14.14-.28.28-.12.55.16.27.72 1.18 1.54 1.92 1.06.94 1.95 1.24 2.22 1.38.27.14.43.12.59-.07.16-.18.68-.79.86-1.06.18-.27.36-.23.61-.14.25.09 1.59.75 1.86.89.27.14.45.2.52.32.07.11.07.66-.17 1.34Z" />
+    </svg>
+  );
+}
+
+export function Facebook({ className, ...props }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true" {...props}>
+      <path d="M24 12.07C24 5.4 18.63 0 12 0S0 5.4 0 12.07C0 18.1 4.39 23.1 10.13 24v-8.44H7.08v-3.49h3.05V9.41c0-3.02 1.79-4.69 4.53-4.69 1.31 0 2.68.24 2.68.24v2.97h-1.51c-1.49 0-1.96.93-1.96 1.89v2.25h3.33l-.53 3.49h-2.8V24C19.61 23.1 24 18.1 24 12.07Z" />
+    </svg>
+  );
+}

--- a/frontend/landing-page/main/src/components/creators/CreatorHero.tsx
+++ b/frontend/landing-page/main/src/components/creators/CreatorHero.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  Sparkles,
+  BadgeCheck,
+  Wallet,
+  Play,
+} from "lucide-react";
+import { Youtube, Instagram, Linkedin, Telegram } from "./BrandIcons";
+import Typewriter from "../institutes/Typewriter";
+import { openLeadDialog } from "@/lib/leads";
+
+export default function CreatorHero() {
+  return (
+    <section className="relative overflow-hidden bg-surface-50 dark:bg-surface-950 pt-16 pb-24">
+      {/* Animated background blobs */}
+      <div className="absolute inset-0 pointer-events-none opacity-40 dark:opacity-25">
+        <div className="absolute -top-10 -left-24 w-[30rem] h-[30rem] bg-primary-400 rounded-full blur-[130px] animate-pulse-slow" />
+        <div className="absolute bottom-0 right-0 w-[30rem] h-[30rem] bg-accent-400 rounded-full blur-[130px] animate-pulse-slow" />
+        <div className="absolute top-1/3 left-1/2 w-72 h-72 bg-success-400 rounded-full blur-[120px] animate-pulse-slow" />
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-14 items-center">
+          {/* Copy */}
+          <div className="text-center lg:text-left flex flex-col items-center lg:items-start space-y-6">
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 font-semibold text-sm"
+            >
+              <Sparkles className="w-4 h-4" />
+              <span>Best for Creators &amp; Coaching Institutes</span>
+            </motion.div>
+
+            <motion.h1
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.05 }}
+              className="text-4xl sm:text-5xl lg:text-6xl font-display font-bold leading-[1.08] text-surface-900 dark:text-white"
+            >
+              Sell your knowledge online —{" "}
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-accent-500">
+                on your own branded website
+              </span>
+            </motion.h1>
+
+            <motion.p
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.08 }}
+              className="text-lg sm:text-xl font-semibold text-primary-600 dark:text-primary-400"
+            >
+              Start your online learning portal in minutes — with us.
+            </motion.p>
+
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.1 }}
+              className="text-2xl sm:text-3xl font-display font-semibold text-surface-800 dark:text-surface-100 min-h-[2.5rem]"
+            >
+              Built for{" "}
+              <Typewriter
+                words={[
+                  "Online Creators",
+                  "Coaching Institutes",
+                  "Schools & Colleges",
+                ]}
+                className="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-accent-500"
+              />
+            </motion.div>
+
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.15 }}
+              className="text-lg lg:text-xl text-surface-600 dark:text-surface-400 max-w-2xl"
+            >
+              Turn your audience into income. Launch structured courses, test series and
+              live cohorts on your own domain — with AI-assisted course &amp; content creation,
+              an AI doubt-solving tutor, payments, certificates and analytics built in. No
+              code, no middleman.
+            </motion.p>
+
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.25 }}
+              className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto"
+            >
+              <button
+                onClick={() => openLeadDialog("demo")}
+                className="px-8 py-4 bg-primary-600 hover:bg-primary-700 text-white rounded-xl font-bold text-lg shadow-glow transition-all hover:scale-105 active:scale-95 flex items-center justify-center gap-2"
+              >
+                Book a Demo <ArrowRight className="w-5 h-5" />
+              </button>
+              <button
+                onClick={() => openLeadDialog("contact")}
+                className="px-8 py-4 bg-white dark:bg-surface-800 border-2 border-surface-200 dark:border-surface-700 hover:border-primary-500 text-surface-900 dark:text-white rounded-xl font-bold text-lg transition-all hover:scale-105 text-center flex items-center justify-center gap-2"
+              >
+                <Play className="w-5 h-5" /> Start Selling
+              </button>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.6, delay: 0.35 }}
+              className="flex flex-wrap items-center justify-center lg:justify-start gap-x-5 gap-y-2 pt-1 text-sm text-surface-500 dark:text-surface-400 font-medium"
+            >
+              <span className="flex items-center gap-2">
+                <BadgeCheck className="w-4 h-4 text-success-500" /> Your brand, your domain
+              </span>
+              <span className="flex items-center gap-2">
+                <Wallet className="w-4 h-4 text-primary-500" /> Keep your earnings
+              </span>
+              <span className="flex items-center gap-2">
+                <Sparkles className="w-4 h-4 text-accent-500" /> AI tutor included
+              </span>
+            </motion.div>
+          </div>
+
+          {/* Branded creator site mockup */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 24 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ duration: 0.7, delay: 0.2 }}
+            className="relative mx-auto w-full max-w-lg lg:max-w-none"
+          >
+            <div className="rounded-3xl overflow-hidden shadow-2xl border border-surface-200 dark:border-surface-700 bg-white dark:bg-surface-900">
+              {/* Browser chrome with the creator's own domain */}
+              <div className="flex items-center gap-2 px-4 py-3 bg-surface-100 dark:bg-surface-800 border-b border-surface-200 dark:border-surface-700">
+                <span className="w-3 h-3 rounded-full bg-error-400" />
+                <span className="w-3 h-3 rounded-full bg-warning-400" />
+                <span className="w-3 h-3 rounded-full bg-success-400" />
+                <div className="ml-3 flex-1 h-6 rounded-md bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-700 flex items-center px-3">
+                  <span className="text-[11px] text-surface-500 font-mono truncate">
+                    learn.yourbrand.com
+                  </span>
+                </div>
+              </div>
+
+              {/* Creator storefront body */}
+              <div className="p-5 space-y-4">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary-500 to-accent-500" />
+                    <div>
+                      <div className="h-2.5 w-24 rounded bg-surface-200 dark:bg-surface-700" />
+                      <div className="mt-1 h-2 w-16 rounded bg-surface-100 dark:bg-surface-800" />
+                    </div>
+                  </div>
+                  <div className="h-7 w-16 rounded-lg bg-primary-100 dark:bg-primary-900/40" />
+                </div>
+
+                {/* Featured course card */}
+                <div className="rounded-2xl border border-surface-200 dark:border-surface-800 overflow-hidden">
+                  <div className="h-20 bg-gradient-to-r from-primary-500 via-accent-500 to-primary-500 [background-size:200%_200%] animate-gradient" />
+                  <div className="p-3">
+                    <div className="h-2.5 w-32 rounded bg-surface-200 dark:bg-surface-700" />
+                    <div className="mt-2 flex items-center justify-between">
+                      <div className="h-2 w-20 rounded bg-surface-100 dark:bg-surface-800" />
+                      <div className="text-[11px] font-bold text-success-600 dark:text-success-400">
+                        ₹2,999
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Course grid */}
+                <div className="grid grid-cols-2 gap-3">
+                  {[
+                    "from-primary-500 to-primary-600",
+                    "from-accent-500 to-accent-600",
+                    "from-success-500 to-success-600",
+                    "from-warning-500 to-accent-600",
+                  ].map((c, i) => (
+                    <div
+                      key={i}
+                      className="rounded-xl border border-surface-200 dark:border-surface-800 p-2"
+                    >
+                      <div className={`h-10 rounded-lg bg-gradient-to-br ${c} mb-2`} />
+                      <div className="h-2 w-full rounded bg-surface-200 dark:bg-surface-700" />
+                      <div className="mt-1 h-2 w-2/3 rounded bg-surface-100 dark:bg-surface-800" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Floating badges */}
+            <motion.div
+              animate={{ y: [0, -10, 0] }}
+              transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
+              className="absolute -top-5 -left-4 sm:-left-8 bg-white/90 dark:bg-surface-800/90 backdrop-blur-md px-4 py-3 rounded-2xl shadow-lg border border-surface-100 dark:border-surface-700 flex items-center gap-3"
+            >
+              <div className="w-10 h-10 bg-success-100 dark:bg-success-900/30 text-success-600 dark:text-success-400 rounded-xl flex items-center justify-center">
+                <Wallet className="w-5 h-5" />
+              </div>
+              <div>
+                <p className="font-bold text-surface-900 dark:text-white text-sm">New sale</p>
+                <p className="text-surface-500 text-xs">₹2,999 · just now</p>
+              </div>
+            </motion.div>
+
+            <motion.div
+              animate={{ y: [0, 10, 0] }}
+              transition={{ duration: 3.4, repeat: Infinity, ease: "easeInOut" }}
+              className="absolute -bottom-5 -right-4 sm:-right-8 bg-white/90 dark:bg-surface-800/90 backdrop-blur-md px-4 py-3 rounded-2xl shadow-lg border border-surface-100 dark:border-surface-700 flex items-center gap-2"
+            >
+              {[Youtube, Instagram, Linkedin, Telegram].map((Icon, i) => (
+                <div
+                  key={i}
+                  className="w-8 h-8 rounded-lg bg-surface-100 dark:bg-surface-700 flex items-center justify-center text-primary-600 dark:text-primary-400"
+                >
+                  <Icon className="w-4 h-4" />
+                </div>
+              ))}
+            </motion.div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/landing-page/main/src/components/creators/CreatorNav.tsx
+++ b/frontend/landing-page/main/src/components/creators/CreatorNav.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "framer-motion";
+import { Menu, X, Rocket } from "lucide-react";
+import { openLeadDialog } from "@/lib/leads";
+
+const links = [
+  { name: "Who it's for", href: "#audience" },
+  { name: "Features", href: "#features" },
+  { name: "How it works", href: "#how" },
+  { name: "Pricing", href: "#pricing" },
+  { name: "FAQ", href: "#faq" },
+];
+
+export default function CreatorNav() {
+  const [open, setOpen] = useState(false);
+  return (
+    <header className="sticky top-0 z-50 bg-white/80 dark:bg-surface-900/80 backdrop-blur-lg border-b border-surface-200 dark:border-surface-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <Link href="/" className="flex items-center gap-2 flex-shrink-0">
+            <div className="w-8 h-8 bg-gradient-to-br from-primary-500 to-accent-500 rounded-lg flex items-center justify-center">
+              <span className="text-white text-sm font-bold">dt</span>
+            </div>
+            <span className="font-display font-bold text-xl hidden sm:block">
+              DailyTaiyari{" "}
+              <span className="text-primary-600 dark:text-primary-400">for Creators</span>
+            </span>
+          </Link>
+
+          <nav className="hidden md:flex items-center gap-8">
+            {links.map((l) => (
+              <Link
+                key={l.name}
+                href={l.href}
+                className="text-surface-600 hover:text-primary-600 dark:text-surface-300 dark:hover:text-primary-400 font-medium transition-colors"
+              >
+                {l.name}
+              </Link>
+            ))}
+          </nav>
+
+          <div className="hidden md:flex items-center gap-4">
+            <button
+              onClick={() => openLeadDialog("demo")}
+              className="px-5 py-2.5 bg-primary-600 hover:bg-primary-700 text-white rounded-xl font-semibold shadow-glow transition-all hover:scale-105 active:scale-95 flex items-center gap-2"
+            >
+              <Rocket className="w-4 h-4" /> Book a Demo
+            </button>
+          </div>
+
+          <button
+            onClick={() => setOpen(!open)}
+            className="flex md:hidden p-2 rounded-md text-surface-600 hover:text-primary-600 dark:text-surface-300"
+            aria-label="Toggle menu"
+          >
+            {open ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+          </button>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            className="md:hidden overflow-hidden bg-white/95 dark:bg-surface-900/95 border-b border-surface-200 dark:border-surface-800"
+          >
+            <div className="px-4 py-4 space-y-2">
+              {links.map((l) => (
+                <Link
+                  key={l.name}
+                  href={l.href}
+                  onClick={() => setOpen(false)}
+                  className="block px-2 py-2 rounded-lg text-surface-700 dark:text-surface-300 hover:bg-surface-100 dark:hover:bg-surface-800"
+                >
+                  {l.name}
+                </Link>
+              ))}
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  openLeadDialog("demo");
+                }}
+                className="w-full px-4 py-2 bg-primary-600 text-white rounded-xl text-center font-semibold"
+              >
+                Book a Demo
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </header>
+  );
+}

--- a/frontend/landing-page/main/src/components/creators/CreatorSections.tsx
+++ b/frontend/landing-page/main/src/components/creators/CreatorSections.tsx
@@ -1,0 +1,729 @@
+"use client";
+
+import { motion, useInView, useMotionValue, animate } from "framer-motion";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  Globe,
+  Bot,
+  Wallet,
+  BadgeCheck,
+  Code2,
+  BarChart3,
+  ClipboardCheck,
+  Layers,
+  Palette,
+  Users,
+  Sparkles,
+  Rocket,
+  Building2,
+  School,
+  GraduationCap,
+  Star,
+  TrendingUp,
+  ArrowRight,
+  ListChecks,
+  Trophy,
+  Database,
+  FileText,
+  Download,
+} from "lucide-react";
+import { Youtube, Instagram, Linkedin, Telegram, Whatsapp, Facebook } from "./BrandIcons";
+import Marquee from "./Marquee";
+import Reveal from "../institutes/Reveal";
+import { openLeadDialog } from "@/lib/leads";
+
+/* ── shared heading ────────────────────────────────────────────────── */
+function SectionHeading({
+  eyebrow,
+  title,
+  highlight,
+  subtitle,
+}: {
+  eyebrow: string;
+  title: string;
+  highlight?: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="text-center max-w-3xl mx-auto mb-12">
+      <span className="inline-block px-3 py-1 rounded-full bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400 text-xs font-bold uppercase tracking-wider mb-4">
+        {eyebrow}
+      </span>
+      <h2 className="text-3xl sm:text-4xl font-display font-bold text-surface-900 dark:text-white mb-4">
+        {title}{" "}
+        {highlight && (
+          <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary-500 to-accent-500">
+            {highlight}
+          </span>
+        )}
+      </h2>
+      {subtitle && (
+        <p className="text-lg text-surface-600 dark:text-surface-400">{subtitle}</p>
+      )}
+    </div>
+  );
+}
+
+/* ── 1. Platforms marquee ──────────────────────────────────────────── */
+export function PlatformsMarquee() {
+  const platforms = [
+    { icon: Youtube, label: "YouTube" },
+    { icon: Instagram, label: "Instagram" },
+    { icon: Linkedin, label: "LinkedIn" },
+    { icon: Telegram, label: "Telegram" },
+    { icon: Whatsapp, label: "WhatsApp" },
+    { icon: Facebook, label: "Facebook" },
+    { icon: Globe, label: "Your Website" },
+  ];
+  return (
+    <section className="py-10 bg-white dark:bg-surface-900 border-y border-surface-200 dark:border-surface-800">
+      <p className="text-center text-sm font-semibold uppercase tracking-wider text-surface-500 dark:text-surface-400 mb-6">
+        Loved by creators building an audience on
+      </p>
+      <Marquee speed={26} gapClassName="gap-4">
+        {platforms.map((p) => (
+          <div
+            key={p.label}
+            className="flex items-center gap-3 px-6 py-3 rounded-2xl bg-surface-50 dark:bg-surface-950 border border-surface-200 dark:border-surface-800"
+          >
+            <p.icon className="w-6 h-6 text-primary-600 dark:text-primary-400" />
+            <span className="font-semibold text-surface-700 dark:text-surface-200 whitespace-nowrap">
+              {p.label}
+            </span>
+          </div>
+        ))}
+      </Marquee>
+    </section>
+  );
+}
+
+/* ── 2. Impact stats + growth graph ────────────────────────────────── */
+function Counter({
+  to,
+  suffix = "",
+  prefix = "",
+}: {
+  to: number;
+  suffix?: string;
+  prefix?: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const inView = useInView(ref, { once: true, margin: "-60px" });
+  const mv = useMotionValue(0);
+  const [val, setVal] = useState(0);
+  useEffect(() => {
+    if (!inView) return;
+    const controls = animate(mv, to, {
+      duration: 1.6,
+      ease: [0.22, 1, 0.36, 1],
+      onUpdate: (v) => setVal(v),
+    });
+    return () => controls.stop();
+  }, [inView, to, mv]);
+  return (
+    <span ref={ref}>
+      {prefix}
+      {Math.round(val).toLocaleString("en-IN")}
+      {suffix}
+    </span>
+  );
+}
+
+export function ImpactStats() {
+  const bars = [32, 45, 40, 60, 55, 72, 68, 85, 92];
+  return (
+    <section className="py-24 bg-surface-50 dark:bg-surface-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="Grow with DailyTaiyari"
+          title="Everything you need to"
+          highlight="turn followers into revenue"
+          subtitle="Stop losing your audience to someone else's platform. Own the relationship, the brand and the earnings."
+        />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
+          {/* Stat cards */}
+          <div className="grid grid-cols-2 gap-5">
+            {[
+              { icon: Wallet, label: "Revenue kept on your brand", value: 100, suffix: "%", c: "from-primary-500 to-primary-600" },
+              { icon: Globe, label: "Your own domain & branding", value: 1, suffix: " site", c: "from-accent-500 to-accent-600" },
+              { icon: Bot, label: "AI tutor answering doubts", value: 24, suffix: "/7", c: "from-success-500 to-success-600" },
+              { icon: Rocket, label: "Go live in days, not months", value: 3, suffix: " steps", c: "from-warning-500 to-accent-600" },
+            ].map((s, i) => (
+              <Reveal key={s.label} index={i}>
+                <div className="h-full p-6 rounded-3xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800">
+                  <div className={`w-12 h-12 rounded-2xl bg-gradient-to-br ${s.c} flex items-center justify-center mb-4 shadow-lg`}>
+                    <s.icon className="w-6 h-6 text-white" />
+                  </div>
+                  <div className="text-3xl font-display font-bold text-surface-900 dark:text-white">
+                    <Counter to={s.value} suffix={s.suffix} />
+                  </div>
+                  <p className="mt-1 text-sm text-surface-600 dark:text-surface-400">{s.label}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+
+          {/* Growth graph */}
+          <Reveal index={1}>
+            <div className="h-full p-8 rounded-3xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 flex flex-col">
+              <div className="flex items-center justify-between mb-6">
+                <div>
+                  <p className="text-sm font-semibold text-surface-500 dark:text-surface-400">
+                    Your earnings, compounding
+                  </p>
+                  <p className="text-2xl font-display font-bold text-surface-900 dark:text-white">
+                    Month-on-month growth
+                  </p>
+                </div>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-success-50 dark:bg-success-900/30 text-success-600 dark:text-success-400 text-sm font-bold">
+                  <TrendingUp className="w-4 h-4" /> Trending up
+                </span>
+              </div>
+              <div className="flex-1 flex items-end gap-2 sm:gap-3 min-h-[220px]">
+                {bars.map((h, i) => (
+                  <motion.div
+                    key={i}
+                    initial={{ height: 0 }}
+                    whileInView={{ height: `${h}%` }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.8, delay: i * 0.07, ease: [0.22, 1, 0.36, 1] }}
+                    className="flex-1 rounded-t-lg bg-gradient-to-t from-primary-500 to-accent-500 relative group"
+                  >
+                    <span className="absolute -top-6 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition text-[10px] font-bold text-surface-500">
+                      {h}
+                    </span>
+                  </motion.div>
+                ))}
+              </div>
+              <div className="mt-4 flex justify-between text-[11px] text-surface-400 font-medium">
+                <span>Launch</span>
+                <span>Grow</span>
+                <span>Scale</span>
+              </div>
+            </div>
+          </Reveal>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── 3. Feature marquees (two opposite rows) ───────────────────────── */
+/* ── 3. Student experience — auto-scrolling feature cards ──────────── */
+function FeatureCard({
+  icon: Icon,
+  title,
+  desc,
+  c,
+  visual,
+}: {
+  icon: typeof Globe;
+  title: string;
+  desc: string;
+  c: string;
+  visual: ReactNode;
+}) {
+  return (
+    <div className="w-80 shrink-0 rounded-3xl overflow-hidden bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 shadow-sm">
+      {/* graphic header */}
+      <div className={`relative h-28 bg-gradient-to-br ${c} p-4 overflow-hidden`}>
+        <div className="absolute inset-0 opacity-20">
+          <div className="absolute -top-6 -right-6 w-24 h-24 bg-white rounded-full blur-2xl" />
+        </div>
+        <div className="relative flex items-center gap-2 text-white">
+          <span className="w-9 h-9 rounded-xl bg-white/20 backdrop-blur flex items-center justify-center">
+            <Icon className="w-5 h-5" />
+          </span>
+        </div>
+        <div className="relative mt-2">{visual}</div>
+      </div>
+      <div className="p-5">
+        <h3 className="font-bold text-surface-900 dark:text-white">{title}</h3>
+        <p className="mt-1 text-sm text-surface-600 dark:text-surface-400 leading-relaxed">
+          {desc}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/* small inline graphics reused inside cards */
+const VizBars = () => (
+  <div className="flex items-end gap-1 h-8">
+    {[40, 70, 55, 85, 65, 95].map((h, i) => (
+      <div key={i} className="flex-1 rounded-t bg-white/70" style={{ height: `${h}%` }} />
+    ))}
+  </div>
+);
+const VizPalette = () => (
+  <div className="grid grid-cols-8 gap-1">
+    {Array.from({ length: 16 }).map((_, i) => (
+      <div
+        key={i}
+        className={`h-3 rounded ${[3, 7, 10].includes(i) ? "bg-white" : "bg-white/40"}`}
+      />
+    ))}
+  </div>
+);
+const VizCourse = () => (
+  <div className="flex gap-1.5">
+    {[0, 1, 2].map((i) => (
+      <div key={i} className="flex-1 rounded-lg bg-white/25 h-8 border border-white/30" />
+    ))}
+  </div>
+);
+const VizChat = () => (
+  <div className="space-y-1.5">
+    <div className="h-2.5 w-3/4 rounded-full bg-white/70" />
+    <div className="h-2.5 w-1/2 rounded-full bg-white/40 ml-auto" />
+  </div>
+);
+const VizCode = () => (
+  <div className="space-y-1 font-mono">
+    <div className="h-2 w-2/3 rounded bg-white/70" />
+    <div className="h-2 w-1/2 rounded bg-white/40 ml-4" />
+    <div className="h-2 w-3/5 rounded bg-white/40 ml-4" />
+  </div>
+);
+const VizCert = () => (
+  <div className="flex items-center gap-2">
+    <div className="w-8 h-8 rounded-full border-2 border-white/70 flex items-center justify-center">
+      <BadgeCheck className="w-4 h-4 text-white" />
+    </div>
+    <div className="flex-1 space-y-1">
+      <div className="h-2 w-full rounded bg-white/60" />
+      <div className="h-2 w-2/3 rounded bg-white/30" />
+    </div>
+  </div>
+);
+const VizReport = () => (
+  <div className="flex items-center gap-2">
+    <FileText className="w-7 h-7 text-white/90" />
+    <div className="flex-1 space-y-1">
+      <div className="h-2 w-full rounded bg-white/60" />
+      <div className="h-2 w-1/2 rounded bg-white/30" />
+    </div>
+    <Download className="w-5 h-5 text-white/90" />
+  </div>
+);
+const VizBuilder = () => (
+  <div className="space-y-1.5">
+    <div className="h-3 rounded bg-white/60 w-full" />
+    <div className="flex gap-1.5">
+      <div className="h-3 rounded bg-white/40 w-1/3" />
+      <div className="h-3 rounded bg-white/40 w-1/3" />
+      <div className="h-3 rounded bg-white/40 w-1/4" />
+    </div>
+  </div>
+);
+const VizSpark = () => (
+  <div className="flex items-center gap-2">
+    <Sparkles className="w-6 h-6 text-white" />
+    <div className="flex-1 space-y-1">
+      <div className="h-2.5 w-full rounded-full bg-white/70" />
+      <div className="h-2.5 w-3/4 rounded-full bg-white/40" />
+    </div>
+  </div>
+);
+
+export function StudentExperience() {
+  const cards = [
+    { icon: GraduationCap, title: "Branded course pages", desc: "Beautiful course landing pages with your logo, banner and pricing — ready to sell.", c: "from-primary-500 to-primary-600", visual: <VizCourse /> },
+    { icon: ClipboardCheck, title: "Interactive quizzes", desc: "Topic-wise quizzes with instant scoring and detailed solutions.", c: "from-accent-500 to-accent-600", visual: <VizChat /> },
+    { icon: ListChecks, title: "Timed mock tests", desc: "Real exam UI — question palette, mark-for-review, resume on refresh, instant results.", c: "from-warning-500 to-accent-600", visual: <VizPalette /> },
+    { icon: Bot, title: "24/7 AI doubt-solver", desc: "Every student gets a personal AI tutor with step-by-step explanations.", c: "from-success-500 to-success-600", visual: <VizChat /> },
+    { icon: Code2, title: "Coding labs", desc: "Write & run code against test cases with instant auto-graded verdicts.", c: "from-primary-600 to-accent-500", visual: <VizCode /> },
+    { icon: BadgeCheck, title: "Certificates", desc: "Learners earn certificates they can showcase online.", c: "from-accent-500 to-primary-500", visual: <VizCert /> },
+    { icon: Trophy, title: "XP, streaks & leaderboards", desc: "Gamified progress that turns practice into a daily habit.", c: "from-warning-500 to-warning-600", visual: <VizBars /> },
+  ];
+  return (
+    <section id="features" className="py-20 bg-white dark:bg-surface-900 border-y border-surface-200 dark:border-surface-800 overflow-hidden">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="For your students"
+          title="A learning experience students"
+          highlight="actually love"
+          subtitle="Courses, quizzes, mock tests, coding labs and an AI tutor — all under your brand."
+        />
+      </div>
+      <Marquee speed={46} gapClassName="gap-6">
+        {cards.map((f) => (
+          <FeatureCard key={f.title} {...f} />
+        ))}
+      </Marquee>
+    </section>
+  );
+}
+
+export function CreatorConsole() {
+  const cards = [
+    { icon: Sparkles, title: "AI-assisted content creation", desc: "Generate course outlines, lessons, quizzes and questions with AI — launch faster.", c: "from-accent-500 to-primary-500", visual: <VizSpark /> },
+    { icon: Layers, title: "No-code course builder", desc: "Drag together chapters, videos, notes, quizzes and assignments — no coding.", c: "from-primary-500 to-primary-600", visual: <VizBuilder /> },
+    { icon: Database, title: "Question bank & test builder", desc: "Build a reusable question bank and assemble timed tests in minutes.", c: "from-accent-500 to-accent-600", visual: <VizBuilder /> },
+    { icon: Download, title: "Downloadable reports", desc: "Export attendance, scores and performance reports as ready-to-share files.", c: "from-success-500 to-success-600", visual: <VizReport /> },
+    { icon: BarChart3, title: "Analytics dashboard", desc: "Track enrolments, engagement and revenue at a glance.", c: "from-primary-600 to-accent-500", visual: <VizBars /> },
+    { icon: Users, title: "Student management", desc: "Approve enrolments, manage batches and message learners from one console.", c: "from-warning-500 to-accent-600", visual: <VizBuilder /> },
+    { icon: Wallet, title: "Payments & revenue", desc: "Sell courses, collect payments and keep your earnings on your own brand.", c: "from-success-600 to-primary-500", visual: <VizReport /> },
+    { icon: Palette, title: "Your branding & domain", desc: "Your logo, colors and custom domain — a portal that looks entirely yours.", c: "from-accent-500 to-primary-500", visual: <VizBuilder /> },
+  ];
+  return (
+    <section className="py-20 bg-surface-50 dark:bg-surface-950 overflow-hidden">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="For you — the admin console"
+          title="Run everything from"
+          highlight="one powerful dashboard"
+          subtitle="Create content with AI, manage students, and export reports — no technical team needed."
+        />
+      </div>
+      <Marquee speed={52} reverse gapClassName="gap-6">
+        {cards.map((f) => (
+          <FeatureCard key={f.title} {...f} />
+        ))}
+      </Marquee>
+    </section>
+  );
+}
+
+/* ── 4. How it works ───────────────────────────────────────────────── */
+export function HowItWorks() {
+  const steps = [
+    {
+      icon: Users,
+      title: "Bring your audience",
+      desc: "You already have followers on YouTube, Instagram or LinkedIn. Point them to your own branded site.",
+      c: "from-primary-500 to-primary-600",
+    },
+    {
+      icon: Layers,
+      title: "Build your course",
+      desc: "Add videos, notes, quizzes, coding labs and live classes with a simple, no-code course builder.",
+      c: "from-accent-500 to-accent-600",
+    },
+    {
+      icon: Rocket,
+      title: "Sell on your brand",
+      desc: "Set your price, collect payments directly, and let the AI tutor scale your teaching 24/7.",
+      c: "from-success-500 to-success-600",
+    },
+  ];
+  return (
+    <section id="how" className="py-24 bg-surface-50 dark:bg-surface-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="How it works"
+          title="From follower to paying student in"
+          highlight="3 simple steps"
+          subtitle="Start your online learning portal in minutes — no code, no tech team."
+        />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 relative">
+          {steps.map((s, i) => (
+            <Reveal key={s.title} index={i}>
+              <div className="h-full p-8 rounded-3xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 relative">
+                <span className="absolute top-6 right-6 text-5xl font-display font-bold text-surface-100 dark:text-surface-800 select-none">
+                  {i + 1}
+                </span>
+                <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${s.c} flex items-center justify-center mb-6 shadow-lg`}>
+                  <s.icon className="w-7 h-7 text-white" />
+                </div>
+                <h3 className="font-bold text-surface-900 dark:text-white text-xl mb-3">{s.title}</h3>
+                <p className="text-surface-600 dark:text-surface-400 leading-relaxed">{s.desc}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── 5. Course showcase marquee ────────────────────────────────────── */
+export function CourseShowcase() {
+  const courses = [
+    { title: "Full-Stack Web Dev", tag: "Cohort", c: "from-primary-500 to-accent-500", price: "₹4,999" },
+    { title: "Stock Market Mastery", tag: "Self-paced", c: "from-success-500 to-primary-500", price: "₹1,999" },
+    { title: "UI/UX Design Bootcamp", tag: "Live", c: "from-accent-500 to-warning-500", price: "₹3,499" },
+    { title: "Spoken English Pro", tag: "Self-paced", c: "from-warning-500 to-accent-500", price: "₹999" },
+    { title: "Data Science with Python", tag: "Cohort", c: "from-primary-600 to-success-500", price: "₹5,999" },
+    { title: "Digital Marketing 101", tag: "Self-paced", c: "from-accent-600 to-primary-500", price: "₹2,499" },
+  ];
+  return (
+    <section className="py-24 bg-white dark:bg-surface-900 border-y border-surface-200 dark:border-surface-800 overflow-hidden">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="Any subject, any format"
+          title="If you can teach it, you can"
+          highlight="sell it here"
+          subtitle="Cohorts, self-paced courses, test series, live classes — creators across every niche run them on DailyTaiyari."
+        />
+      </div>
+      <Marquee speed={44} gapClassName="gap-6">
+        {courses.map((c) => (
+          <div
+            key={c.title}
+            className="w-72 rounded-3xl overflow-hidden bg-surface-50 dark:bg-surface-950 border border-surface-200 dark:border-surface-800 shadow-sm"
+          >
+            <div className={`h-32 bg-gradient-to-br ${c.c} relative`}>
+              <span className="absolute top-3 left-3 px-2.5 py-1 rounded-full bg-white/90 text-surface-800 text-xs font-bold">
+                {c.tag}
+              </span>
+            </div>
+            <div className="p-5">
+              <h3 className="font-bold text-surface-900 dark:text-white text-lg">{c.title}</h3>
+              <div className="mt-3 flex items-center justify-between">
+                <span className="text-surface-500 text-sm">Your price</span>
+                <span className="font-display font-bold text-success-600 dark:text-success-400">
+                  {c.price}
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </Marquee>
+    </section>
+  );
+}
+
+/* ── 6. Testimonials marquee ───────────────────────────────────────── */
+export function TestimonialsMarquee() {
+  const testimonials = [
+    { name: "Ananya R.", handle: "YouTube · 120K subs", quote: "I finally own my audience. My students learn on my site, not someone else's app.", c: "from-primary-500 to-accent-500" },
+    { name: "Rahul M.", handle: "Instagram educator", quote: "Set up my branded course site in a weekend. The AI tutor handles doubts while I sleep.", c: "from-success-500 to-primary-500" },
+    { name: "Sneha K.", handle: "LinkedIn coach", quote: "Payments, certificates, analytics — all in one place. No more juggling 5 tools.", c: "from-accent-500 to-warning-500" },
+    { name: "Vikram S.", handle: "Telegram · test series", quote: "My test-series business doubled once everything moved onto my own branded portal.", c: "from-warning-500 to-accent-500" },
+    { name: "Meera J.", handle: "Independent teacher", quote: "It looks like I hired a whole tech team. Students think my brand is a big company.", c: "from-primary-600 to-success-500" },
+  ];
+  return (
+    <section className="py-24 bg-surface-50 dark:bg-surface-950 overflow-hidden">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="Creators love it"
+          title="Built for people who"
+          highlight="teach for a living"
+        />
+      </div>
+      <Marquee speed={50} gapClassName="gap-6" pauseOnHover>
+        {testimonials.map((t) => (
+          <div
+            key={t.name}
+            className="w-[22rem] p-6 rounded-3xl bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 shadow-sm"
+          >
+            <div className="flex items-center gap-1 mb-4 text-warning-400">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Star key={i} className="w-4 h-4 fill-current" />
+              ))}
+            </div>
+            <p className="text-surface-700 dark:text-surface-200 leading-relaxed mb-6">
+              “{t.quote}”
+            </p>
+            <div className="flex items-center gap-3">
+              <div className={`w-11 h-11 rounded-full bg-gradient-to-br ${t.c}`} />
+              <div>
+                <p className="font-bold text-surface-900 dark:text-white text-sm">{t.name}</p>
+                <p className="text-surface-500 text-xs">{t.handle}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </Marquee>
+    </section>
+  );
+}
+
+/* ── 7. Audience + Book-a-Demo card ────────────────────────────────── */
+export function Audience() {
+  const primary = [
+    {
+      icon: Sparkles,
+      title: "Knowledge Creators",
+      desc: "You teach on YouTube, Instagram, LinkedIn or Telegram. Turn that audience into a real business on your own branded site.",
+      c: "from-primary-500 to-accent-500",
+    },
+    {
+      icon: Building2,
+      title: "Coaching Institutes",
+      desc: "Give your JEE/NEET/UPSC or skill batches a premium digital home — test series, notes and tracking under your own brand.",
+      c: "from-accent-500 to-primary-600",
+    },
+  ];
+  const secondary = [
+    { icon: School, title: "Schools", desc: "A digital campus for classes, notes & assessments." },
+    { icon: GraduationCap, title: "Colleges", desc: "Skill programs, placement prep & certifications." },
+  ];
+  const demoPoints = [
+    "A branded portal set up for you",
+    "AI content-creation walkthrough",
+    "Pricing tailored to your scale",
+  ];
+  return (
+    <section id="audience" className="py-24 bg-white dark:bg-surface-900 border-t border-surface-200 dark:border-surface-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <SectionHeading
+          eyebrow="Who it's for"
+          title="Built for creators &"
+          highlight="coaching institutes"
+          subtitle="If you teach, DailyTaiyari gives you the platform to sell and scale — under your own brand."
+        />
+
+        {/* Two primary audiences */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+          {primary.map((p, i) => (
+            <Reveal key={p.title} index={i}>
+              <div className="h-full p-8 rounded-3xl bg-surface-50 dark:bg-surface-950 border border-surface-200 dark:border-surface-800 flex items-start gap-5">
+                <div className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${p.c} flex items-center justify-center shadow-lg shrink-0`}>
+                  <p.icon className="w-7 h-7 text-white" />
+                </div>
+                <div>
+                  <h3 className="font-bold text-surface-900 dark:text-white text-xl mb-2">{p.title}</h3>
+                  <p className="text-surface-600 dark:text-surface-400 leading-relaxed">{p.desc}</p>
+                </div>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+
+        {/* Book a Demo card */}
+        <Reveal>
+          <div className="relative overflow-hidden rounded-[2rem] bg-gradient-to-br from-primary-500 via-accent-500 to-primary-600 [background-size:200%_200%] animate-gradient text-white">
+            <div className="absolute inset-0 opacity-20 pointer-events-none">
+              <div className="absolute -top-10 -right-10 w-72 h-72 bg-white rounded-full blur-3xl" />
+              <div className="absolute -bottom-16 -left-10 w-72 h-72 bg-white rounded-full blur-3xl" />
+            </div>
+            <div className="relative grid grid-cols-1 lg:grid-cols-2 gap-8 items-center p-8 sm:p-12">
+              <div>
+                <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/20 text-white text-xs font-bold uppercase tracking-wider mb-5">
+                  <Rocket className="w-4 h-4" /> Free personalised demo
+                </span>
+                <h3 className="text-3xl sm:text-4xl font-display font-bold mb-4 leading-tight">
+                  See your branded academy in 20 minutes
+                </h3>
+                <p className="text-white/90 text-lg mb-6">
+                  Tell us what you teach — we&apos;ll show you exactly how your courses, tests
+                  and AI-assisted content would look and sell on your own DailyTaiyari site.
+                </p>
+                <ul className="space-y-2.5 mb-8">
+                  {demoPoints.map((pt) => (
+                    <li key={pt} className="flex items-center gap-3 text-white/95">
+                      <span className="w-6 h-6 rounded-full bg-white/20 flex items-center justify-center shrink-0">
+                        <BadgeCheck className="w-4 h-4" />
+                      </span>
+                      {pt}
+                    </li>
+                  ))}
+                </ul>
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <button
+                    onClick={() => openLeadDialog("demo")}
+                    className="px-8 py-4 bg-white text-primary-600 rounded-xl font-bold text-lg shadow-lg transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center gap-2"
+                  >
+                    Book a Demo <ArrowRight className="w-5 h-5" />
+                  </button>
+                  <button
+                    onClick={() => openLeadDialog("contact")}
+                    className="px-8 py-4 bg-white/10 hover:bg-white/20 border border-white/30 text-white rounded-xl font-bold text-lg transition-all hover:scale-105"
+                  >
+                    Ask a question
+                  </button>
+                </div>
+              </div>
+
+              {/* mini visual */}
+              <div className="hidden lg:block">
+                <div className="rounded-2xl bg-white/10 backdrop-blur border border-white/20 p-5 space-y-4">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-xl bg-white/25" />
+                    <div className="flex-1 space-y-1.5">
+                      <div className="h-2.5 w-2/3 rounded-full bg-white/60" />
+                      <div className="h-2 w-1/3 rounded-full bg-white/30" />
+                    </div>
+                    <span className="px-2.5 py-1 rounded-full bg-white/20 text-[11px] font-bold">
+                      Live
+                    </span>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    {["Courses", "Tests", "Reports"].map((t) => (
+                      <div key={t} className="rounded-xl bg-white/10 p-3">
+                        <div className="h-8 rounded-lg bg-white/25 mb-2" />
+                        <div className="text-[10px] font-semibold text-white/90">{t}</div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="rounded-xl bg-white/10 p-3">
+                    <div className="flex items-end gap-1.5 h-16">
+                      {[45, 62, 55, 78, 70, 90].map((h, i) => (
+                        <div key={i} className="flex-1 rounded-t bg-white/60" style={{ height: `${h}%` }} />
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+
+        {/* Secondary: schools & colleges */}
+        <div className="mt-10">
+          <p className="text-center text-sm font-semibold uppercase tracking-wider text-surface-500 dark:text-surface-400 mb-6">
+            Also perfect for schools & colleges
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
+            {secondary.map((s, i) => (
+              <Reveal key={s.title} index={i}>
+                <div className="h-full p-6 rounded-2xl bg-surface-50 dark:bg-surface-950 border border-surface-200 dark:border-surface-800 flex items-start gap-4">
+                  <div className="w-11 h-11 rounded-xl bg-surface-100 dark:bg-surface-800 flex items-center justify-center text-primary-600 dark:text-primary-400 shrink-0">
+                    <s.icon className="w-5 h-5" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-surface-900 dark:text-white">{s.title}</h3>
+                    <p className="text-sm text-surface-600 dark:text-surface-400 mt-1">{s.desc}</p>
+                  </div>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ── Final CTA ─────────────────────────────────────────────────────── */
+export function FinalCTA() {
+  return (
+    <section className="py-24 bg-surface-50 dark:bg-surface-950">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <Reveal>
+          <div className="relative overflow-hidden rounded-[2rem] bg-surface-900 dark:bg-surface-800 px-8 py-16 sm:px-16 text-center">
+            <div className="absolute inset-0 opacity-30 pointer-events-none">
+              <div className="absolute -top-20 -left-10 w-80 h-80 bg-primary-500 rounded-full blur-[120px]" />
+              <div className="absolute -bottom-20 -right-10 w-80 h-80 bg-accent-500 rounded-full blur-[120px]" />
+            </div>
+            <div className="relative">
+              <h2 className="text-3xl sm:text-4xl font-display font-bold text-white mb-4">
+                Ready to sell your knowledge on your own brand?
+              </h2>
+              <p className="text-surface-300 text-lg mb-8 max-w-2xl mx-auto">
+                Join the creators turning their audience into a real, ownable business.
+                Book a free demo and we&apos;ll set up your branded site.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <button
+                  onClick={() => openLeadDialog("demo")}
+                  className="px-8 py-4 bg-primary-600 hover:bg-primary-700 text-white rounded-xl font-bold text-lg shadow-glow transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center gap-2"
+                >
+                  Book a Demo <ArrowRight className="w-5 h-5" />
+                </button>
+                <button
+                  onClick={() => openLeadDialog("contact")}
+                  className="px-8 py-4 bg-white/10 hover:bg-white/20 text-white border border-white/20 rounded-xl font-bold text-lg transition-all hover:scale-105"
+                >
+                  Talk to us
+                </button>
+              </div>
+            </div>
+          </div>
+        </Reveal>
+      </div>
+    </section>
+  );
+}

--- a/frontend/landing-page/main/src/components/creators/Marquee.tsx
+++ b/frontend/landing-page/main/src/components/creators/Marquee.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+type MarqueeProps = {
+  children: ReactNode;
+  /** seconds for one full loop; lower = faster */
+  speed?: number;
+  /** scroll direction */
+  reverse?: boolean;
+  /** pause the animation when the pointer is over the strip */
+  pauseOnHover?: boolean;
+  /** gap between items, tailwind gap class */
+  gapClassName?: string;
+  className?: string;
+};
+
+/**
+ * Seamless, infinitely auto-scrolling horizontal strip.
+ *
+ * The children are rendered twice back-to-back and the track is translated by
+ * exactly -50%, so the loop is perfectly continuous with no visible jump. Edges
+ * fade out via a mask so items appear to flow in and out.
+ */
+export default function Marquee({
+  children,
+  speed = 32,
+  reverse = false,
+  pauseOnHover = true,
+  gapClassName = "gap-4",
+  className = "",
+}: MarqueeProps) {
+  return (
+    <div
+      className={`group relative w-full overflow-hidden ${className}`}
+      style={{
+        maskImage:
+          "linear-gradient(to right, transparent, black 6%, black 94%, transparent)",
+        WebkitMaskImage:
+          "linear-gradient(to right, transparent, black 6%, black 94%, transparent)",
+      }}
+    >
+      <div
+        className={`flex w-max ${gapClassName} ${
+          pauseOnHover ? "group-hover:[animation-play-state:paused]" : ""
+        }`}
+        style={{
+          animationName: reverse ? "dt-marquee-reverse" : "dt-marquee",
+          animationDuration: `${speed}s`,
+          animationTimingFunction: "linear",
+          animationIterationCount: "infinite",
+        }}
+      >
+        <div className={`flex ${gapClassName} shrink-0`}>{children}</div>
+        <div className={`flex ${gapClassName} shrink-0`} aria-hidden="true">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/landing-page/main/src/components/institutes/LeadDialogs.tsx
+++ b/frontend/landing-page/main/src/components/institutes/LeadDialogs.tsx
@@ -165,7 +165,7 @@ export default function LeadDialogs() {
                   </div>
                   <p className="text-sm text-surface-500 dark:text-surface-400 mb-6 ml-[3.25rem]">
                     {isDemo
-                      ? "Tell us about your institute and we'll reach out to schedule a walkthrough."
+                      ? "Tell us a bit about you and we'll reach out to schedule a walkthrough."
                       : "Send us a message and we'll get back to you soon."}
                   </p>
 
@@ -205,16 +205,18 @@ export default function LeadDialogs() {
                             <label className={labelClass} htmlFor="lead-orgtype">Organization type</label>
                             <select id="lead-orgtype" name="organization_type" defaultValue="" className={inputClass}>
                               <option value="">Select…</option>
+                              <option value="creator">Independent Creator</option>
                               <option value="coaching">Coaching Institute</option>
                               <option value="school">School</option>
                               <option value="college">College</option>
+                              <option value="edtech">EdTech / Online Academy</option>
                               <option value="other">Other</option>
                             </select>
                           </div>
                         </div>
                         <div>
-                          <label className={labelClass} htmlFor="lead-org">Institute / organization name</label>
-                          <input id="lead-org" name="organization" className={inputClass} placeholder="e.g. Bright Future Academy" />
+                          <label className={labelClass} htmlFor="lead-org">Brand / organization name</label>
+                          <input id="lead-org" name="organization" className={inputClass} placeholder="e.g. your channel, academy or institute" />
                         </div>
                         <div>
                           <label className={labelClass} htmlFor="lead-msg">Anything you'd like us to know?</label>


### PR DESCRIPTION
## What & why

Our marketing landing page was large and confusing. This redesign makes it **impactful and creator-first**, promoting the previously-previewed `/preview` build to the live `/` route.

**Positioning:** primary audience is **Online Creators**, with **Coaching Institutes** and **Schools & Colleges** as the other named segments. Core pitch: *sell your knowledge on your own branded website — start your online learning portal in minutes.*

## Highlights

- **New creator-first hero** — headline, "Start your online learning portal in minutes — with us." tagline, and a typing rotator cycling only **Online Creators / Coaching Institutes / Schools & Colleges**.
- **Auto-scrolling horizontal marquees** (reusable `Marquee`) for platforms, testimonials and feature strips — premium, seamless feel.
- **Two graphic feature sections** — `StudentExperience` (quizzes, tests, course graphics, AI doubt-solving) and `CreatorConsole` (AI-assisted course & content creation, builder, reports/downloads, analytics), each with mini-visuals.
- **AI-assisted content creation** messaging throughout (hero + console + demo card).
- **Dual-audience Audience + Book-a-Demo card**; demo form now offers **Independent Creator / Coaching Institute / School / College / EdTech-Online Academy / Other**, with copy relaxed to fit solo creators.
- `ImpactStats`, `CourseShowcase`, `HowItWorks`, `TestimonialsMarquee`, `FinalCTA`.

## Implementation notes

- New components under `src/components/creators/` (`CreatorHero`, `CreatorSections`, `CreatorNav`, `Marquee`, `BrandIcons`).
- `BrandIcons.tsx` provides inline SVG brand glyphs — this `lucide-react` version doesn't export brand icons.
- `page.tsx` now composes the creator sections + reused `Pricing`/`FAQ`/`InstituteFooter`/`JsonLd`/`LeadDialogs`; `JsonLd` retained for SEO, `noindex` dropped. The temporary `/preview` route is removed.
- `globals.css` gains `dt-marquee` keyframes with a `prefers-reduced-motion` guard.

## Verification

- `npx next build` passes clean (EXIT 0).
- Local prod server: `/` returns 200 with the new copy; `/preview` now 404; page is indexable.

Frontend deploys via Netlify on merge to `main`.