### PR TITLE
feat(community): surface course-scoped discussion previews on course pages

### DIFF
--- a/backend/community/serializers.py
+++ b/backend/community/serializers.py
@@ -1,6 +1,8 @@
 """
 Community serializers.
 """
+from django.utils.html import strip_tags
+from django.utils.text import Truncator
 from rest_framework import serializers
 from .models import (
     Post, Comment, Like, PollOption, PollVote,
@@ -212,6 +214,49 @@ class PostSerializer(serializers.ModelSerializer):
     def get_top_comments(self, obj):
         comments = obj.comments.filter(parent__isnull=True)[:3]
         return CommentSerializer(comments, many=True, context=self.context).data
+
+
+class PostPreviewSerializer(serializers.ModelSerializer):
+    """Lightweight teaser used by the course-level community preview.
+
+    Deliberately omits the full post body, poll options, quiz answers and
+    comments so the payload can safely be shown to visitors who are not yet
+    enrolled in the course.
+    """
+    author = serializers.SerializerMethodField()
+    excerpt = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = [
+            'id', 'post_type', 'title', 'excerpt', 'author',
+            'likes_count', 'comments_count', 'views_count',
+            'is_solved', 'created_at',
+        ]
+
+    def get_author(self, obj):
+        user = getattr(obj.author, 'user', None)
+        if user is None:
+            return None
+        request = self.context.get('request')
+        avatar = getattr(user, 'avatar', None)
+        avatar_url = None
+        if avatar:
+            try:
+                avatar_url = request.build_absolute_uri(avatar.url) if request else avatar.url
+            except Exception:
+                avatar_url = None
+        return {
+            'full_name': user.full_name,
+            'first_name': user.first_name,
+            'role': getattr(user, 'role', None),
+            'avatar': avatar_url,
+            'current_level': obj.author.current_level,
+        }
+
+    def get_excerpt(self, obj):
+        text = strip_tags(obj.content or '').replace('&nbsp;', ' ')
+        return Truncator(' '.join(text.split())).chars(180)
 
 
 class PostCreateSerializer(serializers.ModelSerializer):

--- a/backend/community/tests.py
+++ b/backend/community/tests.py
@@ -1,9 +1,11 @@
 from rest_framework.test import APIRequestFactory, force_authenticate
 
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
 from core.models import Tenant
-from users.models import User, StudentProfile
+from exams.models import Course
+from users.models import User, StudentProfile, CourseEnrollment
 from community.models import Post, Like
 from community.views import PostViewSet
 
@@ -83,3 +85,87 @@ class PostTenantIsolationTests(TestCase):
         ids = [p['id'] for p in response.data.get('results', response.data)]
         self.assertIn(str(self.post_a.id), ids)
 
+
+class CoursePreviewTests(TestCase):
+    """The course-level community teaser powering course landing pages."""
+
+    def setUp(self):
+        self.tenant = Tenant.objects.create(name='P', subdomain='p')
+        self.other_tenant = Tenant.objects.create(name='Q', subdomain='q')
+        self.course = Course.objects.create(
+            tenant=self.tenant, name='Physics 101', code='PHY101',
+        )
+
+        self.author_user = User.objects.create_user(
+            email='author@p.com', tenant=self.tenant, password='x'
+        )
+        self.author, _ = StudentProfile.objects.get_or_create(user=self.author_user)
+
+        self.outsider_user = User.objects.create_user(
+            email='outsider@p.com', tenant=self.tenant, password='x'
+        )
+        self.outsider, _ = StudentProfile.objects.get_or_create(user=self.outsider_user)
+
+        self.post = Post.objects.create(
+            author=self.author, tenant=self.tenant, post_type='question',
+            title='How do I solve projectile motion?',
+            content='<p>I keep getting the range formula wrong, any tips?</p>',
+            comments_count=3,
+        )
+        self.post.courses.add(self.course)
+
+        # Hidden posts must never surface in the teaser.
+        hidden = Post.objects.create(
+            author=self.author, tenant=self.tenant, post_type='question',
+            title='This one was moderated away',
+            content='Hidden content that should not be exposed.',
+            status='hidden',
+        )
+        hidden.courses.add(self.course)
+
+        self.factory = APIRequestFactory()
+        self.view = PostViewSet.as_view({'get': 'course_preview'})
+
+    def _preview(self, user, tenant=None):
+        request = self.factory.get('/posts/course_preview/', {'course': str(self.course.id)})
+        if user is not None:
+            force_authenticate(request, user=user)
+        request.tenant = tenant or self.tenant
+        return self.view(request)
+
+    def test_anonymous_visitor_gets_locked_teaser(self):
+        response = self._preview(AnonymousUser())
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data['can_participate'])
+        self.assertEqual(response.data['stats']['posts'], 1)
+        titles = [p['title'] for p in response.data['posts']]
+        self.assertIn('How do I solve projectile motion?', titles)
+        self.assertNotIn('This one was moderated away', titles)
+
+    def test_excerpt_is_plain_text_and_body_is_not_exposed(self):
+        response = self._preview(AnonymousUser())
+        post = response.data['posts'][0]
+        self.assertNotIn('content', post)
+        self.assertNotIn('<p>', post['excerpt'])
+        self.assertIn('range formula', post['excerpt'])
+
+    def test_enrolled_student_can_participate(self):
+        CourseEnrollment.objects.create(
+            student=self.outsider, course=self.course, status='approved', is_active=True,
+        )
+        response = self._preview(self.outsider_user)
+        self.assertTrue(response.data['is_enrolled'])
+        self.assertTrue(response.data['can_participate'])
+        self.assertEqual(response.data['stats']['members'], 1)
+
+    def test_answers_are_not_double_counted_for_dual_linked_posts(self):
+        # Legacy FK + M2M pointing at the same course must not inflate stats.
+        self.post.course = self.course
+        self.post.save(update_fields=['course'])
+        response = self._preview(AnonymousUser())
+        self.assertEqual(response.data['stats']['posts'], 1)
+        self.assertEqual(response.data['stats']['answers'], 3)
+
+    def test_course_from_another_tenant_is_not_found(self):
+        response = self._preview(self.author_user, tenant=self.other_tenant)
+        self.assertEqual(response.status_code, 404)

--- a/backend/community/views.py
+++ b/backend/community/views.py
@@ -4,16 +4,19 @@ Community views - Posts, Comments, Likes, Polls, Quizzes, Leaderboard.
 from rest_framework import viewsets, status, mixins
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
-from django.db.models import F, Q
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from django.db.models import F, Q, Count, Sum
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from datetime import timedelta
 
+from users.models import CourseEnrollment
 from .models import (
     Post, Comment, Like, PollOption, PollVote,
     CommunityQuiz, QuizAttempt, CommunityStats, CommunityLeaderboard
 )
 from .serializers import (
-    PostSerializer, PostCreateSerializer,
+    PostSerializer, PostCreateSerializer, PostPreviewSerializer,
     CommentSerializer, CommentCreateSerializer,
     CommunityStatsSerializer, CommunityLeaderboardSerializer,
     QuizAttemptSerializer
@@ -149,6 +152,13 @@ class PostViewSet(TenantAwareViewSet):
             return PostCreateSerializer
         return PostSerializer
 
+    def get_permissions(self):
+        # The course-level teaser is intentionally public so course landing
+        # pages can advertise an active community to logged-out visitors.
+        if self.action == 'course_preview':
+            return [AllowAny()]
+        return super().get_permissions()
+
     @action(detail=False, methods=['get'])
     def filter_options(self, request):
         """Courses the user can filter by / post into.
@@ -172,6 +182,113 @@ class PostViewSet(TenantAwareViewSet):
         return Response({
             'courses': courses,
             'is_staff': _is_staff_user(request.user),
+        })
+
+    @action(detail=False, methods=['get'], permission_classes=[AllowAny])
+    def course_preview(self, request):
+        """Teaser of a single course's community activity.
+
+        Powers the community preview block on the course landing page and the
+        learner's course workspace. Open to anonymous visitors on purpose: the
+        payload is a teaser (title + short excerpt + counters only) so it can
+        advertise an active community without leaking discussion content.
+        """
+        from exams.models import Course
+
+        tenant = getattr(request, 'tenant', None)
+        course_id = request.query_params.get('course')
+        if not tenant or not course_id:
+            return Response(
+                {'detail': 'A course id is required.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        course = Course.objects.filter(id=course_id, tenant=tenant).first()
+        if not course:
+            return Response({'detail': 'Course not found.'}, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            limit = min(max(int(request.query_params.get('limit', 4)), 1), 10)
+        except (TypeError, ValueError):
+            limit = 4
+
+        posts_qs = Post.objects.filter(
+            tenant=tenant, status='active'
+        ).filter(
+            Q(courses=course) | Q(course_id=course.id)
+        ).distinct()
+        # Re-anchor on plain ids: the OR above joins the M2M table, which would
+        # otherwise skew aggregates for posts linked both ways.
+        post_ids = list(posts_qs.values_list('id', flat=True))
+        posts = Post.objects.filter(id__in=post_ids).select_related('author__user')
+
+        is_authenticated = request.user.is_authenticated
+        is_staff = is_authenticated and _is_staff_user(request.user)
+        is_enrolled = is_authenticated and course.id in _student_course_ids(request.user)
+        can_participate = bool(is_staff or is_enrolled)
+
+        week_ago = timezone.now() - timedelta(days=7)
+        totals = posts.aggregate(
+            posts=Count('id'),
+            questions=Count('id', filter=Q(post_type='question')),
+            solved=Count('id', filter=Q(is_solved=True)),
+            answers=Sum('comments_count'),
+            new_this_week=Count('id', filter=Q(created_at__gte=week_ago)),
+        )
+
+        members = CourseEnrollment.objects.filter(
+            course=course, status='approved', is_active=True
+        ).count()
+
+        # Distinct people who have started or replied to a discussion here.
+        contributor_ids = set(posts.values_list('author_id', flat=True))
+        contributor_ids |= set(
+            Comment.objects.filter(post_id__in=post_ids).values_list('author_id', flat=True)
+        )
+
+        # Featured teasers: newest first, topped up with the highest-traction
+        # posts so the block never looks empty or stale.
+        featured = list(posts.order_by('-created_at')[:limit])
+        if len(featured) < limit:
+            featured += [
+                p for p in posts.order_by('-likes_count', '-comments_count')[:limit]
+                if p not in featured
+            ][: limit - len(featured)]
+
+        # Small avatar stack of recent voices (de-duplicated, max 5).
+        seen, contributors_preview = set(), []
+        for p in posts.order_by('-created_at')[:20]:
+            author_user = getattr(p.author, 'user', None)
+            if author_user is None or author_user.id in seen:
+                continue
+            seen.add(author_user.id)
+            avatar = getattr(author_user, 'avatar', None)
+            contributors_preview.append({
+                'full_name': author_user.full_name,
+                'first_name': author_user.first_name,
+                'avatar': request.build_absolute_uri(avatar.url) if avatar else None,
+            })
+            if len(contributors_preview) == 5:
+                break
+
+        return Response({
+            'course': {'id': str(course.id), 'name': course.name, 'code': course.code},
+            'is_authenticated': is_authenticated,
+            'is_enrolled': is_enrolled,
+            'can_participate': can_participate,
+            'stats': {
+                'posts': totals['posts'] or 0,
+                'questions': totals['questions'] or 0,
+                'solved': totals['solved'] or 0,
+                'answers': totals['answers'] or 0,
+                'new_this_week': totals['new_this_week'] or 0,
+                'members': members,
+                'contributors': len(contributor_ids),
+            },
+            'contributors_preview': contributors_preview,
+            'posts': PostPreviewSerializer(
+                featured, many=True, context={'request': request}
+            ).data,
         })
 
     def retrieve(self, request, *args, **kwargs):

--- a/frontend/exam-frontend/src/components/community/CourseCommunityPreview.jsx
+++ b/frontend/exam-frontend/src/components/community/CourseCommunityPreview.jsx
@@ -1,0 +1,314 @@
+import { useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import { useQuery } from '@tanstack/react-query'
+import {
+  MessageSquare, MessageCircle, BarChart3, Zap, Calendar, Users,
+  CheckCircle2, ThumbsUp, Sparkles, ArrowRight, Lock, Maximize2, Flame,
+} from 'lucide-react'
+import { communityService } from '../../services/communityService'
+import { useTenantStore } from '../../context/tenantStore'
+
+const TYPE_META = {
+  question: { icon: MessageCircle, label: 'Question', cls: 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/25' },
+  poll: { icon: BarChart3, label: 'Poll', cls: 'text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-900/25' },
+  quiz: { icon: Zap, label: 'Quiz', cls: 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/25' },
+  event: { icon: Calendar, label: 'Event', cls: 'text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/25' },
+}
+
+const timeAgo = (value) => {
+  if (!value) return ''
+  const diff = Date.now() - new Date(value).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(value).toLocaleDateString()
+}
+
+const Avatar = ({ person, size = 28 }) => (
+  <span
+    className="rounded-full ring-2 ring-white dark:ring-surface-900 bg-gradient-to-br from-primary-400 to-accent-500 text-white flex items-center justify-center text-[11px] font-semibold overflow-hidden shrink-0"
+    style={{ width: size, height: size }}
+    title={person?.full_name}
+  >
+    {person?.avatar ? (
+      <img src={person.avatar} alt={person.full_name || ''} className="w-full h-full object-cover" />
+    ) : (
+      (person?.first_name || person?.full_name || 'U').charAt(0).toUpperCase()
+    )}
+  </span>
+)
+
+const StatPill = ({ icon: Icon, value, label, accent }) => (
+  <div className="flex-1 min-w-[76px] rounded-xl bg-white/10 ring-1 ring-white/15 backdrop-blur-sm px-3 py-2">
+    <div className="flex items-center gap-1.5">
+      <Icon size={14} className={accent || 'text-white/70'} />
+      <span className="text-base font-bold leading-none">{value}</span>
+    </div>
+    <p className="text-[11px] text-white/70 mt-1">{label}</p>
+  </div>
+)
+
+/**
+ * Course-scoped community teaser.
+ *
+ * Renders a compact, attention-grabbing snapshot of a course's discussions and
+ * links through to the full forum pre-filtered to that course. Non-enrolled
+ * visitors get a blurred/locked variant that advertises the activity without
+ * revealing discussion content.
+ *
+ * @param {string}  courseId    Course UUID
+ * @param {string}  courseName  Used for the empty/locked copy
+ * @param {string}  variant     'panel' (wide, course landing) | 'compact' (sidebar)
+ * @param {string}  accentColor Optional course brand colour for the header
+ */
+const CourseCommunityPreview = ({
+  courseId,
+  courseName,
+  variant = 'panel',
+  accentColor,
+  className = '',
+}) => {
+  const navigate = useNavigate()
+  const isFeatureEnabled = useTenantStore((s) => s.isFeatureEnabled)
+  const communityEnabled = isFeatureEnabled('community')
+  const compact = variant === 'compact'
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['courseCommunityPreview', courseId, compact ? 3 : 4],
+    queryFn: () => communityService.getCoursePreview(courseId, compact ? 3 : 4),
+    enabled: !!courseId && communityEnabled,
+    staleTime: 60_000,
+    retry: false,
+  })
+
+  const stats = data?.stats || {}
+  const posts = data?.posts || []
+  const people = data?.contributors_preview || []
+  const canParticipate = !!data?.can_participate
+  const hasActivity = (stats.posts || 0) > 0
+
+  const headerStyle = useMemo(
+    () => (accentColor ? { backgroundImage: `linear-gradient(135deg, ${accentColor}, ${accentColor}cc)` } : undefined),
+    [accentColor]
+  )
+
+  const openForum = () => navigate(`/community?course=${courseId}`)
+  const openPost = (post) => {
+    if (canParticipate) navigate(`/community/${post.id}`)
+    else openForum()
+  }
+
+  if (!communityEnabled || isError) return null
+
+  if (isLoading) {
+    return (
+      <div className={`card overflow-hidden animate-pulse ${className}`}>
+        <div className="h-28 bg-surface-200 dark:bg-surface-800" />
+        <div className="p-5 space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-12 rounded-xl bg-surface-100 dark:bg-surface-800" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35 }}
+      className={`card overflow-hidden ${className}`}
+    >
+      {/* Header band */}
+      <div
+        className="relative overflow-hidden bg-gradient-to-br from-primary-600 via-primary-600 to-accent-600 text-white"
+        style={headerStyle}
+      >
+        <div className="absolute -top-12 -right-8 w-40 h-40 rounded-full bg-white/10" />
+        <div className="absolute -bottom-16 -left-10 w-44 h-44 rounded-full bg-black/10" />
+
+        <div className="relative p-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-white/15 ring-1 ring-white/20 backdrop-blur-sm text-[11px] font-semibold uppercase tracking-wide">
+                  <Users size={12} /> Course community
+                </span>
+                {stats.new_this_week > 0 && (
+                  <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-400/20 ring-1 ring-emerald-200/40 text-[11px] font-semibold">
+                    <span className="relative flex h-1.5 w-1.5">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-200 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-100" />
+                    </span>
+                    {stats.new_this_week} new this week
+                  </span>
+                )}
+              </div>
+              <h2 className={`mt-2.5 font-display font-bold leading-tight ${compact ? 'text-lg' : 'text-xl sm:text-2xl'}`}>
+                {hasActivity ? 'Learners are talking right now' : 'Start the conversation'}
+              </h2>
+              <p className="text-white/80 text-sm mt-1 max-w-lg">
+                {hasActivity
+                  ? 'Questions, answers, polls and live events — all scoped to this course.'
+                  : `Be the first to ask a question in ${courseName || 'this course'} and help others get unstuck.`}
+              </p>
+            </div>
+
+            {!compact && (
+              <button
+                onClick={openForum}
+                className="hidden sm:inline-flex items-center gap-1.5 shrink-0 px-3 py-2 rounded-xl text-sm font-semibold bg-white/15 hover:bg-white/25 ring-1 ring-white/25 backdrop-blur-sm transition-colors"
+                title="Open the full community forum for this course"
+              >
+                <Maximize2 size={15} /> Full screen
+              </button>
+            )}
+          </div>
+
+          {/* Stats */}
+          <div className={`mt-4 flex flex-wrap gap-2 ${compact ? '' : 'sm:gap-3'}`}>
+            <StatPill icon={MessageSquare} value={stats.posts || 0} label="Discussions" />
+            <StatPill icon={MessageCircle} value={stats.answers || 0} label="Replies" />
+            {!compact && <StatPill icon={CheckCircle2} value={stats.solved || 0} label="Solved" accent="text-emerald-200" />}
+            <StatPill icon={Users} value={stats.members || 0} label="Members" />
+          </div>
+
+          {/* Avatar stack */}
+          {people.length > 0 && (
+            <div className="mt-4 flex items-center gap-2.5">
+              <div className="flex -space-x-2">
+                {people.map((p, i) => (
+                  <Avatar key={i} person={p} size={compact ? 24 : 28} />
+                ))}
+              </div>
+              <p className="text-xs text-white/80">
+                {people[0]?.first_name || people[0]?.full_name}
+                {stats.contributors > 1 && ` and ${stats.contributors - 1} other${stats.contributors - 1 === 1 ? '' : 's'}`}
+                {' are active here'}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Post teasers */}
+      <div className="relative">
+        {posts.length > 0 ? (
+          <ul className="divide-y divide-surface-100 dark:divide-surface-800">
+            {posts.map((post, index) => {
+              const meta = TYPE_META[post.post_type] || TYPE_META.question
+              const TypeIcon = meta.icon
+              return (
+                <motion.li
+                  key={post.id}
+                  initial={{ opacity: 0, x: -6 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: 0.05 * index }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => openPost(post)}
+                    className="group w-full text-left px-5 py-3.5 flex gap-3 hover:bg-surface-50 dark:hover:bg-surface-800/60 transition-colors"
+                  >
+                    <span className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${meta.cls}`}>
+                      <TypeIcon size={15} />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-start gap-2">
+                        <span className="font-semibold text-sm leading-snug line-clamp-1 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                          {post.title}
+                        </span>
+                        {post.is_solved && (
+                          <CheckCircle2 size={14} className="text-success-500 shrink-0 mt-0.5" />
+                        )}
+                      </span>
+                      {!compact && post.excerpt && (
+                        <span className="block text-xs text-surface-500 line-clamp-1 mt-0.5">{post.excerpt}</span>
+                      )}
+                      <span className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-[11px] text-surface-400">
+                        <span className="inline-flex items-center gap-1">
+                          <Avatar person={post.author} size={16} />
+                          {post.author?.first_name || post.author?.full_name || 'Member'}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <MessageCircle size={11} /> {post.comments_count || 0}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <ThumbsUp size={11} /> {post.likes_count || 0}
+                        </span>
+                        <span>{timeAgo(post.created_at)}</span>
+                      </span>
+                    </span>
+                    <ArrowRight
+                      size={15}
+                      className="shrink-0 self-center text-surface-300 group-hover:text-primary-500 group-hover:translate-x-0.5 transition-all"
+                    />
+                  </button>
+                </motion.li>
+              )
+            })}
+          </ul>
+        ) : (
+          <div className="px-5 py-8 text-center">
+            <span className="w-12 h-12 rounded-2xl bg-primary-50 dark:bg-primary-900/25 text-primary-500 flex items-center justify-center mx-auto mb-3">
+              <Sparkles size={22} />
+            </span>
+            <p className="font-semibold text-sm">No discussions yet</p>
+            <p className="text-xs text-surface-500 mt-1 max-w-xs mx-auto">
+              {canParticipate
+                ? 'Ask the first question — early contributors earn the most community XP.'
+                : 'Join this course to start the very first discussion.'}
+            </p>
+          </div>
+        )}
+
+        {/* Locked overlay for people who are not part of the course yet */}
+        {!canParticipate && posts.length > 0 && (
+          <div className="absolute inset-0 flex items-end justify-center bg-gradient-to-t from-white via-white/92 to-white/25 dark:from-surface-900 dark:via-surface-900/92 dark:to-surface-900/25 backdrop-blur-[2px]">
+            <div className="w-full px-5 py-4 text-center">
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-surface-600 dark:text-surface-300">
+                <Lock size={13} /> Enroll to read and join these discussions
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Footer CTA */}
+      <div className="px-5 py-4 border-t border-surface-100 dark:border-surface-800 bg-surface-50/60 dark:bg-surface-900/40">
+        <button
+          onClick={openForum}
+          className="btn-primary w-full group/cta"
+          style={accentColor ? { backgroundColor: accentColor } : undefined}
+        >
+          {canParticipate ? (
+            <>
+              <MessageSquare size={16} />
+              Open community
+              <ArrowRight size={16} className="transition-transform group-hover/cta:translate-x-0.5" />
+            </>
+          ) : (
+            <>
+              <Flame size={16} />
+              Explore the community
+              <ArrowRight size={16} className="transition-transform group-hover/cta:translate-x-0.5" />
+            </>
+          )}
+        </button>
+        {!compact && (
+          <p className="text-[11px] text-center text-surface-400 mt-2">
+            Opens the full forum filtered to {courseName || 'this course'}.
+          </p>
+        )}
+      </div>
+    </motion.section>
+  )
+}
+
+export default CourseCommunityPreview

--- a/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
+++ b/frontend/exam-frontend/src/components/community/CreatePostModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { X, Plus, Trash2, HelpCircle, BarChart3, Zap, Image as ImageIcon, Camera, Users, BookOpen, Calendar, Video } from 'lucide-react'
@@ -8,7 +8,7 @@ import { useAuthStore } from '../../context/authStore'
 import SearchableSelect from '../common/SearchableSelect'
 import toast from 'react-hot-toast'
 
-const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
+const CreatePostModal = ({ isOpen, onClose, postType = 'question', defaultCourseId = null }) => {
     const queryClient = useQueryClient()
     const { user, profile } = useAuthStore()
     const role = user?.role || profile?.user?.role
@@ -52,6 +52,7 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
             toast.success('Post created successfully! +XP earned 🎉')
             queryClient.invalidateQueries(['communityPosts'])
             queryClient.invalidateQueries(['communityStats'])
+            queryClient.invalidateQueries(['courseCommunityPreview'])
             resetForm()
             onClose()
         },
@@ -91,8 +92,17 @@ const CreatePostModal = ({ isOpen, onClose, postType = 'question' }) => {
         setSelectedCourses([])
     }
 
-    const toggleCourse = (courseId) => {
-        setSelectedCourses((prev) =>
+    // The modal stays mounted, so sync the requested post type (and the course
+    // the user came from) every time it is opened.
+    useEffect(() => {
+        if (!isOpen) return
+        setType(postType)
+        if (defaultCourseId) {
+            setSelectedCourses((prev) => (prev.length ? prev : [defaultCourseId]))
+        }
+    }, [isOpen, postType, defaultCourseId])
+
+    const toggleCourse = (courseId) => {        setSelectedCourses((prev) =>
             prev.includes(courseId)
                 ? prev.filter((id) => id !== courseId)
                 : [...prev, courseId]

--- a/frontend/exam-frontend/src/pages/Community.jsx
+++ b/frontend/exam-frontend/src/pages/Community.jsx
@@ -1,15 +1,15 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
     MessageCircle, MessageSquare, ThumbsUp, Eye, CheckCircle,
     Plus, Filter, TrendingUp, Clock, HelpCircle,
-    BarChart3, Zap, Trophy, Users, BookOpen, Globe, Calendar, EyeOff
+    BarChart3, Zap, Trophy, Users, BookOpen, Globe, Calendar, EyeOff,
+    Maximize2, Minimize2, X
 } from 'lucide-react'
 import { communityService } from '../services/communityService'
 import { useAuthStore } from '../context/authStore'
-import Loading from '../components/common/Loading'
 import CreatePostModal from '../components/community/CreatePostModal'
 import PostCard from '../components/community/PostCard'
 import CommunityLeaderboard from '../components/community/CommunityLeaderboard'
@@ -19,14 +19,67 @@ import toast from 'react-hot-toast'
 const Community = () => {
     const navigate = useNavigate()
     const queryClient = useQueryClient()
+    const [searchParams, setSearchParams] = useSearchParams()
     const { user, profile } = useAuthStore()
     const role = user?.role || profile?.user?.role
     const isAdmin = role === 'admin' || role === 'instructor'
     const [activeTab, setActiveTab] = useState('all')
     const [sortBy, setSortBy] = useState('recent')
-    const [courseFilter, setCourseFilter] = useState('all')
+    // Deep links from a course page land here as /community?course=<id> so the
+    // forum opens already focused on that course's discussions.
+    const [courseFilter, setCourseFilter] = useState(() => searchParams.get('course') || 'all')
     const [showCreateModal, setShowCreateModal] = useState(false)
     const [createType, setCreateType] = useState('question')
+    const [focusMode, setFocusMode] = useState(false)
+    const containerRef = useRef(null)
+
+    // Keep the URL in sync so the scoped view is shareable / refresh-safe.
+    useEffect(() => {
+        const current = searchParams.get('course') || 'all'
+        if (current === courseFilter) return
+        const next = new URLSearchParams(searchParams)
+        if (courseFilter === 'all') next.delete('course')
+        else next.set('course', courseFilter)
+        setSearchParams(next, { replace: true })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [courseFilter])
+
+    // Back/forward navigation should move the filter too.
+    useEffect(() => {
+        const fromUrl = searchParams.get('course') || 'all'
+        if (fromUrl !== courseFilter) setCourseFilter(fromUrl)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [searchParams])
+
+    // Immersive "full screen" reading mode for the forum.
+    const toggleFocusMode = () => {
+        const next = !focusMode
+        setFocusMode(next)
+        try {
+            if (next && containerRef.current?.requestFullscreen) {
+                containerRef.current.requestFullscreen().catch(() => { })
+            } else if (!next && document.fullscreenElement) {
+                document.exitFullscreen?.().catch(() => { })
+            }
+        } catch {
+            /* Fullscreen API unavailable — the in-page overlay still applies. */
+        }
+    }
+
+    useEffect(() => {
+        const onFsChange = () => {
+            if (!document.fullscreenElement) setFocusMode(false)
+        }
+        const onKey = (e) => {
+            if (e.key === 'Escape') setFocusMode(false)
+        }
+        document.addEventListener('fullscreenchange', onFsChange)
+        document.addEventListener('keydown', onKey)
+        return () => {
+            document.removeEventListener('fullscreenchange', onFsChange)
+            document.removeEventListener('keydown', onKey)
+        }
+    }, [])
 
     // Courses the user belongs to (for scoping the forum by course).
     const { data: filterOptions } = useQuery({
@@ -113,10 +166,42 @@ const Community = () => {
         setShowCreateModal(true)
     }
 
-    if (postsLoading) return <Loading fullScreen />
+    const activeCourse = courses.find((c) => String(c.id) === String(courseFilter))
 
     return (
-        <div className="space-y-6">
+        <div
+            ref={containerRef}
+            className={
+                focusMode
+                    ? 'fixed inset-0 z-50 overflow-y-auto bg-surface-50 dark:bg-surface-950 p-4 sm:p-8 space-y-6'
+                    : 'space-y-6'
+            }
+        >
+            {/* Course scope banner — shown when the forum was opened from a course */}
+            {activeCourse && (
+                <motion.div
+                    initial={{ opacity: 0, y: -8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-primary-600 to-accent-600 text-white px-5 py-4 flex flex-wrap items-center justify-between gap-3"
+                >
+                    <div className="absolute -top-10 -right-6 w-32 h-32 rounded-full bg-white/10" />
+                    <div className="relative min-w-0">
+                        <p className="text-[11px] font-semibold uppercase tracking-wider text-white/70">
+                            Focused discussions
+                        </p>
+                        <h2 className="text-lg font-display font-bold truncate flex items-center gap-2">
+                            <BookOpen size={18} /> {activeCourse.name}
+                        </h2>
+                    </div>
+                    <button
+                        onClick={() => setCourseFilter('all')}
+                        className="relative inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium bg-white/15 hover:bg-white/25 ring-1 ring-white/20 backdrop-blur-sm transition-colors"
+                    >
+                        <X size={14} /> Clear course filter
+                    </button>
+                </motion.div>
+            )}
+
             {/* Header */}
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
                 <div>
@@ -128,6 +213,14 @@ const Community = () => {
 
                 {/* Create Buttons */}
                 <div className="flex items-center gap-2">
+                    <button
+                        onClick={toggleFocusMode}
+                        className="btn-secondary flex items-center gap-2"
+                        title={focusMode ? 'Exit full screen' : 'Read the forum full screen'}
+                    >
+                        {focusMode ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
+                        <span className="hidden lg:inline">{focusMode ? 'Exit full screen' : 'Full screen'}</span>
+                    </button>
                     <motion.button
                         whileHover={{ scale: 1.02 }}
                         whileTap={{ scale: 0.98 }}
@@ -302,7 +395,20 @@ const Community = () => {
                             </div>
                         )}
                         <AnimatePresence mode="popLayout">
-                            {posts.length > 0 ? (
+                            {postsLoading ? (
+                                <motion.div key="loading" initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-4">
+                                    {[0, 1, 2].map((i) => (
+                                        <div key={i} className="card p-5 animate-pulse space-y-3">
+                                            <div className="flex items-center gap-3">
+                                                <div className="w-10 h-10 rounded-full bg-surface-200 dark:bg-surface-800" />
+                                                <div className="h-3 w-32 rounded bg-surface-200 dark:bg-surface-800" />
+                                            </div>
+                                            <div className="h-4 w-3/4 rounded bg-surface-200 dark:bg-surface-800" />
+                                            <div className="h-3 w-full rounded bg-surface-100 dark:bg-surface-800" />
+                                        </div>
+                                    ))}
+                                </motion.div>
+                            ) : posts.length > 0 ? (
                                 posts.map((post, index) => (
                                     <motion.div
                                         key={post.id}
@@ -373,6 +479,7 @@ const Community = () => {
                 isOpen={showCreateModal}
                 onClose={() => setShowCreateModal(false)}
                 postType={createType}
+                defaultCourseId={activeCourse ? String(activeCourse.id) : null}
             />
         </div>
     )

--- a/frontend/exam-frontend/src/pages/CourseDetail.jsx
+++ b/frontend/exam-frontend/src/pages/CourseDetail.jsx
@@ -13,6 +13,8 @@ import { marketingService } from '../services/marketingService'
 import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CourseThumbnail from '../components/course/CourseThumbnail'
+import CourseCommunityPreview from '../components/community/CourseCommunityPreview'
+import { useTenantStore } from '../context/tenantStore'
 import toast from 'react-hot-toast'
 import {
   ArrowLeft, ArrowRight, GraduationCap, CheckCircle2, Clock, PlusCircle,
@@ -99,6 +101,7 @@ const CourseDetail = () => {
   const { user, profile, isAuthenticated } = useAuthStore()
   const role = user?.role || profile?.user?.role
   const isAdmin = role === 'admin'
+  const communityEnabled = useTenantStore((s) => s.isFeatureEnabled)('community')
 
   const [tab, setTab] = useState('overview')
   const [requesting, setRequesting] = useState(false)
@@ -252,6 +255,7 @@ const CourseDetail = () => {
     { key: 'overview', label: 'Overview' },
     { key: 'curriculum', label: 'Curriculum' },
     ...(instructors.length ? [{ key: 'instructors', label: 'Faculty' }] : []),
+    ...(communityEnabled ? [{ key: 'community', label: 'Community' }] : []),
   ]
 
   const enrollMode = course.enroll_mode || 'request'
@@ -446,6 +450,43 @@ const CourseDetail = () => {
                   </p>
                 </section>
               )}
+
+              {communityEnabled && (
+                <section>
+                  <div className="flex items-center justify-between gap-3 mb-3">
+                    <h2 className="text-lg font-display font-bold flex items-center gap-2">
+                      <Users size={18} className="text-primary-500" /> Community
+                    </h2>
+                    <button
+                      onClick={() => setTab('community')}
+                      className="text-sm font-medium text-primary-600 dark:text-primary-400 hover:underline"
+                    >
+                      See more
+                    </button>
+                  </div>
+                  <CourseCommunityPreview
+                    courseId={course.id}
+                    courseName={course.name}
+                    accentColor={course.color}
+                  />
+                </section>
+              )}
+            </div>
+          )}
+
+          {tab === 'community' && communityEnabled && (
+            <div className="space-y-4">
+              <CourseCommunityPreview
+                courseId={course.id}
+                courseName={course.name}
+                accentColor={course.color}
+              />
+              <p className="text-sm text-surface-500 leading-relaxed">
+                Every question, poll, quiz and live event posted here is scoped to{' '}
+                <span className="font-medium text-surface-700 dark:text-surface-200">{course.name}</span>,
+                so the discussion stays focused on what you are actually studying. Answer
+                well and you earn community XP that counts towards your level.
+              </p>
             </div>
           )}
 

--- a/frontend/exam-frontend/src/pages/StudyCourse.jsx
+++ b/frontend/exam-frontend/src/pages/StudyCourse.jsx
@@ -7,6 +7,7 @@ import { certificateService } from '../services/certificateService'
 import { useAuthStore } from '../context/authStore'
 import Loading from '../components/common/Loading'
 import CertificateModal from '../components/certificate/CertificateModal'
+import CourseCommunityPreview from '../components/community/CourseCommunityPreview'
 import {
   BookOpen, Atom, FlaskConical, Calculator, Leaf, Bug,
   ChevronRight, ChevronDown, GraduationCap, ArrowLeft, Settings2,
@@ -592,6 +593,14 @@ const StudyCourse = () => {
                 )}
               </div>
             )}
+
+            {/* Course community */}
+            <CourseCommunityPreview
+              courseId={courseId}
+              courseName={course?.name}
+              accentColor={course?.color}
+              variant="compact"
+            />
 
             {/* Leaderboard by completion */}
             {leaderboard && leaderboard.length > 0 && (

--- a/frontend/exam-frontend/src/services/communityService.js
+++ b/frontend/exam-frontend/src/services/communityService.js
@@ -15,6 +15,14 @@ export const communityService = {
         return response.data
     },
 
+    // Course-scoped teaser used on the course landing page / study workspace.
+    getCoursePreview: async (courseId, limit = 4) => {
+        const response = await api.get('/community/posts/course_preview/', {
+            params: { course: courseId, limit }
+        })
+        return response.data
+    },
+
     getPost: async (id) => {
         const response = await api.get(`/community/posts/${id}/`)
         return response.data


### PR DESCRIPTION
## Why

The community forum already supports course-level filtering, but nothing on a course page hints that a focused, active discussion space exists behind it. Learners had to discover it via the sidebar and then manually filter. This adds an attractive, course-scoped preview right where interest is highest — the course landing page — with a one-click jump into the full forum.

## What

### Backend — `backend/community/`

- **New endpoint** `GET /api/v1/community/posts/course_preview/?course=<id>&limit=4`
  - Deliberately `AllowAny` so logged-out visitors browsing a course landing page still see the community is alive. Tenant-isolated; a course from another tenant returns 404.
  - Returns course info, `is_enrolled` / `can_participate`, stats (discussions, replies, solved, members, contributors, new-this-week), a de-duplicated contributor avatar list, and post teasers.
- **`PostPreviewSerializer`** exposes only `title`, a plain-text `excerpt` and counters — never the body, poll options, quiz answers or comments. Hidden/moderated posts are excluded.
- Aggregates are re-anchored on post ids so a post linked via **both** the legacy `course` FK and the `courses` M2M isn't double-counted.
- `get_permissions()` is overridden explicitly rather than relying on router-injected action kwargs, so the permission holds however the view is invoked.

### Frontend — `frontend/exam-frontend/`

- **New `CourseCommunityPreview.jsx`** — reusable block with a gradient header, live "N new this week" pulse badge, stat pills, overlapping member avatar stack, animated discussion teaser rows with type badges, an empty state, and a **locked/blurred overlay** ("Enroll to read and join these discussions") for non-enrolled visitors. Two variants (`panel` / `compact`), picks up the course's brand colour, respects the tenant `community` feature flag, and renders nothing on error.
- **`CourseDetail`** — preview under Overview plus a dedicated **Community** tab.
- **`StudyCourse`** — compact preview in the sidebar for enrolled learners.
- **`Community`** — reads/writes `?course=<id>` so deep links land pre-filtered, shows a course-scope banner with a clear-filter action, gains a **Full screen** focus mode (Fullscreen API with an in-page overlay fallback, Esc to exit), and renders inline skeletons instead of replacing the whole page while filtering.
- **`CreatePostModal`** — accepts `defaultCourseId` so posting from a scoped forum pre-selects that course. Also fixes a pre-existing bug: the modal stays mounted, so its post type was frozen at first render (clicking "Create Poll" after "Ask Question" reopened as a question).

## Privacy / access

The teaser is public by design, but only ever leaks a title, a 180-char plain-text excerpt and engagement counters. Full discussion content stays behind the existing enrolment checks — clicking a teaser as a non-participant routes to the forum, not the post.

## Testing

- 5 new backend tests (anonymous teaser, no content leakage, enrolled participation, no double-counting, cross-tenant 404) — full `community` suite green (9/9).
- `manage.py check` clean.
- Live smoke test of the endpoint against a local DB with a real linked post (changes rolled back).
- Clean Vite production build.