### PR TITLE
fix(ai): give the assistant real memory and visibility of the student's work

### DIFF
--- a/backend/chatbot/course_context.py
+++ b/backend/chatbot/course_context.py
@@ -12,10 +12,13 @@ message in the conversation, so verbosity here is a recurring cost.
 """
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+
+logger = logging.getLogger(__name__)
 
 # How much detail to include before truncating, keeping the prompt small.
 MAX_SUBJECTS = 12
@@ -270,9 +273,22 @@ def course_context_for(student, course):
     weeks later — and we should stop feeding that course's data to the model
     the moment that happens, not just when the chat was first scoped.
     """
+    from .work_context import work_context_for
+
     if enrolled_course_or_none(student, course.id) is None:
         return ''
-    return render_course_context(build_course_snapshot(student, course))
+
+    block = render_course_context(build_course_snapshot(student, course))
+
+    # Question-, assignment- and code-level detail, so the assistant can talk
+    # about actual mistakes and failures rather than just percentages.
+    try:
+        work = work_context_for(student, course)
+    except Exception:  # noqa: BLE001 - detail is a bonus, never break the chat
+        logger.exception('Failed to build work context for course %s', course.id)
+        work = ''
+
+    return f'{block}\n{work}' if work else block
 
 
 def starter_prompts(student, course=None):
@@ -322,15 +338,51 @@ def starter_prompts(student, course=None):
         prompts.append({'text': f'What should I revise in {course.name}?', 'kind': 'pending'})
 
     weak = snapshot['performance']['weak_topics']
+    quiz_prompt = None
     if weak:
         prompts.append(
             {'text': f"Why do I keep getting {weak[0]['topic']} wrong?", 'kind': 'mistakes'}
         )
-        prompts.append({'text': f"Quiz me on {weak[0]['topic']}", 'kind': 'quiz'})
+        quiz_prompt = {'text': f"Quiz me on {weak[0]['topic']}", 'kind': 'quiz'}
     else:
         prompts.append({'text': 'Where am I making the most mistakes?', 'kind': 'mistakes'})
         if snapshot['subjects']:
-            prompts.append({'text': f"Quiz me on {snapshot['subjects'][0]}", 'kind': 'quiz'})
+            quiz_prompt = {'text': f"Quiz me on {snapshot['subjects'][0]}", 'kind': 'quiz'}
 
+    # Only offer these when the student actually has such work — a prompt that
+    # leads to "you have no assignments" is worse than no prompt at all.
+    try:
+        from .work_context import assignment_status, coding_status
+
+        assignments = assignment_status(student, course)
+        missing = [r for r in assignments['rows'] if r['state'] == 'not_submitted']
+        if missing:
+            overdue = [r for r in missing if r['overdue']]
+            prompts.append(
+                {
+                    'text': (
+                        'Which assignments am I overdue on?'
+                        if overdue
+                        else 'What assignments do I still owe?'
+                    ),
+                    'kind': 'pending',
+                }
+            )
+
+        coding = coding_status(student, course)
+        if coding['rows']:
+            prompts.append(
+                {
+                    'text': f"Why is my {coding['rows'][0]['title']} solution failing?",
+                    'kind': 'mistakes',
+                }
+            )
+    except Exception:  # pragma: no cover - suggestions must never break the page
+        logger.exception('starter_prompts: work context lookup failed')
+
+    # Concrete outstanding work beats a generic quiz suggestion, so the quiz and
+    # study-plan prompts are only added once the actionable ones are in.
+    if quiz_prompt:
+        prompts.append(quiz_prompt)
     prompts.append({'text': f'Build me a 7-day study plan for {course.name}', 'kind': 'plan'})
     return prompts[:6]

--- a/backend/chatbot/services.py
+++ b/backend/chatbot/services.py
@@ -72,6 +72,29 @@ Explanation: [Brief explanation]
 Remember: you are helping a real student make progress. Be patient, helpful, and motivating. Every small concept matters!"""
 
 
+# Appended whenever a course is selected, so the model knows the data below is
+# real and how it is expected to use it.
+COURSE_DATA_CLAUSE = """
+
+**Using the student's own course data**
+The context below is real data from this student's account — their progress, their
+wrong answers, their submissions. Use it directly and specifically:
+- When they ask about mistakes, quote the actual questions they got wrong, what they
+  picked, and why the correct answer is right. Then name the underlying concept, since
+  repeated mistakes usually share a root cause.
+- When they ask about assignments, use the real titles, due dates and teacher feedback.
+  Flag anything overdue or unsubmitted plainly, without nagging.
+- When their code is failing, reason from the actual verdict and error output. "Wrong
+  answer" on some cases usually means an edge case or off-by-one; a timeout usually means
+  the approach is too slow; a compile error is a syntax or type problem. Suggest what to
+  check, and ask to see their code when that would help more than guessing.
+- Prefer naming one concrete next action over a generic list of options.
+- Never invent a question, score, assignment, deadline or test case that is not listed.
+  If the data does not cover something, say so plainly and offer what you can do instead.
+- Refer back to what has already been discussed in this conversation instead of repeating
+  yourself or asking again for something the student has already told you."""
+
+
 NO_QUIZ_CLAUSE = (
     '\n\nQuiz generation is disabled on this platform. If the student asks for a quiz, '
     'politely explain that practice quizzes are available in the Practice Quiz section '
@@ -102,7 +125,7 @@ def build_system_prompt(session, ai_settings=None):
         try:
             course_block = course_context_for(session.student, session.course)
             if course_block:
-                prompt += '\n\n' + course_block
+                prompt += COURSE_DATA_CLAUSE + '\n\n' + course_block
         except Exception:  # noqa: BLE001 - context is an enhancement, never fatal
             logger.exception('Failed to build course context for session %s', session.id)
 
@@ -115,11 +138,19 @@ def build_system_prompt(session, ai_settings=None):
     return prompt
 
 
+HISTORY_TURNS = 30
+
+
 def build_messages(session, history, ai_settings=None):
-    """System prompt + the last 20 turns, in provider-neutral form."""
+    """System prompt + recent conversation, in provider-neutral form.
+
+    The window is what gives the assistant its memory of the exchange, so it
+    can resolve "these quizzes", "that chapter" or "explain it again" against
+    what was actually said earlier.
+    """
     messages = [{'role': 'system', 'content': build_system_prompt(session, ai_settings)}]
-    for msg in history[-20:]:
-        if msg['role'] in ('user', 'assistant'):
+    for msg in history[-HISTORY_TURNS:]:
+        if msg['role'] in ('user', 'assistant') and msg['content']:
             messages.append({'role': msg['role'], 'content': msg['content']})
     return messages
 
@@ -176,9 +207,16 @@ class ChatService:
         return message
 
     @staticmethod
-    def get_session_history(session, limit=50):
-        """Get message history for a session."""
-        messages = session.messages.order_by('created_at')[:limit]
+    def get_session_history(session, limit=60):
+        """The most recent ``limit`` messages, oldest first.
+
+        Note the ordering: slicing ``order_by('created_at')[:limit]`` would take
+        the *oldest* messages, so a long conversation would freeze its context
+        at the opening exchanges and appear to forget everything said since.
+        We take the newest and flip them back into reading order.
+        """
+        messages = list(session.messages.order_by('-created_at')[:limit])
+        messages.reverse()
         return [
             {'role': msg.role, 'content': msg.content, 'id': str(msg.id)} for msg in messages
         ]

--- a/backend/chatbot/work_context.py
+++ b/backend/chatbot/work_context.py
@@ -1,0 +1,379 @@
+"""Question-, assignment- and code-level detail for a course-scoped chat.
+
+:mod:`chatbot.course_context` answers "how far along is this student?" — this
+module answers "what exactly did they get wrong?".
+
+Progress percentages are enough for "what's pending", but useless the moment a
+student asks *"what mistakes did I make?"* or *"why is my code failing?"*. That
+needs the actual wrong answers, the actual grader feedback, and the actual
+failing test cases.
+
+Everything here is deliberately **actionable-only** and tightly capped. This
+block is re-sent with every message in the conversation, so listing work the
+student has already nailed is a recurring token cost for no benefit. We list
+what is wrong, overdue, unsubmitted or failing, and summarise the rest as
+counts.
+"""
+from __future__ import annotations
+
+from django.utils import timezone
+
+# Caps chosen to keep this whole block a few hundred tokens.
+MAX_WRONG_QUESTIONS = 6
+MAX_ASSIGNMENTS = 6
+MAX_CODING = 5
+MAX_RECENT_ATTEMPTS = 5
+
+QUESTION_CHARS = 180
+EXPLANATION_CHARS = 220
+FEEDBACK_CHARS = 200
+ERROR_CHARS = 200
+
+
+def _clip(text, limit):
+    """Single-line, length-capped text — prompts hate stray newlines."""
+    if not text:
+        return ''
+    flat = ' '.join(str(text).split())
+    return flat if len(flat) <= limit else flat[: limit - 1].rstrip() + '…'
+
+
+def _option_label(question, value):
+    """Human-readable label for a stored option value.
+
+    ``Answer.selected_option`` and ``Question.correct_answer`` hold either an
+    option index or a raw value (see ``Answer.check_answer``), so resolve
+    whichever we were given back to the option text the student actually saw.
+    """
+    if value in (None, ''):
+        return 'no answer'
+
+    raw = str(value).strip()
+    options = list(question.options.order_by('order'))
+
+    if raw.isdigit() and options:
+        index = int(raw)
+        if 0 <= index < len(options):
+            return f'{chr(65 + index)}) {_clip(options[index].option_text, 90)}'
+
+    for position, option in enumerate(options):
+        if str(option.option_text).strip() == raw:
+            return f'{chr(65 + position)}) {_clip(option.option_text, 90)}'
+
+    return _clip(raw, 90)
+
+
+def recent_mistakes(student, course, limit=MAX_WRONG_QUESTIONS):
+    """The student's most recent wrong answers, with what they picked and why.
+
+    This is what makes "what did I get wrong?" answerable instead of the
+    assistant apologising that it only has aggregate accuracy.
+    """
+    from quiz.models import Answer
+
+    wrong = (
+        Answer.objects.filter(
+            quiz_attempt__student=student,
+            quiz_attempt__quiz__course=course,
+            quiz_attempt__status='completed',
+            is_correct=False,
+        )
+        .exclude(selected_option='', answer_text='')
+        .select_related('question', 'question__topic', 'question__subject', 'quiz_attempt__quiz')
+        .prefetch_related('question__options')
+        .order_by('-created_at')[:limit]
+    )
+
+    rows = []
+    for answer in wrong:
+        question = answer.question
+        rows.append(
+            {
+                'quiz': question and answer.quiz_attempt.quiz.title,
+                'subject': question.subject.name if question.subject_id else '',
+                'topic': question.topic.name if question.topic_id else '',
+                'question': _clip(question.question_text, QUESTION_CHARS),
+                'chose': _option_label(question, answer.selected_option or answer.answer_text),
+                'correct': _option_label(question, question.correct_answer),
+                'explanation': _clip(question.explanation, EXPLANATION_CHARS),
+            }
+        )
+    return rows
+
+
+def assignment_status(student, course):
+    """Per-assignment standing, biased toward what still needs action."""
+    from assignments.models import Assignment, AssignmentSubmission
+
+    assignments = (
+        Assignment.objects.filter(course=course, status='published')
+        .select_related('topic', 'subject')
+        .order_by('due_at', 'order')
+    )
+    if not assignments:
+        return {'total': 0, 'submitted': 0, 'graded': 0, 'rows': []}
+
+    submissions = {
+        s.assignment_id: s
+        for s in AssignmentSubmission.objects.filter(
+            student=student, assignment__in=assignments
+        ).select_related('assignment')
+    }
+
+    now = timezone.now()
+    rows, submitted, graded = [], 0, 0
+
+    for assignment in assignments:
+        submission = submissions.get(assignment.id)
+        if submission:
+            submitted += 1
+            if submission.status == 'graded':
+                graded += 1
+
+        overdue = bool(assignment.due_at and assignment.due_at < now and not submission)
+
+        # Only surface rows the student can still act on: anything missing, and
+        # anything graded (where the feedback is the teaching opportunity).
+        if submission and submission.status != 'graded':
+            continue
+
+        row = {
+            'title': assignment.title,
+            'topic': assignment.topic.name if assignment.topic_id else '',
+            'due': assignment.due_at.strftime('%d %b') if assignment.due_at else '',
+            'overdue': overdue,
+            'max_marks': assignment.max_marks,
+        }
+        if submission:
+            row.update(
+                {
+                    'state': 'graded',
+                    'marks': (
+                        float(submission.marks) if submission.marks is not None else None
+                    ),
+                    'feedback': _clip(submission.feedback, FEEDBACK_CHARS),
+                }
+            )
+        else:
+            row['state'] = 'not_submitted'
+        rows.append(row)
+
+    return {
+        'total': len(assignments),
+        'submitted': submitted,
+        'graded': graded,
+        'rows': rows[:MAX_ASSIGNMENTS],
+    }
+
+
+def _failure_summary(submission):
+    """Why a coding submission failed, in a few words the model can reason on."""
+    if submission.compile_output:
+        return 'compile error', _clip(submission.compile_output, ERROR_CHARS)
+
+    failures = [
+        result
+        for result in (submission.results or [])
+        if result.get('verdict') and result.get('verdict') != 'passed'
+    ]
+    if not failures:
+        return '', ''
+
+    verdicts = [result['verdict'] for result in failures]
+    # Most common failure mode first — that is the one worth explaining.
+    dominant = max(set(verdicts), key=verdicts.count)
+
+    # Take the error text from a case that actually failed this way, otherwise
+    # we would pair (say) a timeout's output with a "wrong answer" diagnosis.
+    error = next(
+        (
+            _clip(result.get('stderr'), ERROR_CHARS)
+            for result in failures
+            if result['verdict'] == dominant and result.get('stderr')
+        ),
+        '',
+    )
+    return dominant.replace('_', ' '), error
+
+
+def coding_status(student, course):
+    """Coding practice standing, focused on problems that are still failing."""
+    from coding.models import CodingProblem, CodingSubmission
+
+    problems = CodingProblem.objects.filter(course=course, status='published')
+    if not problems:
+        return {'total': 0, 'attempted': 0, 'solved': 0, 'rows': []}
+
+    submissions = (
+        CodingSubmission.objects.filter(student=student, problem__in=problems)
+        .select_related('problem')
+        .order_by('problem_id', '-submitted_at')
+    )
+
+    best = {}
+    for submission in submissions:
+        current = best.get(submission.problem_id)
+        # Keep the strongest attempt per problem, tie-broken by recency.
+        if current is None or submission.passed_count > current.passed_count:
+            best[submission.problem_id] = submission
+
+    rows, solved = [], 0
+    for problem_id, submission in best.items():
+        problem = submission.problem
+        is_solved = (
+            submission.total_count > 0 and submission.passed_count == submission.total_count
+        )
+        if is_solved:
+            solved += 1
+            continue
+
+        reason, error = _failure_summary(submission)
+        rows.append(
+            {
+                'title': problem.title,
+                'difficulty': problem.get_difficulty_display(),
+                'passed': submission.passed_count,
+                'total': submission.total_count,
+                'language': submission.language,
+                'reason': reason,
+                'error': error,
+            }
+        )
+
+    unattempted = problems.exclude(id__in=best.keys()).count()
+
+    return {
+        'total': problems.count(),
+        'attempted': len(best),
+        'solved': solved,
+        'unattempted': unattempted,
+        'rows': rows[:MAX_CODING],
+    }
+
+
+def pending_content(student, course, max_items=8):
+    """The next unfinished study items by name.
+
+    The course snapshot says a chapter is "40% done"; this says *which* lessons
+    are actually left, so "what should I do next?" gets a concrete answer the
+    student can act on rather than a percentage.
+    """
+    from content.models import Content, ContentProgress
+
+    completed_ids = set(
+        ContentProgress.objects.filter(
+            student=student, is_completed=True, content__courses=course
+        ).values_list('content_id', flat=True)
+    )
+
+    items = (
+        Content.objects.filter(courses=course, status='published')
+        .exclude(id__in=completed_ids)
+        .select_related('topic', 'topic__subject')
+        .distinct()
+        .order_by('topic__subject__order', 'topic__order', 'order')[: max_items * 3]
+    )
+
+    # Courses often carry near-identical items (e.g. two "Complete Notes" rows
+    # for one topic). Listing both wastes prompt space and reads like a glitch.
+    rows, seen = [], set()
+    for item in items:
+        key = (item.title.strip().lower(), item.content_type)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(
+            {
+                'title': _clip(item.title, 90),
+                'type': item.get_content_type_display(),
+                'topic': item.topic.name if item.topic_id else '',
+                'subject': (
+                    item.topic.subject.name if item.topic_id and item.topic.subject_id else ''
+                ),
+            }
+        )
+        if len(rows) >= max_items:
+            break
+    return rows
+
+
+def build_work_snapshot(student, course):
+    """Everything this module knows, as one structured dict."""
+    return {
+        'next_items': pending_content(student, course),
+        'mistakes': recent_mistakes(student, course),
+        'assignments': assignment_status(student, course),
+        'coding': coding_status(student, course),
+    }
+
+
+def render_work_context(snapshot):
+    """Render the snapshot as prompt lines, or ``''`` when there is nothing."""
+    lines = []
+
+    next_items = snapshot.get('next_items') or []
+    if next_items:
+        lines.append('')
+        lines.append('### Next unfinished study items (in course order)')
+        for item in next_items:
+            where = ' → '.join(p for p in (item['subject'], item['topic']) if p)
+            lines.append(f"  - {item['title']} ({item['type']})" + (f' — {where}' if where else ''))
+
+    mistakes = snapshot['mistakes']
+    if mistakes:
+        lines.append('')
+        lines.append('### Recent wrong answers (most recent first)')
+        for m in mistakes:
+            where = ' → '.join(p for p in (m['subject'], m['topic']) if p)
+            lines.append(f"  - [{where or 'General'}] {m['question']}")
+            lines.append(f"      student answered: {m['chose']}  |  correct: {m['correct']}")
+            if m['explanation']:
+                lines.append(f"      official explanation: {m['explanation']}")
+    else:
+        lines.append('')
+        lines.append('### Recent wrong answers: none recorded.')
+
+    assignments = snapshot['assignments']
+    if assignments['total']:
+        lines.append('')
+        lines.append(
+            f"### Assignments: {assignments['submitted']} of {assignments['total']} submitted, "
+            f"{assignments['graded']} graded"
+        )
+        for row in assignments['rows']:
+            if row['state'] == 'not_submitted':
+                flag = ' — OVERDUE' if row['overdue'] else ''
+                due = f" (due {row['due']})" if row['due'] else ''
+                lines.append(f"  - NOT SUBMITTED: {row['title']}{due}{flag}")
+            else:
+                score = (
+                    f" scored {row['marks']:g}/{row['max_marks']}"
+                    if row['marks'] is not None and row['max_marks']
+                    else ''
+                )
+                lines.append(f"  - graded: {row['title']}{score}")
+                if row['feedback']:
+                    lines.append(f"      teacher feedback: {row['feedback']}")
+
+    coding = snapshot['coding']
+    if coding['total']:
+        lines.append('')
+        lines.append(
+            f"### Coding practice: {coding['solved']} solved, {coding['attempted']} attempted, "
+            f"{coding.get('unattempted', 0)} not started (of {coding['total']})"
+        )
+        for row in coding['rows']:
+            detail = f"  - FAILING: {row['title']} ({row['difficulty']}) — "
+            detail += f"{row['passed']}/{row['total']} test cases passing"
+            if row['reason']:
+                detail += f", mostly {row['reason']}"
+            lines.append(detail)
+            if row['error']:
+                lines.append(f"      error output: {row['error']}")
+
+    return '\n'.join(lines)
+
+
+def work_context_for(student, course):
+    """Convenience wrapper: snapshot → rendered prompt block."""
+    return render_work_context(build_work_snapshot(student, course))


### PR DESCRIPTION
The assistant kept replying *"I don't have the specific details of the mistakes you made"* — because it genuinely didn't. It was never shown any of the student's actual work, and in longer chats it also lost track of the conversation.

## 1. Conversation memory (the serious one)

`get_session_history` sliced `order_by('created_at')[:50]` — that takes the **oldest** fifty messages. Combined with `history[-20:]` in `build_messages`, any chat past fifty messages permanently showed the model messages 31–50 and nothing since, **including the question the student had just asked**.

Verified against a 100-message session:

| | messages sent to the model |
|---|---|
| before | `msg-31` … `msg-50` |
| after | `msg-71` … `msg-100` |

Fixed by ordering descending, slicing, then reversing back into reading order. Window widened to 30 turns. `get_session_history` is only used for prompt building (two call sites), so nothing else is affected by the ordering change.

## 2. New `chatbot/work_context.py`

Supplies the question-, assignment- and code-level detail the course snapshot never had:

- **Wrong quiz answers** — the question, the option the student picked, the correct one, and the official explanation. `_option_label()` resolves `selected_option` whether it's stored as an index or a value.
- **Assignments** — unsubmitted and overdue items with due dates, plus graded ones with marks and teacher feedback (the feedback is the actual teaching opportunity).
- **Coding practice** — failing problems with pass counts, the dominant verdict and the *matching* error output.
- **Next unfinished study items by name** — so "what's pending?" answers with lessons instead of a percentage. Near-duplicate titles are collapsed.

This block is re-sent with **every** message, so it's deliberately actionable-only: solved problems and clean graded work collapse into counts. Total system prompt measured at **~1.5k tokens**.

## 3. `COURSE_DATA_CLAUSE`

Tells the model how to use the data — quote the real questions, reason from the actual verdict (`wrong answer` → edge case, `time_limit` → approach too slow, compile error → syntax/type), never invent a score or deadline, and refer back to what was already discussed.

## 4. Starter prompts

Now surface this work — *"Which assignments am I overdue on?"*, *"Why is my Balanced Brackets solution failing?"* — and **only when such work exists**, so no suggestion leads to "you have no assignments". They're ordered ahead of the generic quiz/study-plan prompts.

## Verification

- `manage.py check` clean; frontend `npm run build` passes.
- Wrong-answer rendering checked against **real** data (6 Physics/Gravitation answers with question text, chosen vs. correct option and explanation).
- Assignment + coding paths exercised with synthetic data in a rolled-back transaction (the dev DB has none), producing `NOT SUBMITTED … OVERDUE`, `graded … scored 6/10` + feedback, and `FAILING: Balanced Brackets (Medium) — 3/8 test cases passing, mostly wrong answer`.
- Starter prompts verified in both states: with outstanding work, and for a student with none (no dangling prompts).
- All new lookups are scoped through the already-validated course/student, so they inherit the tenancy gate from #167/#168. Every new block is wrapped so a context failure can never break the chat.

## Not included

Retrieval over actual lesson *content* (RAG). The assistant now knows chapter and lesson **names** and everything the student has **done**, but still can't quote the study material itself — worth a follow-up if that's what's wanted.