### PR TITLE
Clarify that XP is one pool across courses and community

### DIFF
--- a/frontend/exam-frontend/src/components/layout/XPChip.jsx
+++ b/frontend/exam-frontend/src/components/layout/XPChip.jsx
@@ -79,7 +79,7 @@ const XPChip = ({ enabled = true }) => {
                                         {totalXP.toLocaleString()} XP earned
                                     </p>
                                     <p className="text-xs text-surface-500 mt-0.5">
-                                        Experience points from everything you study
+                                        Your combined total from courses and community
                                     </p>
                                 </div>
                             </div>

--- a/frontend/exam-frontend/src/pages/XPHistory.jsx
+++ b/frontend/exam-frontend/src/pages/XPHistory.jsx
@@ -79,7 +79,7 @@ const XPHistory = () => {
                         <div>
                             <h1 className="text-2xl font-bold tabular-nums">{totalXP.toLocaleString()} XP</h1>
                             <p className="text-sm text-surface-500">
-                                Level {level} · your all-time experience points
+                                Level {level} · combined total from courses and community
                             </p>
                         </div>
                     </div>
@@ -159,7 +159,8 @@ const XPHistory = () => {
             <div className="card p-6">
                 <h2 className="text-lg font-semibold">How XP is earned</h2>
                 <p className="text-sm text-surface-500 mt-1">
-                    Every point below is awarded automatically the moment you complete the activity.
+                    Your XP is a single running total across every course <em>and</em> the community —
+                    each point below is awarded automatically the moment you complete the activity.
                 </p>
 
                 <div className="grid sm:grid-cols-2 gap-3 mt-4">

--- a/frontend/exam-frontend/src/utils/xp.js
+++ b/frontend/exam-frontend/src/utils/xp.js
@@ -147,8 +147,8 @@ export const XP_EARNING_RULES = [
     {
         Icon: Users,
         title: 'Help out in the community',
-        detail: 'Posting, answering and receiving likes or a best-answer mark. Each is awarded only once.',
-        value: 'varies',
+        detail: 'Asking 5 · polls 5 · quizzes 8 · answering 8 · best answer 20 · each like received 2. Counted in the same total, and each is awarded only once.',
+        value: '2–20 XP',
     },
     {
         Icon: Award,


### PR DESCRIPTION
Follow-up to #165.

## Why

It wasn't obvious whether the header ⚡ number was course activity only, with community XP tracked separately. It isn't — `CommunityXPService.award_xp` (`community/services.py:183`) writes directly into `StudentProfile.total_xp`, the exact field the header reads, and records an `XPTransaction` with `transaction_type='community'`.

`CommunityStats.total_community_xp` and `CommunityLeaderboard.community_xp` are **subtotal counters for the community leaderboard, not a separate wallet** — the same XP is deliberately counted in both places. Nothing in the UI said so.

## Changes

- XP chip and `/xp` page now describe the number as a **"combined total from courses and community"**.
- The "How XP is earned" intro states that XP is a single running total across every course *and* the community.
- The community rule now lists its actual rates from `CommunityXPService.XP_REWARDS` — ask 5, poll 5, quiz 8, answer 8, best answer 20, like received 2 — instead of the vague "varies".

Copy-only; no logic or backend changes. `npm run build` passes.