### PR TITLE
fix(admin): remove duplicate section headings in dashboard panels

### DIFF
--- a/frontend/exam-frontend/src/components/admin/LandingBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/LandingBuilder.jsx
@@ -512,11 +512,7 @@ const LandingBuilder = () => {
   return (
     <div className="max-w-4xl">
       {/* Header actions */}
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <div>
-          <h2 className="text-xl font-bold text-surface-900 dark:text-surface-100">Home Page Builder</h2>
-          <p className="text-sm text-surface-500">Design your public landing page — no code required.</p>
-        </div>
+      <div className="flex flex-wrap items-center justify-end gap-3 mb-6">
         <div className="flex items-center gap-2">
           <a href="/?preview=1" target="_blank" rel="noreferrer" className="inline-flex items-center gap-1.5 rounded-lg border border-surface-200 dark:border-surface-700 px-3 py-2 text-sm font-medium text-surface-600 dark:text-surface-300">
             <ExternalLink size={15} /> Preview

--- a/frontend/exam-frontend/src/components/admin/MarketingPromotions.jsx
+++ b/frontend/exam-frontend/src/components/admin/MarketingPromotions.jsx
@@ -801,11 +801,6 @@ const MarketingPromotions = () => {
     ]
     return (
         <div className="space-y-6">
-            <div>
-                <h2 className="text-2xl font-display font-bold">Marketing &amp; Promotions</h2>
-                <p className="text-surface-500">Run coupon campaigns and promote sales with a sitewide banner.</p>
-            </div>
-
             <div className="flex gap-2 border-b border-surface-200 dark:border-surface-800">
                 {tabs.map((t) => {
                     const Icon = t.icon

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -1320,10 +1320,7 @@ const EnrollmentRequests = () => {
 
     return (
         <div className="space-y-6">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="text-xl font-bold flex items-center gap-2">
-                    <GraduationCap className="w-5 h-5 text-primary-500" /> Enrollment Requests
-                </h2>
+            <div className="flex flex-wrap items-center justify-end gap-3">
                 <div className="flex gap-1 p-1 bg-surface-100 dark:bg-surface-800 rounded-lg overflow-x-auto">
                     {['pending', 'approved', 'rejected', 'all'].map((f) => (
                         <button key={f} onClick={() => setFilter(f)} className={`px-4 py-1.5 rounded-md text-sm font-semibold capitalize transition-all whitespace-nowrap ${filter === f ? 'bg-white dark:bg-surface-700 text-primary-600 shadow-sm' : 'text-surface-500'}`}>


### PR DESCRIPTION
## Problem

Three admin dashboard panels rendered their own title/subtitle on top of the shared `AdminDashboard` section header, so the heading appeared twice:

- **Enrollments** → "Enrollments" header + "Enrollment Requests" h2
- **Marketing & Promotions** → header + identical "Marketing & Promotions" h2
- **Landing Page** → header + "Home Page Builder" h2

## Fix

Removed the inner headings, keeping only the action controls (status filter tabs, sub-tabs, Preview/Save buttons) and right-aligning those rows. This matches how every other admin section (Students, Sales, Performance, Settings) renders — they rely solely on the shared page header.

## Testing

- `npm run build` passes
- Verified no now-unused imports