### PR TITLE
Return topic page navigation directly to the course page

### DIFF
--- a/backend/exams/views.py
+++ b/backend/exams/views.py
@@ -696,6 +696,8 @@ class StudyChapterDetailView(APIView):
                 'description': chapter.description,
                 'subject_name': chapter.subject.name,
                 'subject_id': str(chapter.subject.id),
+                'course_id': str(chapter.subject.course_id),
+                'course_name': chapter.subject.course.name,
                 'estimated_hours': float(chapter.estimated_hours),
                 'locked': locked,
                 'locked_by': locked_by,

--- a/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
+++ b/frontend/exam-frontend/src/pages/StudyTopicContent.jsx
@@ -25,7 +25,7 @@ const TABS = [
 
 /**
  * Shows notes and quizzes for a single topic within a chapter.
- * Flow: Study → Subject → Chapters → Topics → [this page: topic content]
+ * Flow: Course (StudyCourse) → [this page: topic content]
  */
 const StudyTopicContent = () => {
   const { chapterId, topicId } = useParams()
@@ -74,10 +74,10 @@ const StudyTopicContent = () => {
       <div className="card p-8 text-center">
         <p className="text-surface-500">Topic not found.</p>
         <button
-          onClick={() => navigate(`/study/chapter/${chapterId}`)}
+          onClick={() => navigate(chapter?.course_id ? `/study/course/${chapter.course_id}` : '/study')}
           className="btn-outline mt-4"
         >
-          Back to topics
+          Back to course
         </button>
       </div>
     )
@@ -98,10 +98,10 @@ const StudyTopicContent = () => {
           {lockedBy?.name ? <> <span className="font-semibold">“{lockedBy.name}”</span></> : ' the previous chapter'} to unlock “{topic.name}”.
         </p>
         <button
-          onClick={() => navigate(`/study/chapter/${chapterId}`)}
+          onClick={() => navigate(chapter?.course_id ? `/study/course/${chapter.course_id}` : '/study')}
           className="btn-primary inline-flex items-center gap-2"
         >
-          <ArrowLeft size={16} /> Back to topics
+          <ArrowLeft size={16} /> Back to course
         </button>
       </div>
     )
@@ -127,25 +127,13 @@ const StudyTopicContent = () => {
       {/* Breadcrumb */}
       <div className="flex items-center gap-2 text-sm flex-wrap">
         <button
-          onClick={() => navigate('/study')}
+          onClick={() => navigate(`/study/course/${chapter?.course_id}`)}
           className="text-surface-500 hover:text-primary-600 flex items-center gap-1"
         >
-          <ArrowLeft size={16} /> Study
+          <ArrowLeft size={16} /> {chapter?.course_name || 'Course'}
         </button>
         <span className="text-surface-400">/</span>
-        <button
-          onClick={() => navigate(`/study/${chapter?.subject_id}`)}
-          className="text-surface-500 hover:text-primary-600"
-        >
-          {chapter?.subject_name}
-        </button>
-        <span className="text-surface-400">/</span>
-        <button
-          onClick={() => navigate(`/study/chapter/${chapterId}`)}
-          className="text-surface-500 hover:text-primary-600"
-        >
-          {chapter?.name}
-        </button>
+        <span className="text-surface-500">{chapter?.name}</span>
         <span className="text-surface-400">/</span>
         <span className="font-medium">{topic.name}</span>
       </div>


### PR DESCRIPTION
## Problem

From the course study page (`/study/course/:courseId`), entering a topic worked, but the topic content page's breadcrumb and back buttons sent users into the **old** `Study → Subject → Chapters → Topics` sub-page flow. As a result, coming back from a topic never returned to the course page.

## Changes

**Backend** (`exams/views.py`)
- The chapter-detail API now also returns `course_id` and `course_name`, so the topic page knows which course it belongs to.

**Frontend** (`StudyTopicContent.jsx`)
- Breadcrumb is now **`← Course / Chapter / Topic`**, with the back link going straight to `/study/course/:courseId`. Removed the intermediate Study/Subject/Chapter links.
- "Topic not found" and "locked chapter" back buttons now read **"Back to course"** and return to the course page.

The result is a clean two-level flow: **Course page ⇄ Topic page**. Quiz and content-viewer pages already returned correctly to the topic page, so those are unaffected.

## Notes
- The old routes (`/study/:subjectId`, `/study/chapter/:chapterId`) still exist but are no longer reachable from this flow.
- Backend needs a deploy for `course_name`/`course_id` to take effect; until then the breadcrumb falls back to "Course".

## Testing
- `vite build` passes.