### PR TITLE
Fix: only offer courses the student can actually use as AI context

### DIFF
--- a/backend/chatbot/course_context.py
+++ b/backend/chatbot/course_context.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 # How much detail to include before truncating, keeping the prompt small.
@@ -22,15 +23,48 @@ MAX_CHAPTERS_LISTED = 8
 MAX_WEAK_TOPICS = 6
 
 
-def enrolled_courses(student):
-    """Approved, active course enrollments for this student (newest first)."""
+def enrolled_courses(student, tenant=None):
+    """Courses this student may actually use as AI context.
+
+    Deliberately stricter than "has an enrollment row". A course only qualifies
+    when the enrollment is approved and live *and* the course itself is still
+    active — an inactive or "coming soon" course has no meaningful syllabus or
+    progress to reason about, so offering it in the picker just invites the
+    assistant to answer from an empty snapshot.
+
+    Passing ``tenant`` additionally pins the result to that tenant, so a stale
+    enrollment pointing at another tenant's course can never leak its content.
+    """
     from users.models import CourseEnrollment
 
-    return (
-        CourseEnrollment.objects.filter(student=student, is_active=True, status='approved')
-        .select_related('course')
-        .order_by('-enrolled_at')
+    qs = CourseEnrollment.objects.filter(
+        student=student,
+        is_active=True,
+        status='approved',
+        course__status='active',
     )
+    if tenant is not None:
+        qs = qs.filter(course__tenant=tenant)
+
+    return qs.select_related('course').order_by('-enrolled_at')
+
+
+def enrolled_course_or_none(student, course_id, tenant=None):
+    """Resolve ``course_id`` to a usable enrolled course, else ``None``.
+
+    One indexed query rather than iterating the student's enrollments, and the
+    single place that decides whether a given course is fair game for this
+    student — used by both the course picker and the session endpoints.
+    """
+    if not course_id:
+        return None
+
+    try:
+        enrollment = enrolled_courses(student, tenant=tenant).filter(course_id=course_id).first()
+    except (ValueError, ValidationError):
+        # A malformed uuid is simply "no such course" rather than a 500.
+        return None
+    return enrollment.course if enrollment else None
 
 
 def _content_progress(student, course):
@@ -229,7 +263,15 @@ def render_course_context(snapshot):
 
 
 def course_context_for(student, course):
-    """Convenience wrapper: snapshot → rendered prompt block."""
+    """Convenience wrapper: snapshot → rendered prompt block.
+
+    Re-checks eligibility at send time. A conversation can outlive the access
+    that created it — the course may be deactivated or the enrollment revoked
+    weeks later — and we should stop feeding that course's data to the model
+    the moment that happens, not just when the chat was first scoped.
+    """
+    if enrolled_course_or_none(student, course.id) is None:
+        return ''
     return render_course_context(build_course_snapshot(student, course))
 
 

--- a/backend/chatbot/services.py
+++ b/backend/chatbot/services.py
@@ -100,7 +100,9 @@ def build_system_prompt(session, ai_settings=None):
     allow_course_context = ai_settings is None or ai_settings.allow_course_context
     if session.course_id and allow_course_context:
         try:
-            prompt += '\n\n' + course_context_for(session.student, session.course)
+            course_block = course_context_for(session.student, session.course)
+            if course_block:
+                prompt += '\n\n' + course_block
         except Exception:  # noqa: BLE001 - context is an enhancement, never fatal
             logger.exception('Failed to build course context for session %s', session.id)
 

--- a/backend/chatbot/views.py
+++ b/backend/chatbot/views.py
@@ -23,7 +23,7 @@ from .serializers import (
     SubmitAIQuizSerializer, AILearningStatsSerializer
 )
 from . import resolver
-from .course_context import enrolled_courses, starter_prompts
+from .course_context import enrolled_course_or_none, enrolled_courses, starter_prompts
 from .services import ChatService
 from .tenancy import request_tenant
 from core.views import TenantAwareViewSet, TenantAwareReadOnlyViewSet
@@ -43,6 +43,7 @@ class AIWorkspaceView(APIView):
         student = request.user.profile
         tenant = request_tenant(request, required=False)
 
+        enrollments = list(enrolled_courses(student, tenant=tenant))
         courses = [
             {
                 'id': str(e.course.id),
@@ -51,14 +52,13 @@ class AIWorkspaceView(APIView):
                 'color': e.course.color,
                 'course_type': e.course.get_course_type_display(),
             }
-            for e in enrolled_courses(student)
+            for e in enrollments
         ]
 
-        course = None
-        course_id = request.query_params.get('course_id')
-        if course_id:
-            match = next((e.course for e in enrolled_courses(student) if str(e.course.id) == course_id), None)
-            course = match
+        requested = request.query_params.get('course_id')
+        course = next(
+            (e.course for e in enrollments if str(e.course.id) == str(requested)), None
+        ) if requested else None
 
         try:
             resolution = resolver.resolve(tenant, student=None)
@@ -99,18 +99,26 @@ class ChatSessionViewSet(TenantAwareViewSet):
         return ChatSessionSerializer
 
     def _enrolled_course(self, course_id):
-        """Resolve a course id to one the student is actually enrolled in.
+        """Resolve a course id to one the student may actually use.
 
-        Scoping a chat to a course exposes that course's progress data to the
-        model, so only approved enrollments are accepted.
+        Scoping a chat to a course feeds that course's syllabus and the
+        student's own progress to the model, so this rejects anything they are
+        not approved for, anything no longer active, and anything outside the
+        tenant they are signed in to.
         """
         if not course_id:
             return None
-        student = self.request.user.profile
-        for enrollment in enrolled_courses(student):
-            if str(enrollment.course.id) == str(course_id):
-                return enrollment.course
-        raise ValidationError({'course_id': 'You are not enrolled in this course.'})
+
+        course = enrolled_course_or_none(
+            self.request.user.profile,
+            course_id,
+            tenant=request_tenant(self.request, required=False),
+        )
+        if course is None:
+            raise ValidationError(
+                {'course_id': 'You are not enrolled in this course, or it is no longer available.'}
+            )
+        return course
 
     def create(self, request, *args, **kwargs):
         """Create a new chat session."""

--- a/frontend/exam-frontend/src/pages/AIDoubtSolver.jsx
+++ b/frontend/exam-frontend/src/pages/AIDoubtSolver.jsx
@@ -506,6 +506,14 @@ const AIDoubtSolver = () => {
     if (sessionData?.course) setCourseId(sessionData.course)
   }, [sessionData?.course])
 
+  // A course can stop being selectable after it was picked (deactivated, or the
+  // enrollment revoked). Drop the stale selection so the UI doesn't keep showing
+  // a course the server will no longer accept.
+  useEffect(() => {
+    if (!workspace || !courseId) return
+    if (!workspace.courses?.some((c) => c.id === courseId)) setCourseId(null)
+  }, [workspace, courseId])
+
   const handleNewChat = () => {
     setActiveSession(null)
     setStreamingContent('')


### PR DESCRIPTION
Follow-up to #167. The course picker was offering courses that shouldn't be selectable.

## What was wrong

`enrolled_courses()` only checked that an approved enrollment row existed:

```python
CourseEnrollment.objects.filter(student=student, is_active=True, status='approved')
```

Two gaps:

1. **No course status check.** Inactive and "coming soon" courses appeared in the picker. The rest of the codebase already guards this — `exams/views.py` uses `status='approved', is_active=True, course__status='active'` — this was the one place that didn't. Picking one handed the assistant an empty syllabus snapshot to reason from.
2. **No tenant scoping.** A stale enrollment pointing at another tenant's course would surface it, and that course's syllabus would flow into the prompt.

Worth flagging the reason the list looks longer than expected: free courses with self-enrolment **auto-approve** (`users/views.py` — `'self' → auto-approve`), so merely opening a free course creates an approved enrollment. That's existing platform behaviour and I haven't changed it here, but it's why a student sees courses they don't think of as "theirs". Happy to narrow the AI picker further — e.g. only courses with actual progress — if that's the behaviour you want.

## Changes

- `enrolled_courses()` now requires `course__status='active'` and takes an optional `tenant` to pin results to.
- New `enrolled_course_or_none()` — the single place deciding whether a course is fair game for a student. Replaces a Python loop over every enrollment with one indexed query, and treats a malformed uuid as "no such course" instead of a 500.
- Session creation and `set_course` validate through that same helper, so passing a hidden course id directly is rejected, not merely hidden from the dropdown.
- `course_context_for()` **re-checks eligibility at send time.** A conversation outlives the access that created it — if a course is deactivated or an enrollment revoked weeks later, the chat was still feeding that course's progress data to the model. Now the context block silently drops out.
- The frontend clears a selection that disappears from the workspace list.

## Verified against real data

| Scenario | Before | After |
|---|---|---|
| baseline | JEE Main, NEET | JEE Main, NEET |
| course → `inactive` | still listed | hidden |
| course → `coming_soon` | still listed | hidden |
| enrollment `is_active=False` | hidden | hidden |
| enrollment `pending` | hidden | hidden |
| create session with inactive course id | accepted | `400` |
| malformed uuid | `500` | `None` |
| course list pinned to another tenant | leaked | `[]` |

Send-time net confirmed too: the system prompt carries the course block while access holds (2369 chars) and drops it once the course is deactivated (1888 chars).

`manage.py check` clean, `npm run build` passes.