### PR TITLE
fix(security): bind X-Tenant-ID to the authenticated user

### DIFF
--- a/backend/chatbot/tenancy.py
+++ b/backend/chatbot/tenancy.py
@@ -1,14 +1,14 @@
 """Authoritative tenant resolution for the AI feature.
 
-``TenantMiddleware`` sets ``request.tenant`` purely from the client-supplied
-``X-Tenant-ID`` header; it never checks that the header matches the tenant the
-authenticated user actually belongs to. That is tolerable for read-mostly
-endpoints, but the AI feature guards encrypted provider credentials and a
-spend budget, so anchoring on the header alone would let a user of tenant A
-spend (or read the configuration of) tenant B by swapping one header value.
+``TenantMiddleware`` now rejects any request whose ``X-Tenant-ID`` header does
+not match the authenticated caller's own tenant, so this module is no longer
+the only thing standing between tenants. It is kept as defence in depth: the AI
+feature guards encrypted provider credentials and a real spend budget, and a
+view that resolves its tenant from the **user** cannot be compromised by a
+future change to the middleware or its exempt-path list.
 
-Everything here therefore derives the tenant from the **user**, and treats a
-mismatching header as an attempt to cross tenants.
+Everything here derives the tenant from the user, and treats a mismatching
+header as an attempt to cross tenants.
 """
 from rest_framework.exceptions import NotFound, PermissionDenied
 

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,7 +1,44 @@
+import logging
+import uuid
+
 from django.utils.deprecation import MiddlewareMixin
 from django.http import JsonResponse
 from core.models import Tenant
-import uuid
+
+logger = logging.getLogger(__name__)
+
+_USER_CACHE_ATTR = '_resolved_api_user'
+
+
+def resolve_request_user(request):
+    """The authenticated user for an API request, or ``None``.
+
+    Middleware runs before DRF, so ``request.user`` is still anonymous for
+    token-authenticated calls. We decode the JWT here and cache the result on
+    the request so the tenant and suspension checks don't each pay for it.
+    """
+    if hasattr(request, _USER_CACHE_ATTR):
+        return getattr(request, _USER_CACHE_ATTR)
+
+    user = None
+
+    # Session auth (Django admin, browsable API) is already resolved upstream.
+    session_user = getattr(request, 'user', None)
+    if session_user is not None and getattr(session_user, 'is_authenticated', False):
+        user = session_user
+    else:
+        from rest_framework_simplejwt.authentication import JWTAuthentication
+
+        try:
+            result = JWTAuthentication().authenticate(request)
+        except Exception:
+            # Invalid/expired/malformed token — let the normal auth flow answer.
+            result = None
+        if result is not None:
+            user, _token = result
+
+    setattr(request, _USER_CACHE_ATTR, user)
+    return user
 
 # Paths that don't require a tenant header
 TENANT_EXEMPT_PATHS = [
@@ -29,10 +66,13 @@ TENANT_SUSPENSION_BYPASS_PATHS = [
 ]
 
 class TenantMiddleware(MiddlewareMixin):
-    """
-    Middleware to extract and enforce the tenant from request headers.
-    All API requests must include a valid X-Tenant-ID header,
-    except for whitelisted paths like admin and tenant config endpoints.
+    """Resolve and enforce the tenant for every API request.
+
+    All API requests must carry a valid ``X-Tenant-ID`` header (except the
+    whitelisted paths above), *and* the authenticated caller must belong to
+    that tenant. Validating only that the tenant exists is not enough — the
+    header is client-supplied, so without the ownership check it is a
+    self-service cross-tenant access grant.
     """
     def process_request(self, request):
         # Check if this path is exempt from tenant requirement
@@ -66,6 +106,13 @@ class TenantMiddleware(MiddlewareMixin):
 
         request.tenant = tenant
 
+        # The header alone proves nothing: anyone can send any tenant's UUID.
+        # Bind it to the caller's own account, or a logged-in user of tenant A
+        # could read and write tenant B's data simply by editing one header.
+        mismatch = self._tenant_mismatch(request, tenant)
+        if mismatch is not None:
+            return mismatch
+
         # A suspended or billing-frozen tenant stays active (so its public
         # config + notice still load) but is frozen: every authenticated API
         # call is rejected. Auth-bootstrap paths are allowed through so the
@@ -80,6 +127,38 @@ class TenantMiddleware(MiddlewareMixin):
                 },
                 status=403,
             )
+
+    @staticmethod
+    def _tenant_mismatch(request, tenant):
+        """403 when the caller does not belong to the tenant they asked for.
+
+        Anonymous requests are left alone — public endpoints (registration, the
+        course catalogue, landing config) legitimately have no user to check.
+        Django superusers are platform operators and are tenant-less by design,
+        so they are exempt; every other account is pinned to its own tenant.
+        """
+        user = resolve_request_user(request)
+        if user is None or getattr(user, 'is_superuser', False):
+            return None
+
+        user_tenant_id = getattr(user, 'tenant_id', None)
+        if user_tenant_id is None or user_tenant_id == tenant.id:
+            return None
+
+        logger.warning(
+            'Tenant mismatch: user %s (tenant %s) requested tenant %s on %s',
+            getattr(user, 'id', '?'),
+            user_tenant_id,
+            tenant.id,
+            request.path,
+        )
+        return JsonResponse(
+            {
+                'detail': 'You do not have access to this tenant.',
+                'code': 'tenant_mismatch',
+            },
+            status=403,
+        )
 
     @staticmethod
     def _is_suspension_bypass(path):
@@ -117,14 +196,11 @@ class BlockSuspendedUsersMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        # Import lazily-safe: simplejwt is already an installed app.
-        from rest_framework_simplejwt.authentication import JWTAuthentication
-        self._authenticator = JWTAuthentication()
 
     def __call__(self, request):
         path = request.path
         if path.startswith('/api/') and not self._is_exempt(path):
-            user = self._get_user(request)
+            user = resolve_request_user(request)
             if user is not None and getattr(user, 'is_suspended', False):
                 return JsonResponse(
                     {
@@ -138,14 +214,3 @@ class BlockSuspendedUsersMiddleware:
     @staticmethod
     def _is_exempt(path):
         return any(path.startswith(p) for p in SUSPENSION_EXEMPT_PATHS)
-
-    def _get_user(self, request):
-        try:
-            result = self._authenticator.authenticate(request)
-        except Exception:
-            # Invalid/expired token — let the normal auth flow handle it.
-            return None
-        if result is None:
-            return None
-        user, _token = result
-        return user

--- a/backend/core/tests.py
+++ b/backend/core/tests.py
@@ -1,0 +1,93 @@
+"""Tests for tenant isolation.
+
+The ``X-Tenant-ID`` header is supplied by the client, so it can only be trusted
+once it has been checked against the caller's own account. These tests pin that
+behaviour down: a regression here silently exposes one academy's data to
+another, which is the single worst failure mode this platform has.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from core.models import Tenant
+from users.models import User
+
+PROBE_PATH = '/api/v1/auth/profile/'
+
+
+class TenantIsolationTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.tenant_a = Tenant.objects.create(name='Academy A', is_active=True)
+        cls.tenant_b = Tenant.objects.create(name='Academy B', is_active=True)
+
+        cls.user_a = User.objects.create_user(
+            email='a@example.com', password='pw-a-12345', tenant=cls.tenant_a
+        )
+        cls.user_b = User.objects.create_user(
+            email='b@example.com', password='pw-b-12345', tenant=cls.tenant_b
+        )
+        cls.superuser = User.objects.create_superuser(
+            email='root@example.com', password='pw-root-12345'
+        )
+
+    def client_for(self, user):
+        client = APIClient()
+        if user is not None:
+            token = RefreshToken.for_user(user).access_token
+            client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
+        return client
+
+    def get(self, user, tenant, path=PROBE_PATH):
+        return self.client_for(user).get(path, HTTP_X_TENANT_ID=str(tenant.id))
+
+    def test_user_can_access_own_tenant(self):
+        response = self.get(self.user_a, self.tenant_a)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_cannot_access_another_tenant(self):
+        """The core guarantee: a valid login for A must not unlock B."""
+        response = self.get(self.user_a, self.tenant_b)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['code'], 'tenant_mismatch')
+
+    def test_rejection_is_mutual(self):
+        response = self.get(self.user_b, self.tenant_a)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['code'], 'tenant_mismatch')
+
+    def test_tenant_header_is_required(self):
+        response = self.client_for(self.user_a).get(PROBE_PATH)
+        self.assertEqual(response.status_code, 403)
+
+    def test_unknown_tenant_is_rejected(self):
+        response = self.client_for(self.user_a).get(
+            PROBE_PATH, HTTP_X_TENANT_ID='2b1f1d8e-0000-4000-8000-000000000000'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_malformed_tenant_header_is_rejected(self):
+        response = self.client_for(self.user_a).get(PROBE_PATH, HTTP_X_TENANT_ID='not-a-uuid')
+        self.assertEqual(response.status_code, 403)
+
+    def test_superuser_is_not_pinned_to_a_tenant(self):
+        """Platform operators are tenant-less by design and must stay unblocked."""
+        for tenant in (self.tenant_a, self.tenant_b):
+            response = self.get(self.superuser, tenant)
+            self.assertEqual(response.status_code, 200)
+
+    def test_anonymous_requests_are_not_treated_as_a_mismatch(self):
+        """Public endpoints have no user to check; they must fail as 401, not 403."""
+        response = self.get(None, self.tenant_a)
+        self.assertEqual(response.status_code, 401)
+
+    def test_inactive_tenant_is_rejected(self):
+        self.tenant_a.is_active = False
+        self.tenant_a.save(update_fields=['is_active'])
+        try:
+            response = self.get(self.user_a, self.tenant_a)
+            self.assertEqual(response.status_code, 403)
+        finally:
+            self.tenant_a.is_active = True
+            self.tenant_a.save(update_fields=['is_active'])


### PR DESCRIPTION
You were right to flag this. `TenantMiddleware` validated that the requested tenant **existed and was active**, but never checked that the caller **belonged to it**. Since `X-Tenant-ID` is client-supplied, that made it a self-service cross-tenant access grant.

## This was live, not theoretical

Reproduced against the dev database with a real JWT, *before* the fix:

```
attacker: apiadmin3@x.com  (tenant "APITenant3")
target:   "Test Academy"

GET /api/v1/courses/   X-Tenant-ID: <Test Academy>
→ 200 OK
LEAKED 3 courses from another tenant:
   - JEE Advanced
   - JEE Main
   - NEET
```

The identical request now returns `403 {"code": "tenant_mismatch"}`. No password, no privilege escalation — just editing one header in DevTools.

## The fix

`TenantMiddleware` now resolves the caller and rejects any mismatch. Middleware runs before DRF, so `request.user` is still anonymous for token-authenticated calls; the JWT is decoded here and cached on the request, and `BlockSuspendedUsersMiddleware` reuses that cache rather than decoding a second time.

Scope of the check, deliberately narrow so nothing legitimate breaks:

| caller | behaviour |
|---|---|
| anonymous | untouched — public endpoints still work, still fail as **401** not 403 |
| Django superuser | exempt — platform operators, tenant-less by design, and all superadmin routes are already tenant-exempt |
| everyone else | pinned to their own tenant |

I confirmed against the database that **every non-superuser account has a tenant** (0 exceptions), so there's no population that silently slips through the `tenant_id is None` branch.

## Verification

- **182 API routes** exercised with the *correct* tenant header — none wrongly blocked.
- Cross-tenant probes return 403 in **both** directions, on plain, student and tenant-admin endpoints.
- Anonymous and superuser paths behave exactly as before.
- Re-audited every entry in `TENANT_EXEMPT_PATHS`: all are either public by design (tenant branding — an explicit whitelist of branding fields, certificate verification, payment webhooks, marketing leads) or superuser-only.
- Checked there is no impersonation feature or dynamic tenant switching; the frontend builds with a single static `VITE_TENANT_ID`, so no legitimate call ever crosses tenants.

## Regression guard

New `core/tests.py` covers both directions of the block, the missing / unknown / malformed header cases, the superuser bypass and the anonymous path. **Two of these tests fail against the old middleware** (`AssertionError: 200 != 403`) and pass against the new one, so the hole is genuinely pinned rather than just described.

`chatbot/tenancy.py` is kept as defence in depth — a view that derives its tenant from the user can't be reopened by a future change to the middleware or its exempt-path list. Its docstring is updated since it's no longer the only barrier.

## Worth knowing

This closes header-level access. It does **not** retrofit tenant filtering onto every queryset — views still scope by `request.tenant`, which is now trustworthy. That's the correct chokepoint, but if you want belt-and-braces at the ORM layer too, that's a larger follow-up worth doing deliberately.