### PR TITLE
Remove primary_course concept; treat all courses equally via enrollments

### DIFF
--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -261,21 +261,17 @@ class StudyPlanViewSet(TenantAwareViewSet):
     def _resolve_course_id(student, requested_course_id=None):
         """Resolve a usable course for the student's study plan.
 
-        Order: explicitly requested -> primary course -> first approved/active
-        enrollment. Returns None if the student has no usable course.
+        Order: explicitly requested -> first approved/active enrollment.
+        Returns None if the student has no usable course.
         """
-        candidates = [requested_course_id, student.primary_course_id]
-        for course_id in candidates:
-            if course_id and student.enrollments.filter(
-                course_id=course_id, status='approved', is_active=True
-            ).exists():
-                return course_id
+        if requested_course_id and student.enrollments.filter(
+            course_id=requested_course_id, status='approved', is_active=True
+        ).exists():
+            return requested_course_id
         enrollment = student.enrollments.filter(
             status='approved', is_active=True
         ).order_by('created_at').first()
-        return enrollment.course_id if enrollment else (
-            requested_course_id or student.primary_course_id
-        )
+        return enrollment.course_id if enrollment else requested_course_id
 
     @action(detail=False, methods=['get'])
     def today(self, request):

--- a/backend/core/management/commands/seed_data.py
+++ b/backend/core/management/commands/seed_data.py
@@ -1043,7 +1043,6 @@ class Command(BaseCommand):
                 defaults={
                     'grade': user_data['grade'],
                     'city': user_data['city'],
-                    'primary_course': self.courses.get('neet'),
                     'total_xp': user_data['xp'],
                     'current_level': user_data['level'],
                     'daily_study_goal_minutes': random.choice([30, 60, 90, 120]),
@@ -1073,7 +1072,6 @@ class Command(BaseCommand):
                 defaults={
                     'grade': '12',
                     'city': 'Delhi',
-                    'primary_course': self.courses.get('neet'),
                     'total_xp': 1500,
                     'current_level': 3,
                     'daily_study_goal_minutes': 60,

--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -349,7 +349,8 @@ class StudySubjectsView(APIView):
     """
     Return subjects for the selected course with completion progress.
     Flow: Study tab → select course → this list of subjects.
-    Query params: course_id (optional) — if omitted, uses student's primary_course.
+    Query params: course_id (optional) — if omitted, uses the student's first
+    approved enrollment.
     """
     permission_classes = [permissions.IsAuthenticated]
 
@@ -367,7 +368,10 @@ class StudySubjectsView(APIView):
             except Course.DoesNotExist:
                 return Response({'error': 'Course not found'}, status=404)
         else:
-            course = getattr(student, 'primary_course', None)
+            enrollment = student.enrollments.filter(
+                status='approved', is_active=True, course__status='active'
+            ).order_by('created_at').first()
+            course = enrollment.course if enrollment else None
         if not course:
             return Response([])
 

--- a/backend/quiz/views.py
+++ b/backend/quiz/views.py
@@ -258,9 +258,7 @@ class QuizViewSet(TenantAwareReadOnlyViewSet):
         course_id = None
         if requested and str(requested) in {str(c) for c in accessible_ids}:
             course_id = requested
-        if not course_id and student and student.primary_course_id in accessible_ids:
-            course_id = student.primary_course_id
-        if not course_id and accessible_ids:
+        if not course_id and accessible_ids and student:
             enr = student.enrollments.filter(
                 status='approved', is_active=True, course__status='active'
             ).order_by('created_at').first()

--- a/backend/users/admin.py
+++ b/backend/users/admin.py
@@ -31,10 +31,9 @@ class UserAdmin(BaseUserAdmin):
 
 @admin.register(StudentProfile)
 class StudentProfileAdmin(admin.ModelAdmin):
-    list_display = ['user', 'primary_course', 'total_xp', 'current_level']
-    list_filter = ['primary_course']
+    list_display = ['user', 'total_xp', 'current_level']
     search_fields = ['user__email', 'user__first_name']
-    raw_id_fields = ['user', 'primary_course']
+    raw_id_fields = ['user']
 
 
 @admin.register(CourseEnrollment)

--- a/backend/users/migrations/0014_remove_studentprofile_primary_course.py
+++ b/backend/users/migrations/0014_remove_studentprofile_primary_course.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Drop StudentProfile.primary_course.
+
+    Courses are now tracked solely through CourseEnrollment; every course a
+    student is associated with is treated at the same level, so the single
+    "primary" course is no longer a distinct concept.
+    """
+
+    dependencies = [
+        ('users', '0013_alter_user_role'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='studentprofile',
+            name='primary_course',
+        ),
+    ]

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -194,15 +194,6 @@ class StudentProfile(TimeStampedModel):
     city = models.CharField(max_length=100, blank=True)
     state = models.CharField(max_length=100, blank=True)
     
-    # Target courses (Many-to-many through CourseEnrollment)
-    primary_course = models.ForeignKey(
-        'exams.Course', 
-        on_delete=models.SET_NULL, 
-        null=True, 
-        blank=True,
-        related_name='primary_students'
-    )
-    
     # Study preferences
     daily_study_goal_minutes = models.PositiveIntegerField(default=60)
     preferred_study_time = models.CharField(

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -167,17 +167,28 @@ class StudentProfileSerializer(serializers.ModelSerializer):
 
     overall_accuracy = serializers.ReadOnlyField()
     xp_for_next_level = serializers.ReadOnlyField()
-    primary_course_name = serializers.CharField(source='primary_course.name', read_only=True)
     enrolled_course_ids = serializers.SerializerMethodField()
+    enrolled_courses = serializers.SerializerMethodField()
 
     def get_enrolled_course_ids(self, obj):
         """All courses the student is enrolled in (excluding rejected requests).
 
-        Lets the admin roster filter by any course a student is associated with,
-        not just their single primary course.
+        Lets the admin roster filter by any course a student is associated with.
         """
         return [
             str(e.course_id)
+            for e in obj.enrollments.all()
+            if e.status != 'rejected'
+        ]
+
+    def get_enrolled_courses(self, obj):
+        """Course id/name/status for every non-rejected enrollment.
+
+        All of a student's courses are treated at the same level; this is the
+        single source of truth for which courses a student belongs to.
+        """
+        return [
+            {'id': str(e.course_id), 'name': e.course.name, 'status': e.status}
             for e in obj.enrollments.all()
             if e.status != 'rejected'
         ]
@@ -197,7 +208,7 @@ class StudentProfileSerializer(serializers.ModelSerializer):
             # Location
             'city', 'state',
             # Course info
-            'primary_course', 'primary_course_name', 'enrolled_course_ids',
+            'enrolled_course_ids', 'enrolled_courses',
             # Study preferences
             'daily_study_goal_minutes', 'preferred_study_time', 
             # Stats

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -413,7 +413,7 @@ class TenantStudentViewSet(TenantAwareViewSet):
 
     def get_queryset(self):
         tenant = self.request.tenant
-        qs = StudentProfile.objects.filter(user__tenant=tenant).select_related('user', 'primary_course').prefetch_related('enrollments')
+        qs = StudentProfile.objects.filter(user__tenant=tenant).select_related('user').prefetch_related('enrollments__course')
 
         # Optional explicit filters (used by the admin dashboard).
         role = self.request.query_params.get('role')
@@ -426,9 +426,17 @@ class TenantStudentViewSet(TenantAwareViewSet):
         elif status_param == 'suspended':
             qs = qs.filter(user__is_suspended=True)
 
-        primary_course = self.request.query_params.get('primary_course')
-        if primary_course:
-            qs = qs.filter(primary_course_id=primary_course)
+        # Filter by any course the student is enrolled in (non-rejected).
+        # unique_together(student, course) means one enrollment per pair, so the
+        # exclude below targets exactly the matched course's enrollment.
+        course = self.request.query_params.get('course') or self.request.query_params.get('primary_course')
+        if course:
+            qs = qs.filter(
+                enrollments__course_id=course,
+            ).exclude(
+                enrollments__course_id=course,
+                enrollments__status='rejected',
+            ).distinct()
 
         return qs
 

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -197,7 +197,7 @@ const SelectInput = ({ options, ...props }) => (
 /* ---------------------------------------------------------------------------
  * StudentEditModal — edit ANY metadata of a student
  * ------------------------------------------------------------------------- */
-const StudentEditModal = ({ student, exams, onClose }) => {
+const StudentEditModal = ({ student, onClose }) => {
     const queryClient = useQueryClient()
 
     const [form, setForm] = useState(() => ({
@@ -218,7 +218,6 @@ const StudentEditModal = ({ student, exams, onClose }) => {
         board: student.board || '',
         medium: student.medium || 'english',
         target_year: student.target_year || '',
-        primary_course: student.primary_course || '',
         // profile — location & prefs
         city: student.city || '',
         state: student.state || '',
@@ -265,7 +264,6 @@ const StudentEditModal = ({ student, exams, onClose }) => {
             board: form.board,
             medium: form.medium,
             target_year: form.target_year === '' ? null : Number(form.target_year),
-            primary_course: form.primary_course || null,
             city: form.city,
             state: form.state,
             daily_study_goal_minutes: Number(form.daily_study_goal_minutes) || 0,
@@ -337,13 +335,6 @@ const StudentEditModal = ({ student, exams, onClose }) => {
                             <School className="w-4 h-4" /> Academic Details
                         </h3>
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            <Field label="Primary Course">
-                                <SelectInput
-                                    options={[{ value: '', label: '—' }, ...exams.map((ex) => ({ value: ex.id, label: ex.name }))]}
-                                    value={form.primary_course}
-                                    onChange={set('primary_course')}
-                                />
-                            </Field>
                             <Field label="Target Year"><TextInput type="number" value={form.target_year} onChange={set('target_year')} placeholder="e.g. 2026" /></Field>
                             <Field label="Grade / Class"><SelectInput options={GRADE_OPTIONS} value={form.grade} onChange={set('grade')} /></Field>
                             <Field label="Board / University"><SelectInput options={BOARD_OPTIONS} value={form.board} onChange={set('board')} /></Field>
@@ -408,7 +399,7 @@ const StudentDetailModal = ({ student, onClose, onEdit }) => {
             title: 'Academic Details',
             icon: School,
             fields: [
-                { label: 'Primary Course', value: student.primary_course_name || 'Not set' },
+                { label: 'Enrolled Courses', value: (student.enrolled_courses || []).map((c) => c.name).filter(Boolean).join(', ') || 'None' },
                 { label: 'Target Year', value: student.target_year || 'Not set' },
                 { label: 'Grade/Level', value: student.grade || 'Not provided' },
                 { label: 'School/Institute', value: student.school || 'Not provided' },
@@ -573,7 +564,7 @@ const StudentManagement = () => {
                 filterStatus === 'all' ||
                 (filterStatus === 'active' && !s.user.is_suspended) ||
                 (filterStatus === 'suspended' && s.user.is_suspended)
-            const matchesExam = filterExam === 'all' || String(s.primary_course) === String(filterExam) || (s.enrolled_course_ids || []).some((cid) => String(cid) === String(filterExam))
+            const matchesExam = filterExam === 'all' || (s.enrolled_course_ids || []).some((cid) => String(cid) === String(filterExam))
             return matchesSearch && matchesRole && matchesStatus && matchesExam
         })
 
@@ -606,7 +597,7 @@ const StudentManagement = () => {
             return
         }
         const headers = [
-            'Full Name', 'Email', 'Phone', 'Role', 'Status', 'Primary Course', 'Target Year',
+            'Full Name', 'Email', 'Phone', 'Role', 'Status', 'Enrolled Courses', 'Target Year',
             'Grade', 'School', 'Coaching', 'Board', 'Medium', 'City', 'State',
             'Level', 'Total XP', 'Accuracy %', 'Questions Attempted', 'Correct Answers', 'Study Minutes',
         ]
@@ -614,7 +605,8 @@ const StudentManagement = () => {
         const rows = filteredStudents.map((s) => [
             s.user.full_name, s.user.email, s.user.phone, s.user.role,
             s.user.is_suspended ? 'Suspended' : 'Active',
-            s.primary_course_name, s.target_year, s.grade, s.school, s.coaching, s.board, s.medium,
+            (s.enrolled_courses || []).map((c) => c.name).filter(Boolean).join('; '),
+            s.target_year, s.grade, s.school, s.coaching, s.board, s.medium,
             s.city, s.state, s.current_level, s.total_xp, s.overall_accuracy,
             s.total_questions_attempted, s.total_correct_answers, s.total_study_time_minutes,
         ].map(escape).join(','))
@@ -741,7 +733,20 @@ const StudentManagement = () => {
                                         </div>
                                     </td>
                                     <td className="px-6 py-4 text-sm text-surface-600 dark:text-surface-300">
-                                        {student.primary_course_name || <span className="text-surface-400">—</span>}
+                                        {(() => {
+                                            const enrolled = student.enrolled_courses || []
+                                            const names = [...new Set(enrolled.map((c) => c.name).filter(Boolean))]
+                                            if (!names.length) return <span className="text-surface-400">—</span>
+                                            return (
+                                                <div className="flex flex-wrap gap-1">
+                                                    {names.map((name) => (
+                                                        <span key={name} className="inline-block px-2 py-0.5 rounded-md bg-surface-100 dark:bg-surface-800 text-xs">
+                                                            {name}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            )
+                                        })()}
                                     </td>
                                     <td className="px-6 py-4">
                                         <button
@@ -824,7 +829,6 @@ const StudentManagement = () => {
                 {editingStudent && (
                     <StudentEditModal
                         student={editingStudent}
-                        exams={exams}
                         onClose={() => setEditingStudent(null)}
                     />
                 )}
@@ -871,7 +875,7 @@ const PerformanceReports = () => {
     // Roster filtered by the active course + status selectors.
     const filtered = useMemo(() => {
         return studentList.filter((s) => {
-            const matchesCourse = filterCourse === 'all' || String(s.primary_course) === String(filterCourse) || (s.enrolled_course_ids || []).some((cid) => String(cid) === String(filterCourse))
+            const matchesCourse = filterCourse === 'all' || (s.enrolled_course_ids || []).some((cid) => String(cid) === String(filterCourse))
             const matchesStatus =
                 filterStatus === 'all' ||
                 (filterStatus === 'active' && !s.user.is_suspended) ||
@@ -880,12 +884,11 @@ const PerformanceReports = () => {
         })
     }, [studentList, filterCourse, filterStatus])
 
-    // Aggregate the roster into per-course performance rows.
+    // Aggregate the roster into per-course performance rows. A student counts
+    // toward every course they're enrolled in (all courses are equal level).
     const courseStats = useMemo(() => {
         const map = new Map()
-        studentList.forEach((s) => {
-            const key = s.primary_course ?? 'none'
-            const name = s.primary_course_name || 'No Course Assigned'
+        const bump = (key, name, s) => {
             if (!map.has(key)) {
                 map.set(key, { id: key, name, students: 0, active: 0, xp: 0, level: 0, accuracy: 0, questions: 0, correct: 0, minutes: 0 })
             }
@@ -898,6 +901,14 @@ const PerformanceReports = () => {
             g.questions += s.total_questions_attempted || 0
             g.correct += s.total_correct_answers || 0
             g.minutes += s.total_study_time_minutes || 0
+        }
+        studentList.forEach((s) => {
+            const enrolled = s.enrolled_courses || []
+            if (enrolled.length) {
+                enrolled.forEach((c) => bump(c.id ?? 'none', c.name || 'Unnamed Course', s))
+            } else {
+                bump('none', 'No Course Assigned', s)
+            }
         })
         return Array.from(map.values())
             .map((g) => ({
@@ -928,6 +939,7 @@ const PerformanceReports = () => {
     )
 
     const courseLabel = filterCourse === 'all' ? 'all-courses' : (courseStats.find((c) => String(c.id) === String(filterCourse))?.name || 'course')
+    const courseNames = (s) => (s.enrolled_courses || []).map((c) => c.name).filter(Boolean).join('; ')
     const slug = (s) => String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
     const stamp = new Date().toISOString().slice(0, 10)
 
@@ -936,7 +948,7 @@ const PerformanceReports = () => {
         if (!filtered.length) return toast.error('No students match the current filters')
         const headers = ['Full Name', 'Email', 'Phone', 'Course', 'Status', 'Grade', 'Target Year', 'School', 'Coaching', 'Board', 'Medium', 'City', 'State', 'Level', 'Total XP', 'Accuracy %', 'Questions Attempted', 'Correct Answers', 'Study Minutes', 'Joined', 'Last Active']
         const rows = filtered.map((s) => [
-            s.user.full_name, s.user.email, s.user.phone, s.primary_course_name, s.user.is_suspended ? 'Suspended' : 'Active',
+            s.user.full_name, s.user.email, s.user.phone, courseNames(s), s.user.is_suspended ? 'Suspended' : 'Active',
             s.grade, s.target_year, s.school, s.coaching, s.board, s.medium, s.city, s.state,
             s.current_level, s.total_xp, s.overall_accuracy, s.total_questions_attempted, s.total_correct_answers, s.total_study_time_minutes,
             fmtDate(s.user.created_at), fmtDate(s.user.last_active),
@@ -957,7 +969,7 @@ const PerformanceReports = () => {
         const ranked = [...filtered].sort((a, b) => (b.total_xp || 0) - (a.total_xp || 0))
         if (!ranked.length) return toast.error('No students match the current filters')
         const headers = ['Rank', 'Full Name', 'Email', 'Course', 'Level', 'Total XP', 'Accuracy %']
-        const rows = ranked.map((s, i) => [i + 1, s.user.full_name, s.user.email, s.primary_course_name, s.current_level, s.total_xp, s.overall_accuracy])
+        const rows = ranked.map((s, i) => [i + 1, s.user.full_name, s.user.email, courseNames(s), s.current_level, s.total_xp, s.overall_accuracy])
         downloadCsv(headers, rows, `leaderboard-${slug(courseLabel)}-${stamp}.csv`)
         toast.success('Exported leaderboard')
     }
@@ -966,7 +978,7 @@ const PerformanceReports = () => {
         if (!filtered.length) return toast.error('No students match the current filters')
         const headers = ['Full Name', 'Email', 'Course', 'Status', 'Study Minutes', 'Questions Attempted', 'Correct Answers', 'Accuracy %', 'Joined', 'Last Active']
         const rows = filtered.map((s) => [
-            s.user.full_name, s.user.email, s.primary_course_name, s.user.is_suspended ? 'Suspended' : 'Active',
+            s.user.full_name, s.user.email, courseNames(s), s.user.is_suspended ? 'Suspended' : 'Active',
             s.total_study_time_minutes, s.total_questions_attempted, s.total_correct_answers, s.overall_accuracy,
             fmtDate(s.user.created_at), fmtDate(s.user.last_active),
         ])

--- a/frontend/exam-frontend/src/pages/Profile.jsx
+++ b/frontend/exam-frontend/src/pages/Profile.jsx
@@ -291,11 +291,11 @@ const Profile = () => {
             <div className="flex flex-wrap items-center gap-2 mt-3">
               <span className="badge-primary">Level {profile?.current_level || 1}</span>
               <span className="badge-success">{profile?.total_xp?.toLocaleString() || 0} XP</span>
-              {profile?.primary_course_name && (
-                <span className="px-2 py-1 text-xs rounded-lg bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
-                  {profile.primary_course_name}
+              {(profile?.enrolled_courses || []).filter((c) => c.name).map((c) => (
+                <span key={c.id || c.name} className="px-2 py-1 text-xs rounded-lg bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
+                  {c.name}
                 </span>
-              )}
+              ))}
             </div>
             {formData.bio && (
               <p className="text-sm text-surface-600 dark:text-surface-400 mt-3 italic">"{formData.bio}"</p>
@@ -500,13 +500,19 @@ const Profile = () => {
             )}
           </div>
 
-          {/* Course */}
+          {/* Courses */}
           <div>
-            <label className="block text-sm font-medium text-surface-500 mb-1">Primary Course</label>
-            <p className="text-base py-2">
-              <span className="px-2 py-1 text-xs rounded-lg bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
-                {profile?.primary_course_name || '—'}
-              </span>
+            <label className="block text-sm font-medium text-surface-500 mb-1">Enrolled Courses</label>
+            <p className="text-base py-2 flex flex-wrap gap-2">
+              {(profile?.enrolled_courses || []).filter((c) => c.name).length ? (
+                profile.enrolled_courses.filter((c) => c.name).map((c) => (
+                  <span key={c.id || c.name} className="px-2 py-1 text-xs rounded-lg bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300">
+                    {c.name}
+                  </span>
+                ))
+              ) : (
+                <span className="text-surface-400">—</span>
+              )}
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

Removes the `primary_course` concept entirely. Every course a student belongs to is now treated at the same level through `CourseEnrollment`.

This also fixes the reported bug: the **Student Records** roster showed a blank COURSE ("—") for enrolled students because it only read the unset `primary_course`.

## Changes

### Backend
- `users/models.py` — drop `primary_course` FK from `StudentProfile`.
- `users/migrations/0014_...` — remove the column.
- `users/serializers.py` — remove `primary_course`/`primary_course_name`; expose `enrolled_course_ids` and `enrolled_courses` (id/name/status).
- `users/views.py` — roster course filter now matches non-rejected enrollments (accepts `course` or legacy `primary_course` param); dropped `select_related('primary_course')`.
- `content/views.py`, `quiz/views.py`, `exams/views.py` — default-course resolution falls back to the student's first approved active enrollment.
- `users/admin.py`, `core/management/commands/seed_data.py` — removed `primary_course` usages.

### Frontend
- `AdminDashboard.jsx` — removed Primary Course edit field, detail-modal row, and CSV column; COURSE cell, filters, per-course performance aggregation, and report exports now derive from `enrolled_courses`. A student counts toward every enrolled course.
- `Profile.jsx` — replaced "Primary Course" with an "Enrolled Courses" list.

## Verification
- `manage.py makemigrations --check` → no changes; `manage.py check` → clean.
- Django test suite: 13/13 passing (migration applied cleanly to test DB).
- Both changed JSX files compile.

## Note
The migration **drops the `primary_course` column** — existing values are discarded. Since enrollments were already the source of truth and `primary_course` was never populated on enrollment, no course associations are lost.