### PR TITLE
Make streak & XP transparent for students, with polished icons

### DIFF
--- a/frontend/exam-frontend/src/App.jsx
+++ b/frontend/exam-frontend/src/App.jsx
@@ -39,6 +39,7 @@ import MockTestAttempt from './pages/MockTestAttempt'
 import MockTestReview from './pages/MockTestReview'
 import Analytics from './pages/Analytics'
 import Leaderboard from './pages/Leaderboard'
+import XPHistory from './pages/XPHistory'
 import Profile from './pages/Profile'
 import Notifications from './pages/Notifications'
 import AIDoubtSolver from './pages/AIDoubtSolver'
@@ -266,6 +267,7 @@ function App() {
           <Route path="/leaderboard" element={<LoginGate><FeatureRoute feature="leaderboard"><Leaderboard /></FeatureRoute></LoginGate>} />
           <Route path="/profile" element={<LoginGate><Profile /></LoginGate>} />
           <Route path="/notifications" element={<LoginGate><Notifications /></LoginGate>} />
+          <Route path="/xp" element={<LoginGate><XPHistory /></LoginGate>} />
           <Route path="/doubt-solver" element={<LoginGate><FeatureRoute feature="ai"><AIDoubtSolver /></FeatureRoute></LoginGate>} />
           <Route path="/ai-doubt-solver" element={<LoginGate><FeatureRoute feature="ai"><AIDoubtSolver /></FeatureRoute></LoginGate>} />
           <Route path="/ai-learning" element={<LoginGate><FeatureRoute feature="ai"><AILearning /></FeatureRoute></LoginGate>} />

--- a/frontend/exam-frontend/src/components/chat/ChatQuiz.jsx
+++ b/frontend/exam-frontend/src/components/chat/ChatQuiz.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Zap } from 'lucide-react'
 import MathRenderer from './MathRenderer'
 import { chatService } from '../../services/chatService'
 import confetti from 'canvas-confetti'
@@ -257,7 +258,7 @@ const ChatQuiz = ({ quiz, sessionId, onComplete }) => {
               transition={{ delay: 0.3 }}
               className="mt-3 inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-violet-500 to-purple-600 text-white rounded-full font-semibold"
             >
-              <span>⚡</span>
+              <Zap className="w-4 h-4" fill="currentColor" strokeWidth={1.5} />
               <span>+{xpEarned} XP Earned!</span>
             </motion.div>
           )}

--- a/frontend/exam-frontend/src/components/common/StreakFire.jsx
+++ b/frontend/exam-frontend/src/components/common/StreakFire.jsx
@@ -1,11 +1,12 @@
 import { motion } from 'framer-motion'
+import { Flame } from 'lucide-react'
 
 const StreakFire = ({ streak, size = 'md' }) => {
   const sizes = {
-    sm: { container: 'w-12 h-12', text: 'text-sm', icon: 'text-xl' },
-    md: { container: 'w-16 h-16', text: 'text-base', icon: 'text-2xl' },
-    lg: { container: 'w-20 h-20', text: 'text-xl', icon: 'text-3xl' },
-    xl: { container: 'w-24 h-24', text: 'text-2xl', icon: 'text-4xl' },
+    sm: { container: 'w-12 h-12', text: 'text-sm', icon: 'w-5 h-5' },
+    md: { container: 'w-16 h-16', text: 'text-base', icon: 'w-7 h-7' },
+    lg: { container: 'w-20 h-20', text: 'text-xl', icon: 'w-9 h-9' },
+    xl: { container: 'w-24 h-24', text: 'text-2xl', icon: 'w-11 h-11' },
   }
 
   const { container, text, icon } = sizes[size]
@@ -17,25 +18,25 @@ const StreakFire = ({ streak, size = 'md' }) => {
       className={`${container} relative flex flex-col items-center justify-center`}
     >
       {/* Glow effect */}
-      <div className="absolute inset-0 bg-gradient-to-t from-orange-500/30 to-yellow-400/30 rounded-full blur-xl animate-pulse" />
-      
+      <div className="absolute inset-0 bg-gradient-to-t from-orange-500/30 to-amber-400/30 rounded-full blur-xl animate-pulse" />
+
       {/* Fire container */}
       <div className="relative z-10 flex flex-col items-center">
         <motion.span
           animate={{ 
             y: [0, -2, 0],
-            scale: [1, 1.1, 1]
+            scale: [1, 1.08, 1]
           }}
           transition={{ 
-            duration: 0.5, 
+            duration: 1.6, 
             repeat: Infinity,
             ease: "easeInOut"
           }}
-          className={`${icon}`}
+          className="drop-shadow-[0_2px_6px_rgba(249,115,22,0.45)]"
         >
-          🔥
+          <Flame className={`${icon} text-orange-500`} fill="currentColor" strokeWidth={1.5} />
         </motion.span>
-        <span className={`${text} font-bold text-primary-600 dark:text-primary-400 -mt-1`}>
+        <span className={`${text} font-bold text-orange-600 dark:text-orange-400 -mt-0.5 tabular-nums`}>
           {streak}
         </span>
       </div>

--- a/frontend/exam-frontend/src/components/common/StudyTimer.jsx
+++ b/frontend/exam-frontend/src/components/common/StudyTimer.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Flame, CheckCircle2, Zap, Timer } from 'lucide-react'
 import { analyticsService } from '../../services/analyticsService'
 import toast from 'react-hot-toast'
 import confetti from 'canvas-confetti'
@@ -207,13 +208,14 @@ const StudyTimer = () => {
 
   // Get status info
   const getStatus = () => {
-    if (exceededGoal) return { emoji: '🔥', color: 'success', label: 'Excellent!' }
-    if (timerData.goal_achieved) return { emoji: '✅', color: 'success', label: 'Done!' }
-    if (remainingSeconds < 300) return { emoji: '⚡', color: 'warning', label: 'Almost!' }
-    return { emoji: '⏱️', color: 'primary', label: 'Study' }
+    if (exceededGoal) return { Icon: Flame, color: 'success', label: 'Excellent!' }
+    if (timerData.goal_achieved) return { Icon: CheckCircle2, color: 'success', label: 'Done!' }
+    if (remainingSeconds < 300) return { Icon: Zap, color: 'warning', label: 'Almost!' }
+    return { Icon: Timer, color: 'primary', label: 'Study' }
   }
 
   const status = getStatus()
+  const StatusIcon = status.Icon
 
   const handleDragEnd = (event, info) => {
     setPosition({ x: info.point.x, y: info.point.y })
@@ -274,9 +276,9 @@ const StudyTimer = () => {
             >
               <button
                 onClick={() => setViewMode('expanded')}
-                className={`w-10 h-10 rounded-full ${colors.bg} shadow-lg flex items-center justify-center text-lg hover:scale-110 transition-transform ring-4 ${colors.ring}`}
+                className={`w-10 h-10 rounded-full ${colors.bg} shadow-lg flex items-center justify-center hover:scale-110 transition-transform ring-4 ${colors.ring}`}
               >
-                {status.emoji}
+                <StatusIcon className="w-5 h-5 text-white" strokeWidth={2} />
               </button>
 
               {/* Progress ring */}
@@ -355,10 +357,10 @@ const StudyTimer = () => {
               {/* Minimize button */}
               <button
                 onClick={() => setViewMode('minimal')}
-                className="text-sm hover:scale-110 transition-transform"
+                className="hover:scale-110 transition-transform"
                 title="Minimize"
               >
-                {status.emoji}
+                <StatusIcon className={`w-4 h-4 ${colors.textDark}`} strokeWidth={2} />
               </button>
 
               {/* Time - click to expand */}
@@ -410,7 +412,7 @@ const StudyTimer = () => {
                 className={`px-4 py-3 ${exceededGoal ? 'bg-success-500' : timerData.goal_achieved ? 'bg-success-100 dark:bg-success-900/50' : 'bg-primary-50 dark:bg-primary-900/20'} flex items-center justify-between`}
               >
                 <div className="flex items-center gap-2">
-                  <span className="text-lg">{status.emoji}</span>
+                  <StatusIcon className={`w-5 h-5 ${exceededGoal ? 'text-white' : colors.textDark}`} strokeWidth={2} />
                   <span className={`font-semibold text-sm ${exceededGoal ? 'text-white' : colors.textDark}`}>
                     {status.label}
                   </span>

--- a/frontend/exam-frontend/src/components/layout/Header.jsx
+++ b/frontend/exam-frontend/src/components/layout/Header.jsx
@@ -2,11 +2,11 @@ import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import { motion } from 'framer-motion'
-import { useQuery } from '@tanstack/react-query'
 import { useAuthStore } from '../../context/authStore'
 import { useAppStore } from '../../context/appStore'
-import { analyticsService } from '../../services/analyticsService'
 import NotificationBell from './NotificationBell'
+import StreakChip from './StreakChip'
+import XPChip from './XPChip'
 
 const Header = () => {
   const navigate = useNavigate()
@@ -18,14 +18,6 @@ const Header = () => {
   const isAdmin = profile?.user?.role === 'admin'
   const isAdminView = location.pathname.startsWith('/admin-dashboard')
 
-
-  // Fetch current streak
-  const { data: streakData } = useQuery({
-    queryKey: ['currentStreak'],
-    queryFn: () => analyticsService.getCurrentStreak(),
-    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
-    enabled: isAuthenticated,
-  })
 
   return (
     <header className="sticky top-0 z-30 bg-white/80 dark:bg-surface-900/80 backdrop-blur-lg border-b border-surface-200 dark:border-surface-800">
@@ -96,24 +88,11 @@ const Header = () => {
         {/* Right Section */}
         <div className="flex items-center gap-2 lg:gap-4">
           {/* Streak Indicator */}
-          {(streakData?.current_streak > 0) && (
-            <div className="hidden sm:flex items-center gap-1 px-3 py-1.5 rounded-full bg-primary-50 dark:bg-primary-900/30">
-              <span className="text-lg">🔥</span>
-              <span className="font-semibold text-primary-600 dark:text-primary-400">
-                {streakData?.current_streak || 0}
-              </span>
-            </div>
-          )}
+          <StreakChip enabled={isAuthenticated} />
 
           {/* XP */}
-          {isAuthenticated && (
-            <div className="hidden sm:flex items-center gap-1 px-3 py-1.5 rounded-full bg-accent-50 dark:bg-accent-900/30">
-              <span className="text-lg">⚡</span>
-              <span className="font-semibold text-accent-600 dark:text-accent-400">
-                {profile?.total_xp?.toLocaleString() || 0}
-              </span>
-            </div>
-          )}
+          <XPChip enabled={isAuthenticated} />
+
 
           {/* Dark Mode Toggle */}
           <button

--- a/frontend/exam-frontend/src/components/layout/StreakChip.jsx
+++ b/frontend/exam-frontend/src/components/layout/StreakChip.jsx
@@ -1,0 +1,148 @@
+import { useState, useRef, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useQuery } from '@tanstack/react-query'
+import { Flame, Trophy, CalendarCheck, CheckCircle2, AlertCircle } from 'lucide-react'
+
+import { analyticsService } from '../../services/analyticsService'
+
+const formatDate = (iso) => {
+    if (!iso) return '—'
+    return new Date(iso).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+const isToday = (iso) => {
+    if (!iso) return false
+    const today = new Date()
+    const d = new Date(iso)
+    return (
+        d.getFullYear() === today.getFullYear() &&
+        d.getMonth() === today.getMonth() &&
+        d.getDate() === today.getDate()
+    )
+}
+
+const StreakChip = ({ enabled = true }) => {
+    const [open, setOpen] = useState(false)
+    const ref = useRef(null)
+
+    const { data } = useQuery({
+        queryKey: ['currentStreak'],
+        queryFn: () => analyticsService.getCurrentStreak(),
+        staleTime: 5 * 60 * 1000,
+        enabled,
+    })
+
+    useEffect(() => {
+        if (!open) return undefined
+        const onClick = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false) }
+        const onKey = (e) => { if (e.key === 'Escape') setOpen(false) }
+        document.addEventListener('mousedown', onClick)
+        document.addEventListener('keydown', onKey)
+        return () => {
+            document.removeEventListener('mousedown', onClick)
+            document.removeEventListener('keydown', onKey)
+        }
+    }, [open])
+
+    const current = data?.current_streak || 0
+    if (!enabled || current <= 0) return null
+
+    const countedToday = isToday(data?.last_activity_date)
+
+    return (
+        <div className="relative hidden sm:block" ref={ref}>
+            <button
+                onClick={() => setOpen((v) => !v)}
+                aria-label={`Study streak: ${current} days. Click for details`}
+                aria-expanded={open}
+                className="flex items-center gap-1.5 pl-2 pr-3 py-1.5 rounded-full bg-gradient-to-br from-orange-50 to-amber-50 dark:from-orange-950/40 dark:to-amber-950/30 ring-1 ring-orange-200/70 dark:ring-orange-800/50 hover:ring-orange-300 dark:hover:ring-orange-700 transition-all"
+            >
+                <span className="relative flex items-center justify-center w-6 h-6 rounded-full bg-gradient-to-br from-orange-400 to-red-500 shadow-sm shadow-orange-500/30">
+                    <Flame className="w-3.5 h-3.5 text-white" fill="currentColor" strokeWidth={1.5} />
+                </span>
+                <span className="font-semibold text-sm text-orange-600 dark:text-orange-400 tabular-nums">
+                    {current}
+                </span>
+            </button>
+
+            <AnimatePresence>
+                {open && (
+                    <motion.div
+                        initial={{ opacity: 0, y: 8, scale: 0.98 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: 8, scale: 0.98 }}
+                        transition={{ duration: 0.15 }}
+                        className="absolute right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] card shadow-xl overflow-hidden z-50"
+                    >
+                        <div className="px-4 py-3 bg-gradient-to-br from-orange-50 to-amber-50 dark:from-orange-950/40 dark:to-amber-950/20 border-b border-surface-200 dark:border-surface-700">
+                            <div className="flex items-center gap-3">
+                                <span className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-orange-400 to-red-500 shadow-sm shadow-orange-500/30">
+                                    <Flame className="w-5 h-5 text-white" fill="currentColor" strokeWidth={1.5} />
+                                </span>
+                                <div>
+                                    <p className="font-semibold leading-tight">
+                                        {current} day{current === 1 ? '' : 's'} in a row
+                                    </p>
+                                    <p className="text-xs text-surface-500 mt-0.5">
+                                        Your study streak
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="px-4 py-3">
+                            <p className="text-xs text-surface-600 dark:text-surface-300 leading-relaxed">
+                                Your streak counts the number of <strong>consecutive days</strong> you have studied.
+                                It goes up by one each new day you are active, and resets to 1 if you skip a full day.
+                            </p>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-px bg-surface-200 dark:bg-surface-700 border-y border-surface-200 dark:border-surface-700">
+                            <div className="bg-white dark:bg-surface-900 px-4 py-3">
+                                <div className="flex items-center gap-1.5 text-surface-500">
+                                    <Trophy className="w-3.5 h-3.5" />
+                                    <span className="text-[11px] font-medium uppercase tracking-wide">Longest</span>
+                                </div>
+                                <p className="text-lg font-bold mt-0.5 tabular-nums">
+                                    {data?.longest_streak || 0}
+                                    <span className="text-xs font-medium text-surface-400 ml-1">days</span>
+                                </p>
+                            </div>
+                            <div className="bg-white dark:bg-surface-900 px-4 py-3">
+                                <div className="flex items-center gap-1.5 text-surface-500">
+                                    <CalendarCheck className="w-3.5 h-3.5" />
+                                    <span className="text-[11px] font-medium uppercase tracking-wide">Active days</span>
+                                </div>
+                                <p className="text-lg font-bold mt-0.5 tabular-nums">
+                                    {data?.total_active_days || 0}
+                                    <span className="text-xs font-medium text-surface-400 ml-1">total</span>
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className={`flex items-start gap-2 px-4 py-3 text-xs ${countedToday
+                            ? 'text-green-700 dark:text-green-400 bg-green-50/60 dark:bg-green-900/10'
+                            : 'text-amber-700 dark:text-amber-400 bg-amber-50/60 dark:bg-amber-900/10'
+                            }`}>
+                            {countedToday ? (
+                                <>
+                                    <CheckCircle2 className="w-4 h-4 shrink-0 mt-px" />
+                                    <span>Today is counted. Come back tomorrow to make it {current + 1}.</span>
+                                </>
+                            ) : (
+                                <>
+                                    <AlertCircle className="w-4 h-4 shrink-0 mt-px" />
+                                    <span>
+                                        Study today to keep your streak alive — last active {formatDate(data?.last_activity_date)}.
+                                    </span>
+                                </>
+                            )}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+export default StreakChip

--- a/frontend/exam-frontend/src/components/layout/XPChip.jsx
+++ b/frontend/exam-frontend/src/components/layout/XPChip.jsx
@@ -1,0 +1,166 @@
+import { useState, useRef, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useQuery } from '@tanstack/react-query'
+import { Zap, ChevronRight, Sparkles } from 'lucide-react'
+
+import { gamificationService } from '../../services/gamificationService'
+import { useAuthStore } from '../../context/authStore'
+import { getXPMeta, getLevelBounds, getLevelProgress } from '../../utils/xp'
+import { timeAgo } from './NotificationBell'
+
+const XPChip = ({ enabled = true }) => {
+    const navigate = useNavigate()
+    const { profile } = useAuthStore()
+    const [open, setOpen] = useState(false)
+    const ref = useRef(null)
+
+    const { data: history, isLoading } = useQuery({
+        queryKey: ['xpHistory', 'recent'],
+        queryFn: () => gamificationService.getXPHistory(),
+        enabled: enabled && open,
+        staleTime: 60 * 1000,
+    })
+
+    useEffect(() => {
+        if (!open) return undefined
+        const onClick = (e) => { if (ref.current && !ref.current.contains(e.target)) setOpen(false) }
+        const onKey = (e) => { if (e.key === 'Escape') setOpen(false) }
+        document.addEventListener('mousedown', onClick)
+        document.addEventListener('keydown', onKey)
+        return () => {
+            document.removeEventListener('mousedown', onClick)
+            document.removeEventListener('keydown', onKey)
+        }
+    }, [open])
+
+    if (!enabled) return null
+
+    const totalXP = profile?.total_xp || 0
+    const level = profile?.current_level || 1
+    const toNextLevel = Math.max(0, profile?.xp_for_next_level ?? 0)
+    const progress = getLevelProgress(totalXP, level)
+    const { end } = getLevelBounds(level)
+
+    const items = (Array.isArray(history) ? history : history?.results || []).slice(0, 5)
+
+    return (
+        <div className="relative hidden sm:block" ref={ref}>
+            <button
+                onClick={() => setOpen((v) => !v)}
+                aria-label={`Total XP: ${totalXP}. Click for details`}
+                aria-expanded={open}
+                className="flex items-center gap-1.5 pl-2 pr-3 py-1.5 rounded-full bg-gradient-to-br from-violet-50 to-fuchsia-50 dark:from-violet-950/40 dark:to-fuchsia-950/30 ring-1 ring-violet-200/70 dark:ring-violet-800/50 hover:ring-violet-300 dark:hover:ring-violet-700 transition-all"
+            >
+                <span className="flex items-center justify-center w-6 h-6 rounded-full bg-gradient-to-br from-violet-500 to-fuchsia-500 shadow-sm shadow-violet-500/30">
+                    <Zap className="w-3.5 h-3.5 text-white" fill="currentColor" strokeWidth={1.5} />
+                </span>
+                <span className="font-semibold text-sm text-violet-600 dark:text-violet-400 tabular-nums">
+                    {totalXP.toLocaleString()}
+                </span>
+            </button>
+
+            <AnimatePresence>
+                {open && (
+                    <motion.div
+                        initial={{ opacity: 0, y: 8, scale: 0.98 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: 8, scale: 0.98 }}
+                        transition={{ duration: 0.15 }}
+                        className="absolute right-0 mt-2 w-80 sm:w-96 max-w-[calc(100vw-2rem)] card shadow-xl overflow-hidden z-50"
+                    >
+                        <div className="px-4 py-3 bg-gradient-to-br from-violet-50 to-fuchsia-50 dark:from-violet-950/40 dark:to-fuchsia-950/20 border-b border-surface-200 dark:border-surface-700">
+                            <div className="flex items-center gap-3">
+                                <span className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-violet-500 to-fuchsia-500 shadow-sm shadow-violet-500/30">
+                                    <Zap className="w-5 h-5 text-white" fill="currentColor" strokeWidth={1.5} />
+                                </span>
+                                <div className="min-w-0">
+                                    <p className="font-semibold leading-tight">
+                                        {totalXP.toLocaleString()} XP earned
+                                    </p>
+                                    <p className="text-xs text-surface-500 mt-0.5">
+                                        Experience points from everything you study
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div className="mt-3">
+                                <div className="flex items-center justify-between text-[11px] font-medium mb-1">
+                                    <span className="text-violet-700 dark:text-violet-300">Level {level}</span>
+                                    <span className="text-surface-500 tabular-nums">
+                                        {totalXP.toLocaleString()} / {end.toLocaleString()} XP
+                                    </span>
+                                </div>
+                                <div className="h-2 rounded-full bg-white/70 dark:bg-surface-800 overflow-hidden">
+                                    <motion.div
+                                        initial={{ width: 0 }}
+                                        animate={{ width: `${progress}%` }}
+                                        transition={{ duration: 0.5, ease: 'easeOut' }}
+                                        className="h-full rounded-full bg-gradient-to-r from-violet-500 to-fuchsia-500"
+                                    />
+                                </div>
+                                <p className="text-[11px] text-surface-500 mt-1">
+                                    {toNextLevel > 0
+                                        ? `${toNextLevel.toLocaleString()} XP to reach Level ${level + 1}`
+                                        : `Ready for Level ${level + 1}!`}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="px-4 pt-3 pb-1">
+                            <p className="text-[11px] font-semibold uppercase tracking-wide text-surface-500">
+                                Recent XP
+                            </p>
+                        </div>
+
+                        <div className="max-h-64 overflow-y-auto pb-1">
+                            {isLoading ? (
+                                <div className="p-6 text-center text-sm text-surface-500">Loading…</div>
+                            ) : items.length === 0 ? (
+                                <div className="px-4 py-6 text-center">
+                                    <Sparkles className="w-7 h-7 mx-auto text-surface-300 mb-2" />
+                                    <p className="text-sm text-surface-500">
+                                        No XP yet. Finish a lesson or quiz to get started.
+                                    </p>
+                                </div>
+                            ) : (
+                                items.map((t) => {
+                                    const meta = getXPMeta(t.transaction_type)
+                                    const { Icon } = meta
+                                    return (
+                                        <div key={t.id} className="flex items-center gap-3 px-4 py-2">
+                                            <div className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${meta.bg}`}>
+                                                <Icon className={`w-4 h-4 ${meta.color}`} />
+                                            </div>
+                                            <div className="min-w-0 flex-1">
+                                                <p className="text-sm font-medium truncate">
+                                                    {t.description || t.transaction_type_display || meta.label}
+                                                </p>
+                                                <p className="text-[11px] text-surface-400">
+                                                    {t.transaction_type_display || meta.label} · {timeAgo(t.created_at)}
+                                                </p>
+                                            </div>
+                                            <span className={`shrink-0 text-sm font-bold tabular-nums ${t.xp_amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'}`}>
+                                                {t.xp_amount >= 0 ? '+' : ''}{t.xp_amount}
+                                            </span>
+                                        </div>
+                                    )
+                                })
+                            )}
+                        </div>
+
+                        <button
+                            onClick={() => { setOpen(false); navigate('/xp') }}
+                            className="w-full py-3 text-sm font-medium text-primary-600 hover:bg-surface-50 dark:hover:bg-surface-800/50 transition-colors border-t border-surface-200 dark:border-surface-700 flex items-center justify-center gap-1"
+                        >
+                            View all XP &amp; how it&apos;s earned
+                            <ChevronRight className="w-4 h-4" />
+                        </button>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+export default XPChip

--- a/frontend/exam-frontend/src/pages/XPHistory.jsx
+++ b/frontend/exam-frontend/src/pages/XPHistory.jsx
@@ -1,0 +1,261 @@
+import { useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { useQuery } from '@tanstack/react-query'
+import { Zap, Flame, ArrowLeft, Trophy, CalendarCheck, Sparkles, Info } from 'lucide-react'
+
+import { gamificationService } from '../services/gamificationService'
+import { analyticsService } from '../services/analyticsService'
+import { useAuthStore } from '../context/authStore'
+import { getXPMeta, getLevelBounds, getLevelProgress, XP_EARNING_RULES } from '../utils/xp'
+
+const formatDayLabel = (iso) => {
+    const d = new Date(iso)
+    const today = new Date()
+    const yesterday = new Date()
+    yesterday.setDate(today.getDate() - 1)
+    const same = (a, b) =>
+        a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
+    if (same(d, today)) return 'Today'
+    if (same(d, yesterday)) return 'Yesterday'
+    return d.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+const formatTime = (iso) =>
+    new Date(iso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+
+const XPHistory = () => {
+    const navigate = useNavigate()
+    const { profile } = useAuthStore()
+
+    const { data: history, isLoading } = useQuery({
+        queryKey: ['xpHistory', 'all'],
+        queryFn: () => gamificationService.getXPHistory(),
+    })
+
+    const { data: streak } = useQuery({
+        queryKey: ['currentStreak'],
+        queryFn: () => analyticsService.getCurrentStreak(),
+        staleTime: 5 * 60 * 1000,
+    })
+
+    const transactions = useMemo(
+        () => (Array.isArray(history) ? history : history?.results || []),
+        [history]
+    )
+
+    const groups = useMemo(() => {
+        const map = new Map()
+        transactions.forEach((t) => {
+            const key = new Date(t.created_at).toDateString()
+            if (!map.has(key)) map.set(key, [])
+            map.get(key).push(t)
+        })
+        return Array.from(map.entries())
+    }, [transactions])
+
+    const totalXP = profile?.total_xp || 0
+    const level = profile?.current_level || 1
+    const toNextLevel = Math.max(0, profile?.xp_for_next_level ?? 0)
+    const progress = getLevelProgress(totalXP, level)
+    const { end } = getLevelBounds(level)
+
+    return (
+        <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
+            <button
+                onClick={() => navigate(-1)}
+                className="flex items-center gap-1.5 text-sm font-medium text-surface-500 hover:text-surface-900 dark:hover:text-surface-100 transition-colors"
+            >
+                <ArrowLeft className="w-4 h-4" /> Back
+            </button>
+
+            {/* XP summary */}
+            <div className="card overflow-hidden">
+                <div className="p-6 bg-gradient-to-br from-violet-50 to-fuchsia-50 dark:from-violet-950/40 dark:to-fuchsia-950/20">
+                    <div className="flex items-center gap-4">
+                        <span className="flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-violet-500 to-fuchsia-500 shadow-lg shadow-violet-500/30">
+                            <Zap className="w-7 h-7 text-white" fill="currentColor" strokeWidth={1.5} />
+                        </span>
+                        <div>
+                            <h1 className="text-2xl font-bold tabular-nums">{totalXP.toLocaleString()} XP</h1>
+                            <p className="text-sm text-surface-500">
+                                Level {level} · your all-time experience points
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="mt-5">
+                        <div className="flex items-center justify-between text-xs font-medium mb-1.5">
+                            <span className="text-violet-700 dark:text-violet-300">Level {level}</span>
+                            <span className="text-surface-500 tabular-nums">
+                                {totalXP.toLocaleString()} / {end.toLocaleString()} XP
+                            </span>
+                        </div>
+                        <div className="h-2.5 rounded-full bg-white/70 dark:bg-surface-800 overflow-hidden">
+                            <motion.div
+                                initial={{ width: 0 }}
+                                animate={{ width: `${progress}%` }}
+                                transition={{ duration: 0.6, ease: 'easeOut' }}
+                                className="h-full rounded-full bg-gradient-to-r from-violet-500 to-fuchsia-500"
+                            />
+                        </div>
+                        <p className="text-xs text-surface-500 mt-1.5">
+                            {toNextLevel > 0
+                                ? `${toNextLevel.toLocaleString()} XP to reach Level ${level + 1}`
+                                : `Ready for Level ${level + 1}!`}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            {/* Streak summary */}
+            <div className="card p-6">
+                <div className="flex items-center gap-4">
+                    <span className="flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-orange-400 to-red-500 shadow-lg shadow-orange-500/30">
+                        <Flame className="w-7 h-7 text-white" fill="currentColor" strokeWidth={1.5} />
+                    </span>
+                    <div>
+                        <h2 className="text-2xl font-bold tabular-nums">
+                            {streak?.current_streak || 0}
+                            <span className="text-base font-semibold text-surface-400 ml-1.5">day streak</span>
+                        </h2>
+                        <p className="text-sm text-surface-500">Consecutive days you have studied</p>
+                    </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4 mt-5">
+                    <div className="rounded-xl bg-surface-50 dark:bg-surface-800/50 px-4 py-3">
+                        <div className="flex items-center gap-1.5 text-surface-500">
+                            <Trophy className="w-3.5 h-3.5" />
+                            <span className="text-[11px] font-medium uppercase tracking-wide">Longest streak</span>
+                        </div>
+                        <p className="text-xl font-bold mt-0.5 tabular-nums">
+                            {streak?.longest_streak || 0}
+                            <span className="text-xs font-medium text-surface-400 ml-1">days</span>
+                        </p>
+                    </div>
+                    <div className="rounded-xl bg-surface-50 dark:bg-surface-800/50 px-4 py-3">
+                        <div className="flex items-center gap-1.5 text-surface-500">
+                            <CalendarCheck className="w-3.5 h-3.5" />
+                            <span className="text-[11px] font-medium uppercase tracking-wide">Active days</span>
+                        </div>
+                        <p className="text-xl font-bold mt-0.5 tabular-nums">
+                            {streak?.total_active_days || 0}
+                            <span className="text-xs font-medium text-surface-400 ml-1">total</span>
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex items-start gap-2 mt-4 text-xs text-surface-600 dark:text-surface-300 bg-surface-50 dark:bg-surface-800/50 rounded-xl px-4 py-3">
+                    <Info className="w-4 h-4 shrink-0 mt-px text-surface-400" />
+                    <span>
+                        Any studying activity on a given day keeps the streak going. Study on the next calendar
+                        day and it grows by one; miss a full day and it restarts at 1.
+                    </span>
+                </div>
+            </div>
+
+            {/* How XP is earned */}
+            <div className="card p-6">
+                <h2 className="text-lg font-semibold">How XP is earned</h2>
+                <p className="text-sm text-surface-500 mt-1">
+                    Every point below is awarded automatically the moment you complete the activity.
+                </p>
+
+                <div className="grid sm:grid-cols-2 gap-3 mt-4">
+                    {XP_EARNING_RULES.map((rule) => {
+                        const { Icon } = rule
+                        return (
+                            <div
+                                key={rule.title}
+                                className="flex gap-3 rounded-xl border border-surface-200 dark:border-surface-700 p-3"
+                            >
+                                <div className="shrink-0 w-9 h-9 rounded-lg bg-surface-100 dark:bg-surface-800 flex items-center justify-center">
+                                    <Icon className="w-4 h-4 text-primary-600 dark:text-primary-400" />
+                                </div>
+                                <div className="min-w-0">
+                                    <div className="flex items-baseline justify-between gap-2">
+                                        <p className="text-sm font-semibold">{rule.title}</p>
+                                        <span className="shrink-0 text-[11px] font-semibold text-violet-600 dark:text-violet-400 whitespace-nowrap">
+                                            {rule.value}
+                                        </span>
+                                    </div>
+                                    <p className="text-xs text-surface-500 mt-0.5 leading-relaxed">{rule.detail}</p>
+                                </div>
+                            </div>
+                        )
+                    })}
+                </div>
+            </div>
+
+            {/* Ledger */}
+            <div className="card overflow-hidden">
+                <div className="px-6 py-4 border-b border-surface-200 dark:border-surface-700">
+                    <h2 className="text-lg font-semibold">XP history</h2>
+                    <p className="text-sm text-surface-500 mt-0.5">Every point you have ever earned.</p>
+                </div>
+
+                {isLoading ? (
+                    <div className="p-8 text-center text-sm text-surface-500">Loading…</div>
+                ) : groups.length === 0 ? (
+                    <div className="p-10 text-center">
+                        <Sparkles className="w-9 h-9 mx-auto text-surface-300 mb-2" />
+                        <p className="text-sm text-surface-500">
+                            No XP yet. Complete a lesson or a quiz to start earning.
+                        </p>
+                    </div>
+                ) : (
+                    groups.map(([day, items]) => {
+                        const dayTotal = items.reduce((sum, t) => sum + (t.xp_amount || 0), 0)
+                        return (
+                            <div key={day}>
+                                <div className="flex items-center justify-between px-6 py-2 bg-surface-50 dark:bg-surface-800/50 border-y border-surface-200 dark:border-surface-700">
+                                    <span className="text-xs font-semibold text-surface-600 dark:text-surface-300">
+                                        {formatDayLabel(items[0].created_at)}
+                                    </span>
+                                    <span className="text-xs font-bold text-green-600 dark:text-green-400 tabular-nums">
+                                        {dayTotal >= 0 ? '+' : ''}{dayTotal} XP
+                                    </span>
+                                </div>
+                                {items.map((t) => {
+                                    const meta = getXPMeta(t.transaction_type)
+                                    const { Icon } = meta
+                                    return (
+                                        <div
+                                            key={t.id}
+                                            className="flex items-center gap-3 px-6 py-3 border-b border-surface-100 dark:border-surface-800"
+                                        >
+                                            <div className={`shrink-0 w-9 h-9 rounded-full flex items-center justify-center ${meta.bg}`}>
+                                                <Icon className={`w-4 h-4 ${meta.color}`} />
+                                            </div>
+                                            <div className="min-w-0 flex-1">
+                                                <p className="text-sm font-medium truncate">
+                                                    {t.description || t.transaction_type_display || meta.label}
+                                                </p>
+                                                <p className="text-[11px] text-surface-400">
+                                                    {t.transaction_type_display || meta.label} · {formatTime(t.created_at)}
+                                                </p>
+                                            </div>
+                                            <div className="shrink-0 text-right">
+                                                <p className={`text-sm font-bold tabular-nums ${t.xp_amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'}`}>
+                                                    {t.xp_amount >= 0 ? '+' : ''}{t.xp_amount}
+                                                </p>
+                                                {t.balance_after != null && (
+                                                    <p className="text-[11px] text-surface-400 tabular-nums">
+                                                        {t.balance_after.toLocaleString()} total
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </div>
+                                    )
+                                })}
+                            </div>
+                        )
+                    })
+                )}
+            </div>
+        </div>
+    )
+}
+
+export default XPHistory

--- a/frontend/exam-frontend/src/utils/xp.js
+++ b/frontend/exam-frontend/src/utils/xp.js
@@ -1,0 +1,185 @@
+import {
+    BookOpen,
+    Brain,
+    Award,
+    Target,
+    Flame,
+    Users,
+    Sparkles,
+    TrendingUp,
+    Code2,
+    ClipboardCheck,
+    FileText,
+    Trophy,
+    Gift,
+    SlidersHorizontal,
+} from 'lucide-react'
+
+/**
+ * Visual + explanatory metadata for every XPTransaction.transaction_type
+ * defined in backend/gamification/models.py.
+ */
+export const XP_META = {
+    quiz_complete: {
+        Icon: ClipboardCheck,
+        label: 'Quiz completed',
+        color: 'text-primary-600 dark:text-primary-400',
+        bg: 'bg-primary-100 dark:bg-primary-900/30',
+    },
+    mock_complete: {
+        Icon: FileText,
+        label: 'Mock test completed',
+        color: 'text-indigo-600 dark:text-indigo-400',
+        bg: 'bg-indigo-100 dark:bg-indigo-900/30',
+    },
+    content_complete: {
+        Icon: BookOpen,
+        label: 'Study material completed',
+        color: 'text-emerald-600 dark:text-emerald-400',
+        bg: 'bg-emerald-100 dark:bg-emerald-900/30',
+    },
+    ai_quiz: {
+        Icon: Brain,
+        label: 'AI quiz completed',
+        color: 'text-violet-600 dark:text-violet-400',
+        bg: 'bg-violet-100 dark:bg-violet-900/30',
+    },
+    coding_solved: {
+        Icon: Code2,
+        label: 'Coding problem solved',
+        color: 'text-cyan-600 dark:text-cyan-400',
+        bg: 'bg-cyan-100 dark:bg-cyan-900/30',
+    },
+    assignment_graded: {
+        Icon: ClipboardCheck,
+        label: 'Assignment graded',
+        color: 'text-teal-600 dark:text-teal-400',
+        bg: 'bg-teal-100 dark:bg-teal-900/30',
+    },
+    daily_goal: {
+        Icon: Target,
+        label: 'Daily goal met',
+        color: 'text-green-600 dark:text-green-400',
+        bg: 'bg-green-100 dark:bg-green-900/30',
+    },
+    streak_bonus: {
+        Icon: Flame,
+        label: 'Streak bonus',
+        color: 'text-orange-600 dark:text-orange-400',
+        bg: 'bg-orange-100 dark:bg-orange-900/30',
+    },
+    badge_earned: {
+        Icon: Award,
+        label: 'Badge earned',
+        color: 'text-amber-600 dark:text-amber-400',
+        bg: 'bg-amber-100 dark:bg-amber-900/30',
+    },
+    level_up: {
+        Icon: TrendingUp,
+        label: 'Level up bonus',
+        color: 'text-fuchsia-600 dark:text-fuchsia-400',
+        bg: 'bg-fuchsia-100 dark:bg-fuchsia-900/30',
+    },
+    referral: {
+        Icon: Gift,
+        label: 'Referral bonus',
+        color: 'text-pink-600 dark:text-pink-400',
+        bg: 'bg-pink-100 dark:bg-pink-900/30',
+    },
+    challenge_win: {
+        Icon: Trophy,
+        label: 'Challenge won',
+        color: 'text-yellow-600 dark:text-yellow-400',
+        bg: 'bg-yellow-100 dark:bg-yellow-900/30',
+    },
+    community: {
+        Icon: Users,
+        label: 'Community activity',
+        color: 'text-sky-600 dark:text-sky-400',
+        bg: 'bg-sky-100 dark:bg-sky-900/30',
+    },
+    manual: {
+        Icon: SlidersHorizontal,
+        label: 'Manual adjustment',
+        color: 'text-surface-600 dark:text-surface-300',
+        bg: 'bg-surface-100 dark:bg-surface-800',
+    },
+}
+
+export const getXPMeta = (type) =>
+    XP_META[type] || { Icon: Sparkles, label: 'XP earned', color: 'text-surface-600', bg: 'bg-surface-100 dark:bg-surface-800' }
+
+/**
+ * Plain-English rules mirroring the server-side XP awards
+ * (core/utils.py, content/views.py, analytics/views.py, gamification/services.py).
+ */
+export const XP_EARNING_RULES = [
+    {
+        Icon: BookOpen,
+        title: 'Finish study material',
+        detail: 'Notes, revision & formula sheets 5 XP · PDFs 6 XP · Videos and interactive lessons 8 XP.',
+        value: '5–8 XP',
+    },
+    {
+        Icon: ClipboardCheck,
+        title: 'Complete a quiz',
+        detail: 'Questions × 5, scaled by your accuracy. Capped at 25 XP (40 XP for the daily challenge).',
+        value: 'up to 25 XP',
+    },
+    {
+        Icon: FileText,
+        title: 'Complete a mock test',
+        detail: 'Same as a quiz, then doubled because mock tests are longer.',
+        value: 'up to 50 XP',
+    },
+    {
+        Icon: Brain,
+        title: 'Complete an AI quiz',
+        detail: 'Includes an accuracy bonus. Capped at 25 XP per attempt and 75 XP per day.',
+        value: 'up to 25 XP',
+    },
+    {
+        Icon: Target,
+        title: 'Hit your daily study goal',
+        detail: '25 XP base plus a streak bonus of 3 XP per streak day (bonus capped at 25 XP).',
+        value: '25–50 XP',
+    },
+    {
+        Icon: Users,
+        title: 'Help out in the community',
+        detail: 'Posting, answering and receiving likes or a best-answer mark. Each is awarded only once.',
+        value: 'varies',
+    },
+    {
+        Icon: Award,
+        title: 'Earn a badge',
+        detail: 'Each badge carries its own XP reward, granted the moment you unlock it.',
+        value: 'varies',
+    },
+    {
+        Icon: TrendingUp,
+        title: 'Level up',
+        detail: 'A one-off bonus of 20 XP × the new level, every time you reach a new level.',
+        value: 'level × 20 XP',
+    },
+]
+
+/**
+ * Mirrors StudentProfile.calculate_level / xp_for_next_level:
+ * level 1 needs 100 XP, and every level after needs 50% more than the last.
+ */
+export const getLevelBounds = (level = 1) => {
+    let required = 100
+    let start = 0
+    for (let l = 1; l < level; l += 1) {
+        start += required
+        required = Math.floor(required * 1.5)
+    }
+    return { start, end: start + required, span: required }
+}
+
+export const getLevelProgress = (totalXP = 0, level = 1) => {
+    const { start, span } = getLevelBounds(level)
+    if (!span) return 0
+    return Math.max(0, Math.min(100, Math.round(((totalXP - start) / span) * 100)))
+}


### PR DESCRIPTION
## Problem

The 🔥 and ⚡ counters in the student header were a complete black box — no tooltip, no explanation, no way to see where the numbers came from. On top of that, they were raw emojis, which looked unprofessional next to the rest of the UI.

## What changed

### Professional icons (no emojis)
All streak/XP emojis are now `lucide-react` icons (already a dependency):
- Header: `Flame` in an orange→red gradient badge, `Zap` in a violet→fuchsia gradient badge, both inside soft ring pills
- Also cleaned up `StreakFire` (Dashboard), `StudyTimer` (all 3 view modes) and the `ChatQuiz` XP toast

### Streak popover (`StreakChip`)
Clicking 🔥 now explains, in plain English, that the streak counts **consecutive days with study activity**, and shows:
- Longest streak
- Total active days
- A live status line: *"Today is counted. Come back tomorrow to make it 4."* or *"Study today to keep your streak alive — last active 4 Aug 2026."*

### XP popover (`XPChip`)
Clicking ⚡ shows:
- Level + animated progress bar (`44 / 100 XP`) and "56 XP to reach Level 2"
- The five most recent XP transactions with per-type icons, descriptions and amounts
- A link to the full breakdown

### New `/xp` page (`XPHistory`)
- XP and streak summary cards
- **"How XP is earned"** — every rule documented and verified against the backend: content 5–8 XP by type, quiz ≤25 (40 daily challenge), mock ≤50, AI quiz ≤25/attempt and 75/day, daily goal `25 + min(25, streak × 3)`, community, badges, level-up `level × 20`
- The complete XP ledger grouped by day, with per-day totals and running balance

### `src/utils/xp.js`
Shared metadata for all 14 `XPTransaction` types, the earning-rule copy, and level-threshold helpers that mirror `StudentProfile.calculate_level` / `xp_for_next_level`.

## Notes

- **No backend changes.** This uses existing endpoints — `GET /analytics/streaks/current/` and `GET /gamification/xp-history/` — which were already implemented but not surfaced anywhere in the student UI.
- XP history is fetched lazily, only when the popover is opened.
- Popovers follow the existing `NotificationBell` pattern (outside-click + Escape to close) and carry `aria-label` / `aria-expanded`.

## Testing

- `npm run build` passes clean.
- Please sanity-check visually as a student: header chips in light and dark mode, both popovers, and `/xp`.