### PR TITLE
fix(admin): AI Course Studio button navigated to the home page

### DIFF
--- a/frontend/exam-frontend/src/components/admin/CourseBuilder.jsx
+++ b/frontend/exam-frontend/src/components/admin/CourseBuilder.jsx
@@ -124,7 +124,7 @@ const CourseBuilder = () => {
                     {aiReady && (
                         <button
                             type="button"
-                            onClick={() => navigate('/admin?tab=ai-studio')}
+                            onClick={() => navigate('/admin-dashboard?tab=ai-studio')}
                             title="Draft a course with AI — you review everything before it is saved"
                             className="flex items-center gap-1.5 whitespace-nowrap rounded-xl border border-primary-200 bg-primary-50 px-3.5 py-2.5 text-sm font-medium text-primary-700 transition-colors hover:bg-primary-100 dark:border-primary-800/50 dark:bg-primary-900/20 dark:text-primary-300 dark:hover:bg-primary-900/30"
                         >

--- a/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
+++ b/frontend/exam-frontend/src/components/layout/AdminSidebar.jsx
@@ -18,6 +18,7 @@ import {
   Megaphone,
   Bell,
   Sparkles,
+  Wand2,
 } from 'lucide-react'
 
 // Admin navigation sections. `tab` items drive the in-page section shown by
@@ -31,6 +32,7 @@ export const ADMIN_NAV_ITEMS = [
   { tab: 'announcements', label: 'Announcements', icon: Bell },
   { tab: 'performance', label: 'Reports', icon: BarChart3 },
   { tab: 'content', label: 'Course Builder', icon: Library },
+  { tab: 'ai-studio', label: 'AI Course Studio', icon: Wand2 },
   { tab: 'landing', label: 'Landing Page', icon: LayoutTemplate },
   { path: '/admin/mock-tests', label: 'Mock Tests', icon: ClipboardList },
   { path: '/admin/jobs', label: 'Jobs', icon: Briefcase },


### PR DESCRIPTION
Follow-up to #176, which was squash-merged before this fix landed on the branch.

## The bug you hit

Clicking **Generate with AI** in the Course Builder sent you to the home page. The button navigated to `/admin?tab=ai-studio`, but the dashboard route is `/admin-dashboard` — React Router matched nothing and fell through.

## A second bug found while fixing it

The studio was also missing from `ADMIN_NAV_ITEMS`, so it never appeared in the sidebar.

The cause is that admin navigation lives in two places that have to be kept in sync: `AdminDashboard.jsx` owns a `TABS` array for headings and rendering, while `AdminSidebar.jsx` owns a separate `ADMIN_NAV_ITEMS` array for the menu. #176 only updated the first, so the tab rendered correctly but was reachable only by typing the URL by hand.

## Changes

- Point the Course Builder button at `/admin-dashboard?tab=ai-studio`
- Add **AI Course Studio** to `ADMIN_NAV_ITEMS`, directly under Course Builder

Verified `npm run build` is clean, and all three wiring points (sidebar entry, dashboard tab, render switch) now agree on the `ai-studio` id.