### PR TITLE
Show profile photos on the leaderboard

### DIFF
--- a/backend/gamification/services.py
+++ b/backend/gamification/services.py
@@ -1,6 +1,7 @@
 """
 Gamification service layer.
 """
+from django.core.files.storage import default_storage
 from django.db import transaction
 from django.db.models import Sum, Count, F, Q, Case, When, Value, FloatField
 from django.utils import timezone
@@ -418,6 +419,16 @@ class GamificationService:
     )
 
     @staticmethod
+    def _avatar_url(name):
+        """Resolve a stored avatar path to a servable URL (local or cloud storage)."""
+        if not name:
+            return None
+        try:
+            return default_storage.url(name)
+        except Exception:
+            return None
+
+    @staticmethod
     def get_leaderboard(period='daily', course=None, limit=50, tenant=None):
         """
         Get leaderboard data from DailyActivity. Scoped to tenant when provided.
@@ -435,6 +446,7 @@ class GamificationService:
                 'student__user__first_name',
                 'student__user__last_name',
                 'student__user__role',
+                'student__user__avatar',
                 'student__current_level',
             )
             .annotate(
@@ -454,6 +466,7 @@ class GamificationService:
             result.append({
                 'id': str(row['student']),
                 'student_name': name,
+                'student_avatar': GamificationService._avatar_url(row['student__user__avatar']),
                 'role': row['student__user__role'],
                 'student_level': row['student__current_level'],
                 'xp_earned': row['total_xp'] or 0,

--- a/backend/gamification/views.py
+++ b/backend/gamification/views.py
@@ -118,6 +118,10 @@ class LeaderboardView(APIView):
             }, status=status.HTTP_400_BAD_REQUEST)
         # Get leaderboard entries (tenant-scoped)
         entries = GamificationService.get_leaderboard(period, course, limit, tenant=tenant)
+        for entry in entries:
+            avatar = entry.get('student_avatar')
+            if avatar and not avatar.startswith(('http://', 'https://')):
+                entry['student_avatar'] = request.build_absolute_uri(avatar)
         # Get user's rank (same tenant scope)
         student = request.user.profile
         user_rank = GamificationService.get_student_rank(student, period, course, tenant=tenant)

--- a/frontend/exam-frontend/src/components/common/LeaderboardRow.jsx
+++ b/frontend/exam-frontend/src/components/common/LeaderboardRow.jsx
@@ -28,8 +28,17 @@ const LeaderboardRow = ({ entry, rank, isCurrentUser = false }) => {
       </div>
 
       {/* Avatar */}
-      <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary-400 to-accent-400 flex items-center justify-center text-white font-semibold">
-        {entry.student_name?.charAt(0) || '?'}
+      <div className="w-10 h-10 shrink-0 rounded-full overflow-hidden bg-gradient-to-br from-primary-400 to-accent-400 flex items-center justify-center text-white font-semibold">
+        {entry.student_avatar ? (
+          <img
+            src={entry.student_avatar}
+            alt={entry.student_name || 'Avatar'}
+            className="w-full h-full object-cover"
+            onError={(e) => { e.currentTarget.style.display = 'none' }}
+          />
+        ) : (
+          entry.student_name?.charAt(0) || '?'
+        )}
       </div>
 
       {/* Info */}

--- a/frontend/exam-frontend/src/pages/Leaderboard.jsx
+++ b/frontend/exam-frontend/src/pages/Leaderboard.jsx
@@ -13,6 +13,21 @@ import {
   ChevronDown
 } from 'lucide-react'
 
+const PodiumAvatar = ({ entry, className }) => (
+  <div className={`rounded-full overflow-hidden flex items-center justify-center text-white font-bold mb-2 mx-auto ${className}`}>
+    {entry.student_avatar ? (
+      <img
+        src={entry.student_avatar}
+        alt={entry.student_name || 'Avatar'}
+        className="w-full h-full object-cover"
+        onError={(e) => { e.currentTarget.style.display = 'none' }}
+      />
+    ) : (
+      entry.student_name?.charAt(0)
+    )}
+  </div>
+)
+
 const Leaderboard = () => {
   const [period, setPeriod] = useState('daily')
   const { profile } = useAuthStore()
@@ -133,9 +148,10 @@ const Leaderboard = () => {
               {/* 2nd Place */}
               {entries[1] && (
                 <div className="text-center">
-                  <div className="w-16 h-16 rounded-full bg-gradient-to-br from-gray-300 to-gray-400 flex items-center justify-center text-white text-xl font-bold mb-2 mx-auto">
-                    {entries[1].student_name?.charAt(0)}
-                  </div>
+                  <PodiumAvatar
+                    entry={entries[1]}
+                    className="w-16 h-16 bg-gradient-to-br from-gray-300 to-gray-400 text-xl"
+                  />
                   <p className="text-xs font-medium truncate w-16">{entries[1].student_name?.split(' ')[0]}</p>
                   <div className="h-16 w-16 bg-gray-200 dark:bg-surface-700 rounded-t-lg mt-2 flex items-center justify-center text-surface-400">
                     <Award size={32} />
@@ -146,9 +162,10 @@ const Leaderboard = () => {
               {/* 1st Place */}
               {entries[0] && (
                 <div className="text-center -mb-4">
-                  <div className="w-20 h-20 rounded-full bg-gradient-to-br from-yellow-400 to-yellow-500 flex items-center justify-center text-white text-2xl font-bold mb-2 mx-auto ring-4 ring-yellow-200">
-                    {entries[0].student_name?.charAt(0)}
-                  </div>
+                  <PodiumAvatar
+                    entry={entries[0]}
+                    className="w-20 h-20 bg-gradient-to-br from-yellow-400 to-yellow-500 text-2xl ring-4 ring-yellow-200"
+                  />
                   <p className="text-sm font-medium truncate w-20">{entries[0].student_name?.split(' ')[0]}</p>
                   <div className="h-24 w-16 bg-yellow-100 dark:bg-yellow-900/30 rounded-t-lg mt-2 flex items-center justify-center mx-auto text-warning-500">
                     <Award size={40} />
@@ -159,9 +176,10 @@ const Leaderboard = () => {
               {/* 3rd Place */}
               {entries[2] && (
                 <div className="text-center">
-                  <div className="w-16 h-16 rounded-full bg-gradient-to-br from-amber-600 to-amber-700 flex items-center justify-center text-white text-xl font-bold mb-2 mx-auto">
-                    {entries[2].student_name?.charAt(0)}
-                  </div>
+                  <PodiumAvatar
+                    entry={entries[2]}
+                    className="w-16 h-16 bg-gradient-to-br from-amber-600 to-amber-700 text-xl"
+                  />
                   <p className="text-xs font-medium truncate w-16">{entries[2].student_name?.split(' ')[0]}</p>
                   <div className="h-12 w-16 bg-amber-100 dark:bg-amber-900/30 rounded-t-lg mt-2 flex items-center justify-center text-orange-400">
                     <Award size={28} />


### PR DESCRIPTION
## Problem

Leaderboard rows and the Top 3 podium only showed name initials — never the user's uploaded profile photo. The API response simply didn't include an avatar: `GamificationService.get_leaderboard()` builds its rows from a grouped aggregate query that never selected `student__user__avatar`.

## Changes

**Backend (`gamification`)**
- `services.py`: select `student__user__avatar` in the grouped leaderboard query and return it as `student_avatar`, resolved via `default_storage.url()` so local media, Azure and S3 storage all produce a servable URL.
- `views.py`: `LeaderboardView` absolutizes relative avatar URLs with `request.build_absolute_uri`.

**Frontend (`exam-frontend`)**
- `LeaderboardRow.jsx`: renders `<img src={entry.student_avatar}>` when present, falling back to the name initial when there's no avatar or the image fails to load.
- `Leaderboard.jsx`: extracted a small `PodiumAvatar` component so the Top 3 podium shows photos too, with the same initial fallback.

No schema or migration changes — `User.avatar` already exists.

## Testing

- `manage.py check` — no issues.
- `vite build` — clean production build.