### PR TITLE
Document labs, the async workers, and deploying a new service

### DIFF
--- a/.github/skills/deploy-backend/SKILL.md
+++ b/.github/skills/deploy-backend/SKILL.md
@@ -76,6 +76,15 @@ Decision guide:
 - **Backend code only, no migrations, no dep changes** → pull + restart (steps 2, 5, 6).
 - **New migration files** → pull + migrate the affected app(s) + restart (steps 2, 3, 5, 6).
 - **`requirements.txt` (or other dependency) changes** → pull + **rebuild image** + migrate if needed + restart (steps 2, 4, 3, 6).
+- **New service in `docker-compose.yml`** → also do step 4b **before** restarting.
+  A plain restart only restarts what is already running, so a new worker or
+  sandbox silently never starts.
+
+Check for new services explicitly — it is the easiest thing to miss:
+
+```bash
+git --no-pager diff <VM_HEAD>..origin/main -- backend/docker-compose.yml
+```
 
 ## 2. Pull the latest code on the VM
 
@@ -117,6 +126,45 @@ dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose build web && sudo docker c
 
 (When you rebuild + `up -d`, you do not also need the restart in step 5.)
 
+## 4b. New Compose services (only if the release adds one)
+
+If `docker-compose.yml` gained a service, it needs new env keys, an image, and
+an explicit start. Nothing warns you if you skip this — the API stays healthy
+while jobs on the new worker's queue never run.
+
+```bash
+# i. Append any missing env keys (back up first, never overwrite existing values):
+dt_ssh "cd $DT_APP_DIR/backend && cp .env .env.bak.\$(date +%Y%m%d%H%M%S) && \
+  for kv in KEY_ONE=value KEY_TWO=value; do k=\${kv%%=*}; \
+  grep -q \"^\$k=\" .env || printf '%s\n' \"\$kv\" >> .env; done"
+
+# ii. Build the new images (a new sandbox is a new image; new Celery workers
+#     reuse the web image but must still be built so they exist locally):
+dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose build <new-services>"
+
+# iii. Start them, then recreate web so it picks up the new env:
+dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose up -d <new-services> && \
+  sudo docker compose up -d web"
+```
+
+Cross-check the new keys against the *other* environment's `.env` — pre-prod is
+the reference for what prod is missing:
+
+```bash
+dt_ssh "cd $DT_APP_DIR/backend && grep -E '^(NEW_PREFIX_)' .env"
+```
+
+Then verify the services are doing their job, not merely running:
+
+```bash
+# A new Celery worker logs its queue and task list on boot:
+dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose logs <worker> | grep -A5 'queues'"
+
+# A new internal sandbox must be reachable from web (and must NOT be exposed):
+dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose exec -T web python -c \
+  \"import urllib.request;print(urllib.request.urlopen('http://<svc>:<port>/health',timeout=5).status)\""
+```
+
 ## 5. Restart the web container
 
 For code-only or migration deploys (no image rebuild):
@@ -128,8 +176,11 @@ dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose restart web"
 ## 6. Verify the deploy
 
 ```bash
-# Container is up:
+# Containers are up:
 dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose ps web"
+
+# Every service is up — not just web (catches a worker that failed to start):
+dt_ssh "cd $DT_APP_DIR/backend && sudo docker compose ps --format '{{.Service}}\t{{.State}}'"
 
 # API is serving (expect 200):
 curl -s -o /dev/null -w '%{http_code}\n' "$DT_API_URL/api/docs/"
@@ -169,13 +220,21 @@ Keep such scripts idempotent so they are safe to re-run.
   step 3's `showmigrations` check.
 - **Feature still missing after a green deploy** → confirm the PR actually
   merged to `main` and the VM's HEAD matches `origin/main` (step 1).
+- **Background jobs stuck at `queued` forever, no error** → the worker for that
+  queue isn't running. `docker compose ps` and check every service, not just
+  `web`. Common after a release that added a worker (step 4b).
+- **`[ERROR] Control server error: [Errno 13] Permission denied: '/nonexistent'`**
+  in the `web` logs → harmless gunicorn noise; not a deploy failure.
 
 ## Notes / conventions
 
+- **Current stack** (both environments): `web`, `nginx`, `redis`, `db`,
+  `celery-worker` (default queue), `celery-nbworker` (`notebooks` queue),
+  `celery-aiworker` (`aigen` queue), `piston` and `nbrunner` (sandboxes).
+- **Sandboxes never publish ports.** `piston` and `nbrunner` are reachable only
+  on the internal Docker network. Never add a `ports:` mapping to either.
 - **Local machine has no Django/Postgres access.** Validate code locally only
   with `python3 -m py_compile <file>`; run `check` / `migrate` on the VM.
 - **Frontend & landing page deploy via Netlify automatically on merge** — no VM
   action needed for those.
-- The Compose services on the VM are typically: `web`, a `db`/`nginx` proxy,
-  `piston` (code execution), plus any others defined in `docker-compose.yml`.
 - Never commit the SSH key, its path, host IPs, or tenant IDs to the repo.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -10,6 +10,7 @@ Welcome to the DailyTaiyari developer documentation. This wiki covers the platfo
 | [Tenant Setup Guide](./tenant-setup.md) | How to create and configure tenants |
 | [Backend Guide](./backend-guide.md) | Models, middleware, ViewSets, and services |
 | [Frontend Guide](./frontend-guide.md) | Tenant integration, API layer, and branding |
+| [Labs (Python Notebooks)](./notebooks-labs.md) | Gradeable notebooks: Pyodide kernel, sandboxed grading, AI generation |
 | [API Reference](./api-reference.md) | All API endpoints with request/response examples |
 | [Environment Variables](./environment-variables.md) | All configurable env vars for backend & frontend |
 | [Data Migration Guide](./data-migration.md) | How to migrate data between tenants or backfill |
@@ -32,3 +33,4 @@ npm run dev
 - **Tenant**: An isolated organizational unit (e.g., a coaching institute). Each tenant has its own students, quizzes, content, and analytics.
 - **X-Tenant-ID**: A required HTTP header on all API requests that identifies which tenant the request belongs to.
 - **VITE_TENANT_ID**: Frontend environment variable that controls which tenant the deployed frontend instance serves.
+- **Lab**: The student-facing name for a gradeable Python notebook. The code, models and API paths still say `notebook` — see [Labs](./notebooks-labs.md).

--- a/wiki/api-reference.md
+++ b/wiki/api-reference.md
@@ -206,6 +206,74 @@ All exam endpoints are **read-only** and tenant-filtered.
 
 ---
 
+## Lab (Notebook) Endpoints
+
+Gradeable Python notebooks. Surfaced to users as **"Labs"**; the API path stays
+`notebooks`. Full details in [notebooks-labs.md](./notebooks-labs.md).
+
+### Student
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/api/v1/notebooks/` | Labs across the student's enrolled courses |
+| GET | `/api/v1/notebooks/<id>/` | Lab detail + attempt state + best result |
+| GET/PUT/DELETE | `/api/v1/notebooks/<id>/draft/` | Autosaved work-in-progress |
+| POST | `/api/v1/notebooks/<id>/submit/` | Submit for grading |
+| GET | `/api/v1/notebooks/<id>/submissions/<sub_id>/` | Poll submission status |
+| GET | `/api/v1/notebooks/<id>/my-submissions/` | Attempt history |
+
+Submission is **asynchronous by default**: `submit/` returns a submission with
+`status: "queued"` and the client polls the status endpoint until it reads
+`graded` (or `failed`).
+
+```json
+{
+  "id": "…",
+  "status": "graded",
+  "attempt_number": 2,
+  "passed_count": 4,
+  "total_count": 5,
+  "passed_points": 8,
+  "total_points": 10,
+  "marks": "16.00",
+  "is_late": false,
+  "results": [
+    { "name": "returns the sum", "passed": true, "points": 2 },
+    { "name": "handles negatives", "passed": false, "points": 2,
+      "failure_hint": "Check the sign handling" }
+  ]
+}
+```
+
+Lab detail includes the attempt policy so the client never reimplements it:
+`can_submit`, `allow_resubmission`, `max_attempts`, `attempts_used`,
+`attempts_remaining`, `is_past_due`, `hidden_test_count`, `my_best`,
+`is_complete`.
+
+### Author / admin
+
+| Method | Endpoint | Description |
+|---|---|---|
+| — | `/api/v1/notebooks/admin/notebooks/` | Lab CRUD (incl. tests) |
+| — | `/api/v1/notebooks/admin/datasets/` | Dataset management |
+| — | `/api/v1/notebooks/admin/submissions/` | Review, override marks, feedback |
+| GET | `/api/v1/notebooks/meta/` | Available packages, limits, defaults |
+
+### AI lab generation
+
+Always a background job — poll it, then `apply/` to write a real lab.
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET/POST | `/api/v1/notebooks/admin/generate/jobs/` | List / start a job |
+| GET | `/api/v1/notebooks/admin/generate/jobs/<id>/` | Poll status + draft |
+| POST | `/api/v1/notebooks/admin/generate/jobs/<id>/refine/` | Modify the draft |
+| POST | `/api/v1/notebooks/admin/generate/jobs/<id>/regenerate/` | Retry |
+| POST | `/api/v1/notebooks/admin/generate/jobs/<id>/apply/` | Persist as a lab |
+| POST | `/api/v1/notebooks/admin/generate/jobs/<id>/discard/` | Discard the draft |
+
+---
+
 ## Error Responses
 
 ### 403 — Tenant Required

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -120,6 +120,8 @@ Tenant (core.models.Tenant)
 ├── Badge, StudentBadge, XPTransaction — via TimeStampedModel
 ├── Post, Comment, Like — via TimeStampedModel
 ├── ChatSession, ChatMessage, AIQuizAttempt — via TimeStampedModel
+├── Notebook, NotebookTest, NotebookDataset — via TimeStampedModel
+│   └── NotebookDraft, NotebookSubmission, NotebookCompletion
 └── ... (all models inherit tenant from TimeStampedModel)
 ```
 
@@ -127,3 +129,24 @@ The `TimeStampedModel` base class includes:
 - `id` (UUID, primary key)
 - `tenant` (FK to Tenant, nullable for backward compatibility)
 - `created_at`, `updated_at` (auto timestamps)
+
+---
+
+## Async Processing
+
+Long-running work runs on Celery rather than in the request thread, with
+**queue-per-workload** so a slow job can't block a fast one:
+
+```
+                    ┌─ default   ─► celery-worker     (email, code judging)
+Django (web) ─ redis ├─ notebooks ─► celery-nbworker   ─► nbrunner  (lab grading)
+                    └─ aigen     ─► celery-aiworker   (LLM authoring jobs)
+```
+
+Untrusted student code never runs in `web`. It runs in one of two sandboxes —
+`piston` for coding questions, `nbrunner` for labs — neither of which publishes
+ports, holds credentials, or has database access.
+
+Each async path falls back to inline execution if the broker is unreachable, so
+a Redis outage degrades latency rather than breaking the feature. See
+[Labs](./notebooks-labs.md) for the full pipeline.

--- a/wiki/backend-guide.md
+++ b/wiki/backend-guide.md
@@ -17,6 +17,9 @@ backend/
 ├── gamification/          # Badges, XP, leaderboard, challenges
 ├── community/             # Posts, comments, polls, community quizzes
 ├── chatbot/               # AI chat sessions, FAQ, AI quizzes
+├── coursegen/             # AI course/content authoring (async, `aigen` queue)
+├── notebooks/             # Labs — gradeable Python notebooks + AI lab generator
+├── deploy/nbrunner/       # Sandboxed notebook execution service (no app code)
 └── dailytaiyari/          # Django project settings & URLs
 ```
 
@@ -223,6 +226,17 @@ Below is every app and which ViewSets are tenant-aware:
 | `SavedResponseViewSet` | `TenantAwareViewSet` | |
 | `FrequentQuestionViewSet` | `TenantAwareReadOnlyViewSet` | |
 | `AIQuizAttemptViewSet` | `TenantAwareViewSet` | |
+
+### `notebooks`
+| ViewSet | Base Class | Notes |
+|---|---|---|
+| `NotebookViewSet` | `ReadOnlyModelViewSet` | Student-facing. Scoped to the student's **enrolled courses**, not just the tenant. Adds `draft/`, `submit/`, `my-submissions/` actions |
+| `AdminNotebookViewSet` | `TenantAwareViewSet` | Lab authoring, incl. nested tests |
+| `AdminNotebookDatasetViewSet` | `TenantAwareViewSet` | Dataset uploads |
+| `AdminNotebookSubmissionViewSet` | `TenantAwareViewSet` | Submission review + mark override |
+
+See [notebooks-labs.md](./notebooks-labs.md) for the grading pipeline and the
+sandbox's security properties.
 
 ---
 

--- a/wiki/deployment.md
+++ b/wiki/deployment.md
@@ -35,13 +35,26 @@ Each VM runs the same Docker Compose stack:
 | `nginx`        | TLS termination + reverse proxy                 |
 | `redis`        | Celery broker / cache                           |
 | `celery-worker`| Async tasks (email, async code judging, etc.)   |
+| `celery-nbworker` | Notebook/lab grading (`notebooks` queue)     |
+| `celery-aiworker` | AI authoring — course + lab generation (`aigen` queue) |
 | `piston`       | Sandboxed code execution engine                 |
+| `nbrunner`     | Sandboxed notebook/lab execution engine         |
+
+The three Celery workers are split by queue so a multi-minute LLM call or a
+notebook that trains a model can't head-of-line block a quick coding
+submission. See [Labs](./notebooks-labs.md) for the split and its rationale.
+
+> **If `celery-aiworker` isn't running**, AI generation jobs are enqueued and
+> then silently never execute — they sit at `queued` with no error. Check all
+> workers are up after any deploy.
 
 - **Database:** managed **Azure PostgreSQL Flexible Server** (SSL required). The
   `db` service in `docker-compose.yml` is unused in cloud deploys.
 - **Media:** **Azure Blob Storage**, served as public blob URLs.
 - **TLS:** Let's Encrypt certs per hostname, auto-renewed via a certbot deploy
   hook that reloads nginx.
+- **Sandboxes:** neither `piston` nor `nbrunner` publishes ports — they are
+  reachable only on the internal Docker network. Never add a `ports:` mapping.
 
 ## Configuration
 
@@ -91,6 +104,39 @@ Deploy **pre-prod from `main`** first; deploy **prod from `production`** only
 after promotion (see branching doc). The canonical, secret-aware runbook lives
 in the `deploy-backend` skill under `.github/skills/`.
 
+## Deploying a release that adds a service
+
+A `restart` only restarts what is already running, so a release that introduces
+a **new Compose service** needs extra steps — and missing them fails *silently*
+(the API is healthy, but jobs on the new worker's queue never run). The labs
+release added `nbrunner`, `celery-nbworker` and `celery-aiworker`; use it as the
+template.
+
+```bash
+# 1. New env keys first — check against docker-compose.yml and the env doc.
+#    Back up before editing, and only append keys that are missing.
+cp .env .env.bak.$(date +%Y%m%d%H%M%S)
+
+# 2. Build the new images (a new sandbox is a new image; workers usually
+#    reuse the web image but must still be built to exist locally).
+docker compose build <new-services>
+
+# 3. Migrations for any new app.
+docker compose exec -T web python manage.py migrate <app>
+
+# 4. Start the new services, then recreate web so it picks up new env.
+docker compose up -d <new-services>
+docker compose up -d web
+
+# 5. Verify every service is up — not just web.
+docker compose ps
+```
+
+Then confirm the new services are actually *doing* their job: check a worker
+logged the queue and tasks you expect, and that `web` can reach a new sandbox
+over the internal network. The labs checklist is in
+[notebooks-labs.md](./notebooks-labs.md#operating-notes).
+
 ## Verify a deploy
 
 ```bash
@@ -100,12 +146,22 @@ curl -s -o /dev/null -w '%{http_code}\n' https://<hostname>/api/docs/
 # Containers healthy
 docker compose ps
 
+# All three Celery workers consuming their queues
+docker compose logs celery-worker celery-nbworker celery-aiworker | grep -A4 'queues'
+
 # Recent logs if anything is off
 docker compose logs web --tail=50
 ```
 
 For prod, `<hostname>` is `api-prod.dailytaiyari.in`; for pre-prod,
 `api.dailytaiyari.in`.
+
+> A bare `curl` of a tenant-scoped endpoint returns
+> `{"error": "X-Tenant-ID header is required."}` — that means the API is **up**,
+> not broken.
+>
+> `[ERROR] Control server error: [Errno 13] Permission denied: '/nonexistent'`
+> in the `web` logs is harmless gunicorn noise, not a deploy failure.
 
 ## TLS certificates
 

--- a/wiki/environment-variables.md
+++ b/wiki/environment-variables.md
@@ -20,6 +20,39 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 OPENAI_API_KEY=sk-...
 ```
 
+### Async workers — `backend/.env`
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `CELERY_BROKER_URL` | No | `redis://redis:6379/0` | Celery broker |
+| `CELERY_RESULT_BACKEND` | No | `redis://redis:6379/1` | Celery result backend |
+| `CELERY_NB_CONCURRENCY` | No | `1` | Workers on the `notebooks` queue. Notebook grading is CPU-bound — keep low |
+| `CELERY_AI_CONCURRENCY` | No | `4` | Workers on the `aigen` queue. LLM calls are I/O-bound — higher is fine |
+| `CODE_JUDGE_ASYNC` | No | `False` | Grade coding submissions off the request thread |
+| `COURSEGEN_ASYNC` | No | `True` | Run AI course generation on the `aigen` queue |
+
+### Labs / notebooks — `backend/.env`
+
+See [notebooks-labs.md](./notebooks-labs.md) for what these control.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NOTEBOOKS_ENABLED` | No | `True` | Master switch for the labs feature |
+| `NOTEBOOKS_SERVER_GRADING` | No | `False` | Re-execute submissions in `nbrunner` for the authoritative grade. **Set `True` in any real deployment** — `False` trusts the browser's score |
+| `NOTEBOOKS_JUDGE_ASYNC` | No | `True` | Grade on the `notebooks` queue instead of in-request. Falls back to inline if the broker is down |
+| `NOTEBOOKS_GEN_ASYNC` | No | `True` | Run AI lab generation on the `aigen` queue |
+| `NBRUNNER_URL` | No | `http://nbrunner:2100` | Internal address of the sandbox. Must stay internal-only |
+
+**Deployed values (both pre-prod and prod):**
+```bash
+NOTEBOOKS_ENABLED=True
+NOTEBOOKS_SERVER_GRADING=True
+NOTEBOOKS_JUDGE_ASYNC=True
+NBRUNNER_URL=http://nbrunner:2100
+CELERY_NB_CONCURRENCY=1
+CELERY_AI_CONCURRENCY=4
+```
+
 ### CORS Headers
 
 The following custom headers are allowed through CORS (configured in `settings.py`):

--- a/wiki/frontend-guide.md
+++ b/wiki/frontend-guide.md
@@ -21,6 +21,9 @@ The frontend identifies itself to a specific tenant via the `VITE_TENANT_ID` env
 | `src/components/layout/AuthLayout.jsx` | Desktop tenant branding (login/register) |
 | `src/pages/auth/Login.jsx` | Mobile tenant branding + login form |
 | `src/pages/auth/Register.jsx` | Mobile tenant branding + register form |
+| `src/pages/NotebookPage.jsx` | Student lab surface (see [Labs](./notebooks-labs.md)) |
+| `src/hooks/usePyodideKernel.js` | In-browser Python kernel state machine |
+| `src/workers/pyodideKernel.worker.js` | Pyodide Web Worker |
 
 ---
 

--- a/wiki/notebooks-labs.md
+++ b/wiki/notebooks-labs.md
@@ -1,0 +1,297 @@
+# Labs (Python Notebooks)
+
+Labs are gradeable Python notebooks. A student writes and runs code in the
+browser, submits once, and the server re-executes the notebook against a set of
+tests to produce the authoritative grade.
+
+> **Naming:** the feature is called **"Lab" / "Labs"** everywhere a student or
+> admin can see it. Everything in the code — the Django app, the models, the API
+> paths (`/api/v1/notebooks/`), the React route (`/notebooks/:id`) and the query
+> keys — is still named `notebook`. This is a **label-only** distinction, chosen
+> because an **Assignments** content type already exists (file/text submissions)
+> and "Programming Assignment" would have collided with it. Don't rename the
+> code to match the label.
+
+## Why it is built this way
+
+Interactive execution runs **client-side in Pyodide** (CPython compiled to
+WebAssembly). Every keystroke-to-output loop therefore costs zero server compute
+— which is what makes labs affordable to run for a whole cohort at once.
+
+But a browser is fully under the student's control, so a browser-computed score
+is worthless as a grade. On submit, the notebook is re-executed **server-side**
+in the sandboxed `nbrunner` container and *that* result is the real grade. The
+browser's score is kept alongside it as a *provisional* score, so a student sees
+an instant number while the authoritative one is computed.
+
+```
+Browser (Pyodide)                Django (web)              Worker + sandbox
+─────────────────                ────────────              ────────────────
+run cells interactively   ─┐
+compute provisional score  ├─ POST submit ─► NotebookSubmission
+                          ─┘                  status=queued
+                                                  │
+                                       enqueue ► `notebooks` queue
+                                                  │
+                                       celery-nbworker ─► nbrunner (HTTP)
+                                                  │        re-executes notebook
+                                                  ▼        + runs tests
+client polls submission_status ◄── status=graded, results[], marks
+```
+
+## Backend
+
+The `notebooks` Django app owns the whole feature.
+
+```
+backend/notebooks/
+├── models.py            # Notebook, NotebookTest, NotebookDataset, NotebookDraft,
+│                        # NotebookSubmission, NotebookCompletion, NotebookGenerationJob
+├── views.py             # Student-facing NotebookViewSet
+├── admin_views.py       # Author/admin CRUD + submission review
+├── grading.py           # Talks to nbrunner, scores a submission
+├── services.py          # Completion / best-attempt bookkeeping
+├── nbformat_utils.py    # .ipynb <-> internal document shape
+├── tasks.py             # Celery tasks (grading + AI generation)
+└── aigen/               # AI lab generator (prompt -> draft notebook)
+```
+
+### Models
+
+| Model | Purpose |
+|---|---|
+| `Notebook` | The lab itself: template cells, packages, limits, marks, due date, attempt policy |
+| `NotebookTest` | One graded check. Has `points`, `is_hidden`, an optional `failure_hint` |
+| `NotebookDataset` | A file uploaded alongside the lab and mounted for the student's code |
+| `NotebookDraft` | A student's in-progress work, autosaved. One per student per lab |
+| `NotebookSubmission` | One graded attempt: results, points, marks, provisional score, late flag |
+| `NotebookCompletion` | Per-student rollup — best submission, best marks, attempts used, `is_complete` |
+| `NotebookGenerationJob` | An async AI generation/refine job and its produced draft |
+
+All of them are tenant-scoped through the usual `TimeStampedModel` /
+`OrderedModel` bases — see [architecture.md](./architecture.md).
+
+Attempt policy lives on `Notebook`: `allow_resubmission`, `max_attempts`,
+`is_timed` + `due_at`. The student API derives `can_submit`, `attempts_used` and
+`attempts_remaining` from those so the client never has to reimplement the rule.
+
+### Grading modes
+
+`NOTEBOOKS_SERVER_GRADING` decides where the real grade comes from:
+
+- **`True` (both deployed environments)** — the submission is re-executed in
+  `nbrunner` and scored there. Authoritative.
+- **`False`** — the browser's provisional score is recorded as-is. Useful for
+  local dev, or an environment that hasn't started the runner yet.
+
+`NOTEBOOKS_JUDGE_ASYNC` decides *when*: when `True` grading is enqueued on the
+`notebooks` queue and the client polls; when `False` it runs inline in the
+request. Async falls back to inline automatically if the broker is unreachable,
+so a Redis outage degrades latency rather than breaking submission.
+
+### The `nbrunner` sandbox
+
+`backend/deploy/nbrunner/` is a small HTTP service that executes untrusted
+student notebooks. It is deliberately minimal: **no app code, no credentials, no
+database access**.
+
+- Never gets a `ports:` mapping — reachable only on the internal Docker network
+  at `http://nbrunner:2100`.
+- Runs as non-root, `read_only`, `cap_drop: ALL`, `no-new-privileges`.
+- Each request executes in a **fresh forked subprocess** with `RLIMIT_AS` /
+  `RLIMIT_CPU` / `RLIMIT_FSIZE` caps and a hard wall-clock kill.
+- Unlike `piston` it does **not** need privileged mode.
+
+If you change anything here, keep those properties. The threat model is "the
+student is hostile and controls the code being run."
+
+### Queues and workers
+
+Three Celery workers, split so that a slow job can never head-of-line block a
+fast one:
+
+| Worker | Queue | Carries |
+|---|---|---|
+| `celery-worker` | default | email, async code judging, misc |
+| `celery-nbworker` | `notebooks` | `notebooks.grade_submission` — can re-run a notebook that trains a model |
+| `celery-aiworker` | `aigen` | `notebooks.generate` + `coursegen.generate` — multi-minute LLM calls |
+
+`celery-aiworker` runs higher concurrency (`CELERY_AI_CONCURRENCY`, default 4)
+because AI generation is I/O-bound and several authors may generate at once.
+`celery-nbworker` stays at 1 by default since notebook execution is CPU-bound.
+
+> **Deploy gotcha:** if `celery-aiworker` isn't running, `notebooks.generate`
+> and `coursegen.generate` are enqueued and then silently never execute — jobs
+> sit at `queued` forever with no error. Always confirm all three workers are up
+> after a deploy.
+
+## API
+
+Base path `/api/v1/notebooks/`. All routes require the usual `X-Tenant-ID`
+header and JWT auth.
+
+### Student
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/v1/notebooks/` | Labs for the student's enrolled courses (filterable by topic) |
+| `GET` | `/api/v1/notebooks/<id>/` | One lab, plus attempt state and best result |
+| `GET`/`PUT`/`DELETE` | `/api/v1/notebooks/<id>/draft/` | Autosaved work-in-progress |
+| `POST` | `/api/v1/notebooks/<id>/submit/` | Submit for grading. Returns a submission (often `queued`) |
+| `GET` | `/api/v1/notebooks/<id>/submissions/<sub_id>/` | Poll a submission's status/result |
+| `GET` | `/api/v1/notebooks/<id>/my-submissions/` | Attempt history |
+
+A lab detail response carries the fields the UI needs to explain the policy
+without extra calls: `can_submit`, `allow_resubmission`, `max_attempts`,
+`attempts_used`, `attempts_remaining`, `is_past_due`, `hidden_test_count`,
+`my_best`, `is_complete`.
+
+### Author / admin
+
+| Method | Path | Purpose |
+|---|---|---|
+| — | `/api/v1/notebooks/admin/notebooks/` | Lab CRUD (incl. nested tests) |
+| — | `/api/v1/notebooks/admin/datasets/` | Dataset upload/management |
+| — | `/api/v1/notebooks/admin/submissions/` | Review, override marks, leave feedback |
+| `GET` | `/api/v1/notebooks/meta/` | Available packages, limits, defaults |
+
+### AI lab generator
+
+Generation is **always** a background job — the client creates a job and polls
+it. A real `Notebook` row is only written on `apply/`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `.../admin/generate/options/` | Supported models/params |
+| `GET`/`POST` | `.../admin/generate/jobs/` | List / start a job |
+| `GET` | `.../admin/generate/jobs/<id>/` | Poll status + draft |
+| `POST` | `.../admin/generate/jobs/<id>/refine/` | Modify the draft with an instruction |
+| `POST` | `.../admin/generate/jobs/<id>/regenerate/` | Retry a failed or unwanted generation |
+| `POST` | `.../admin/generate/jobs/<id>/apply/` | Persist the draft as a real lab |
+| `POST` | `.../admin/generate/jobs/<id>/discard/` | Throw the draft away |
+
+Because a job outlives the modal that started it, the topic studio surfaces
+in-flight jobs in the topic's own tabs with a "generating" status — closing the
+dialog never loses the work.
+
+## Frontend
+
+```
+frontend/exam-frontend/src/
+├── workers/pyodideKernel.worker.js   # Pyodide in a Web Worker
+├── hooks/usePyodideKernel.js         # Kernel state machine (boot/exec/restart)
+├── components/notebook/
+│   ├── NotebookEditor.jsx            # Cell list, run-all, per-cell run status
+│   ├── NotebookCell.jsx              # One cell + run-status chip
+│   ├── CellOutput.jsx                # Rendered stdout/plots/errors
+│   ├── LabStatusCard.jsx             # Top-of-page grade + submit affordance
+│   ├── LabSubmitFlow.jsx             # Confirm -> running -> result modal
+│   ├── NotebookAIGenerator.jsx       # Author-side generation UI
+│   └── notebookDoc.js                # Document shape helpers
+└── pages/NotebookPage.jsx            # The student lab surface
+```
+
+### Kernel
+
+The kernel runs in a **Web Worker** so a long-running cell never freezes the UI.
+`usePyodideKernel.js` owns an explicit state machine.
+
+> **Do not infer "busy" from the pending-message map.** That was the original
+> design and it caused a class of bugs where the kernel wedged permanently on
+> "Running": the worker's `init` reply didn't echo the message `id`, so one
+> entry never cleared and the kernel could never return to READY. Busy state is
+> now tracked by an explicit in-flight execution count plus a state variable.
+> Every worker reply must echo `msg.id`.
+
+Package loading memoises failures. `pyodide.loadPackage(batch)` fails the
+**entire batch** if one name can't be resolved, so without memoisation a single
+bad package name forced the slow per-package + micropip fallback on every
+message — which is what made every run look like it was "Loading pandas…".
+
+First boot legitimately downloads tens of MB from the jsDelivr CDN. A kernel
+restart discards `loadedPackages` and re-downloads; that is inherent to
+terminating the worker, not a bug.
+
+### Submit flow
+
+Submitting grades the **whole lab against every test, including hidden ones**,
+so it is a deliberate action rather than a stray click:
+
+1. `LabStatusCard` sits at the top of the page with the current grade, attempt
+   number and resubmission policy. It is the primary submit affordance.
+2. Clicking Submit opens `LabSubmitFlow` — a confirm step that states what will
+   be graded and whether resubmission is allowed, then a running step, then the
+   per-test result.
+3. When no attempts remain or the due date has passed, the button is disabled
+   **with the reason stated**, and reads "Resubmit" once an attempt exists.
+
+## Progress and completion
+
+Labs count toward progress like any other content type. Five aggregates include
+them, and **all five must stay in sync** — if you add a content type, grep for
+these:
+
+| Where | Why it matters |
+|---|---|
+| `exams/views.py` → `_chapter_completion_counts` | Drives **sequential chapter unlock**. Omitting labs means a lab can never gate the next chapter |
+| `exams/views.py` → `StudySubjectsView` | Subject progress bars |
+| `exams/views.py` → `StudyChaptersView` | Chapter progress bars |
+| `exams/views.py` → `_course_leaderboard` | Leaderboard denominator |
+| `exams/serializers.py` → `chapter_content_type_counts` | Pre-enrollment curriculum preview |
+
+> **Payload shape trap.** The chapter-detail endpoint returns a per-topic `labs`
+> array using **`is_completed`**, while `notebookService.getByTopic` returns
+> objects using **`is_complete`** plus `my_best`. Two different shapes for the
+> same concept — `StudyCourse.jsx` uses the former, `StudyTopicContent.jsx` the
+> latter. Check which one you're holding.
+
+> **Rollout note.** Adding labs to these denominators makes existing students'
+> completion percentages **drop** wherever labs exist. That is correct, not a
+> regression, but it is user-visible — mention it when promoting to an
+> environment that already has labs authored.
+
+## Configuration
+
+See [environment-variables.md](./environment-variables.md) for the table. In
+short: `NOTEBOOKS_ENABLED`, `NOTEBOOKS_SERVER_GRADING`, `NOTEBOOKS_JUDGE_ASYNC`,
+`NOTEBOOKS_GEN_ASYNC`, `NBRUNNER_URL`, `CELERY_NB_CONCURRENCY`,
+`CELERY_AI_CONCURRENCY`.
+
+## Operating notes
+
+Deploying labs into an environment for the first time needs more than a
+`restart` — see [deployment.md](./deployment.md#deploying-a-release-that-adds-a-service).
+Checklist:
+
+```bash
+# 1. env vars present
+grep -E '^(NOTEBOOKS_|NBRUNNER_URL|CELERY_NB_|CELERY_AI_)' backend/.env
+
+# 2. images built (nbrunner is a new image; the workers reuse the web image)
+docker compose build nbrunner celery-nbworker celery-aiworker
+
+# 3. migrations
+docker compose exec -T web python manage.py migrate notebooks
+
+# 4. services up
+docker compose up -d nbrunner celery-nbworker celery-aiworker
+
+# 5. verify: nbrunner healthy and reachable from web
+docker compose ps
+docker compose exec -T web python -c \
+  "import urllib.request;print(urllib.request.urlopen('http://nbrunner:2100/health',timeout=5).status)"
+
+# 6. verify: both notebook tasks registered on the workers
+docker compose logs celery-nbworker celery-aiworker | grep 'notebooks\.'
+```
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Generation stuck at `queued` forever | `celery-aiworker` not running |
+| Submission stuck at `queued` | `celery-nbworker` not running, or `nbrunner` unhealthy |
+| Grades match the browser exactly, always | `NOTEBOOKS_SERVER_GRADING=False` |
+| Every cell run says "Loading pandas…" | A package name in `Notebook.packages` can't be resolved |
+| Kernel stuck on "Running" | A worker reply isn't echoing `msg.id` |
+| Labs missing from progress totals | One of the five aggregates above wasn't updated |


### PR DESCRIPTION
## Why

The labs (Python notebooks) feature is now live on **both** pre-prod and production, but nothing about it was written down. That left a few sharp edges undocumented:

- Grading is only trustworthy when it re-runs **server-side** — a browser-computed score is under the student's control. Nothing said so.
- `nbrunner` runs untrusted student code and must never publish ports. Nothing said so.
- If `celery-aiworker` isn't running, AI generation jobs are enqueued and then **silently never execute** — the API stays green while every job sits at `queued` forever. This is the expensive kind of missing knowledge, and it's exactly what a plain `docker compose restart` causes on a release that adds a service.

## What this adds

**New: `wiki/notebooks-labs.md`** — the feature doc. Covers the Pyodide-in-the-browser / sandboxed-server-grade split and *why* it's built that way, the seven models, the student + admin + AI-generation APIs, the queue/worker topology, the kernel, the submit flow, and an ops checklist with a troubleshooting table.

It also records the traps we actually hit while building it, so they aren't rediscovered the hard way:

- The kernel wedged permanently on "Running" because a worker reply didn't echo its message `id`. Busy state must **not** be inferred from the pending-message map.
- `pyodide.loadPackage(batch)` fails the *whole batch* on one unresolvable name — which is why every run appeared to reload pandas.
- Lab completion comes back in **two different payload shapes** (`is_complete` vs `is_completed`) depending on the endpoint.
- **Five** separate aggregates must include a content type or progress silently under-counts — including `_chapter_completion_counts`, which drives sequential chapter unlock.

**Updated: `deploy-backend` skill** — adds a "new Compose service" branch to the decision guide and a step 4b covering env keys, building, starting, and *verifying* new services (worker logged its queue; sandbox reachable from `web`). Also documents the stuck-at-`queued` symptom and the harmless gunicorn `/nonexistent` log noise.

**Updated: the rest of the wiki** — `deployment.md` (all 9 services, new-service procedure), `architecture.md` (async processing topology), `environment-variables.md` (worker + labs vars with deployed values), `api-reference.md` (lab endpoints), `backend-guide.md`, `frontend-guide.md`, `README.md` (TOC + the Lab terminology note).

## Terminology

The feature is **"Lab"** in every user-visible string; the code, models, API paths and routes stay `notebook`. "Programming Assignment" would have collided with the existing Assignments content type. This is called out explicitly so nobody "fixes" the mismatch by renaming the code.

## Verification

- Docs-only — no code, no schema, no runtime impact.
- All internal links and both section anchors resolve.
- Every documented default was checked against `settings.py` and `docker-compose.yml` rather than written from memory.
- Diff scanned for secrets: no hosts, keys, tenant UUIDs or credentials.