### PR TITLE
Show course completion on the student roster, and fix modal lag and late tooltips

### DIFF
--- a/backend/certificates/bulk_progress.py
+++ b/backend/certificates/bulk_progress.py
@@ -1,0 +1,168 @@
+"""Roster-wide course completion, computed in a fixed number of queries.
+
+``certificates.services.compute_course_progress`` is authoritative but costs
+~10 queries per (student, course) pair — fine for one certificate check, far
+too slow for an admin roster where every student may sit in several courses.
+
+``bulk_course_progress`` answers the same question for a whole tenant using
+grouped aggregates: four queries for the per-course denominators and four for
+the per-(student, course) numerators, regardless of roster size. The item
+definitions deliberately mirror ``compute_course_progress`` so the percentage
+an admin sees matches the one that unlocks the student's certificate.
+"""
+from collections import defaultdict
+
+from django.db.models import Count, F
+
+READING_TYPES = ['notes', 'pdf', 'revision', 'formula']
+COUNTED_CONTENT_TYPES = READING_TYPES + ['video']
+
+
+def _totals_by_course(course_ids):
+    """Published item counts per course id."""
+    from assignments.models import Assignment
+    from coding.models import CodingProblem
+    from content.models import Content
+    from quiz.models import Quiz
+
+    totals = defaultdict(int)
+
+    rows = (
+        Content.objects
+        .filter(subject__course_id__in=course_ids, status='published',
+                content_type__in=COUNTED_CONTENT_TYPES)
+        .values('subject__course_id')
+        .annotate(n=Count('id'))
+    )
+    for row in rows:
+        totals[row['subject__course_id']] += row['n']
+
+    rows = (
+        Quiz.objects
+        .filter(course_id__in=course_ids, status='published')
+        .values('course_id')
+        .annotate(n=Count('id'))
+    )
+    for row in rows:
+        totals[row['course_id']] += row['n']
+
+    # Assignments and coding problems are attributed through their topic's
+    # subject (matching compute_course_progress), not their own course FK,
+    # so an item filed under another course's topic isn't double counted.
+    rows = (
+        Assignment.objects
+        .filter(topic__subject__course_id__in=course_ids, status='published')
+        .values('topic__subject__course_id')
+        .annotate(n=Count('id'))
+    )
+    for row in rows:
+        totals[row['topic__subject__course_id']] += row['n']
+
+    rows = (
+        CodingProblem.objects
+        .filter(topic__subject__course_id__in=course_ids, status='published')
+        .values('topic__subject__course_id')
+        .annotate(n=Count('id'))
+    )
+    for row in rows:
+        totals[row['topic__subject__course_id']] += row['n']
+
+    return totals
+
+
+def _completed_by_student_course(student_ids, course_ids):
+    """Completed item counts keyed by ``(student_id, course_id)``."""
+    from assignments.models import AssignmentSubmission
+    from coding.models import CodingSubmission
+    from content.models import ContentProgress
+    from quiz.models import QuizAttempt
+
+    done = defaultdict(int)
+
+    rows = (
+        ContentProgress.objects
+        .filter(student_id__in=student_ids,
+                content__subject__course_id__in=course_ids,
+                content__status='published',
+                content__content_type__in=COUNTED_CONTENT_TYPES,
+                is_completed=True)
+        .values('student_id', 'content__subject__course_id')
+        .annotate(n=Count('content_id', distinct=True))
+    )
+    for row in rows:
+        done[(row['student_id'], row['content__subject__course_id'])] += row['n']
+
+    rows = (
+        QuizAttempt.objects
+        .filter(student_id__in=student_ids, quiz__course_id__in=course_ids,
+                quiz__status='published', status='completed')
+        .values('student_id', 'quiz__course_id')
+        .annotate(n=Count('quiz_id', distinct=True))
+    )
+    for row in rows:
+        done[(row['student_id'], row['quiz__course_id'])] += row['n']
+
+    rows = (
+        AssignmentSubmission.objects
+        .filter(student_id__in=student_ids,
+                assignment__topic__subject__course_id__in=course_ids,
+                assignment__status='published')
+        .values('student_id', 'assignment__topic__subject__course_id')
+        .annotate(n=Count('assignment_id', distinct=True))
+    )
+    for row in rows:
+        done[(row['student_id'], row['assignment__topic__subject__course_id'])] += row['n']
+
+    rows = (
+        CodingSubmission.objects
+        .filter(student_id__in=student_ids,
+                problem__topic__subject__course_id__in=course_ids,
+                problem__status='published',
+                total_count__gt=0, passed_count=F('total_count'))
+        .values('student_id', 'problem__topic__subject__course_id')
+        .annotate(n=Count('problem_id', distinct=True))
+    )
+    for row in rows:
+        done[(row['student_id'], row['problem__topic__subject__course_id'])] += row['n']
+
+    return done
+
+
+def bulk_course_progress(enrollments):
+    """Completion percentages for many enrollments at once.
+
+    ``enrollments`` is any iterable of ``CourseEnrollment`` rows (already
+    filtered to the caller's tenant). Returns::
+
+        {student_id: [{'course_id', 'course_name', 'completed', 'total',
+                       'percent', 'status'}, ...]}
+
+    Courses with no published items report 0% with ``total = 0`` so the client
+    can distinguish "nothing to do yet" from "nothing done yet".
+    """
+    enrollments = list(enrollments)
+    if not enrollments:
+        return {}
+
+    student_ids = {e.student_id for e in enrollments}
+    course_ids = {e.course_id for e in enrollments}
+
+    totals = _totals_by_course(course_ids)
+    done = _completed_by_student_course(student_ids, course_ids)
+
+    result = defaultdict(list)
+    for enrollment in enrollments:
+        total = totals.get(enrollment.course_id, 0)
+        completed = min(done.get((enrollment.student_id, enrollment.course_id), 0), total)
+        result[enrollment.student_id].append({
+            'course_id': str(enrollment.course_id),
+            'course_name': enrollment.course.name,
+            'completed': completed,
+            'total': total,
+            'percent': round((completed / total) * 100) if total else 0,
+            'status': enrollment.status,
+        })
+
+    for rows in result.values():
+        rows.sort(key=lambda r: (-r['percent'], r['course_name']))
+    return result

--- a/backend/users/tests_admin_provisioning.py
+++ b/backend/users/tests_admin_provisioning.py
@@ -194,3 +194,97 @@ class AdminStudentProvisioningTests(APITestCase):
         )
         self.assertEqual(resp.status_code, 200, resp.data)
         self.assertEqual(CourseEnrollment.objects.filter(student=profile).count(), 0)
+
+
+@override_settings(EMAIL_BACKEND='django.core.mail.backends.locmem.EmailBackend')
+class RosterCourseProgressTests(APITestCase):
+    """The roster progress endpoint must be correct and query-bounded."""
+
+    def setUp(self):
+        from exams.models import Subject, Topic
+        from content.models import Content
+
+        self.tenant = Tenant.objects.create(name='Progress Academy')
+        self.admin = User.objects.create_user(
+            email='padmin@test.com', tenant=self.tenant, password='adminpass123',
+            first_name='P', role='admin',
+        )
+        self.course = Course.objects.create(
+            name='Python', code='PY', tenant=self.tenant, status='active',
+        )
+        subject = Subject.objects.create(course=self.course, name='Basics', tenant=self.tenant)
+        topic = Topic.objects.create(subject=subject, name='Vars', tenant=self.tenant)
+        self.contents = [
+            Content.objects.create(
+                title=f'Note {i}', subject=subject, topic=topic, tenant=self.tenant,
+                content_type='notes', status='published', slug=f'progress-note-{i}',
+            )
+            for i in range(4)
+        ]
+        self.client.force_authenticate(user=self.admin)
+        self.headers = {'HTTP_X_TENANT_ID': str(self.tenant.id)}
+
+    def _make_student(self, email):
+        user = User.objects.create_user(
+            email=email, tenant=self.tenant, password='pass12345', first_name='S',
+        )
+        profile = StudentProfile.objects.get(user=user)
+        CourseEnrollment.objects.create(
+            student=profile, course=self.course, status='approved',
+        )
+        return profile
+
+    def test_reports_percent_complete_per_course(self):
+        from content.models import ContentProgress
+
+        profile = self._make_student('p1@test.com')
+        for content in self.contents[:1]:
+            ContentProgress.objects.create(
+                student=profile, content=content, is_completed=True, tenant=self.tenant,
+            )
+
+        resp = self.client.get('/api/v1/auth/tenant-students/course-progress/', **self.headers)
+        self.assertEqual(resp.status_code, 200, resp.data)
+        row = next(r for r in resp.data['results'] if r['student_id'] == str(profile.id))
+        self.assertEqual(row['courses'][0]['total'], 4)
+        self.assertEqual(row['courses'][0]['completed'], 1)
+        self.assertEqual(row['courses'][0]['percent'], 25)
+
+    def test_query_count_does_not_grow_with_roster_size(self):
+        """The whole point of the bulk endpoint: cost stays flat as students are added."""
+        for i in range(2):
+            self._make_student(f'few{i}@test.com')
+        few = len(self._capture_queries())
+
+        for i in range(8):
+            self._make_student(f'many{i}@test.com')
+        many = len(self._capture_queries())
+
+        self.assertEqual(few, many)
+
+    def _capture_queries(self):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        with CaptureQueriesContext(connection) as ctx:
+            resp = self.client.get(
+                '/api/v1/auth/tenant-students/course-progress/', **self.headers)
+        self.assertEqual(resp.status_code, 200)
+        return ctx.captured_queries
+
+    def test_progress_endpoint_is_tenant_scoped(self):
+        other_tenant = Tenant.objects.create(name='Other')
+        outsider = User.objects.create_user(
+            email='out2@test.com', tenant=other_tenant, password='pass12345', first_name='O',
+        )
+        other_course = Course.objects.create(
+            name='Foreign', code='F2', tenant=other_tenant, status='active',
+        )
+        CourseEnrollment.objects.create(
+            student=StudentProfile.objects.get(user=outsider), course=other_course,
+            status='approved',
+        )
+        mine = self._make_student('mine@test.com')
+
+        resp = self.client.get('/api/v1/auth/tenant-students/course-progress/', **self.headers)
+        ids = {r['student_id'] for r in resp.data['results']}
+        self.assertEqual(ids, {str(mine.id)})

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -580,6 +580,31 @@ class TenantStudentViewSet(TenantAwareViewSet):
             payload['temporary_password'] = temp_password
         return Response(payload, status=status.HTTP_201_CREATED)
 
+    @action(detail=False, methods=['get'], url_path='course-progress')
+    def course_progress(self, request):
+        """Per-course completion for every student on the roster.
+
+        Loaded separately from the roster so the (heavier) progress aggregation
+        never delays the student list itself. Costs a fixed number of queries
+        regardless of how many students or courses are involved.
+        """
+        from certificates.bulk_progress import bulk_course_progress
+
+        tenant = request.tenant
+        enrollments = (
+            CourseEnrollment.objects
+            .filter(student__user__tenant=tenant, course__tenant=tenant)
+            .exclude(status='rejected')
+            .select_related('course')
+        )
+        progress = bulk_course_progress(enrollments)
+        return Response({
+            'results': [
+                {'student_id': str(student_id), 'courses': rows}
+                for student_id, rows in progress.items()
+            ],
+        })
+
     @action(detail=True, methods=['post'], url_path='assign-courses')
     def assign_courses(self, request, pk=None):
         """Enrol an existing student in one or more courses and notify them."""

--- a/frontend/exam-frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/exam-frontend/src/pages/AdminDashboard.jsx
@@ -134,6 +134,76 @@ const roleBadgeClass = (role) =>
             : 'bg-surface-100 text-surface-600 dark:bg-surface-800 dark:text-surface-300'
 
 /* ---------------------------------------------------------------------------
+ * Modal chrome
+ *
+ * No backdrop-blur: blurring the overlay forces the browser to repaint the
+ * entire page behind it, which makes these dialogs feel laggy on top of the
+ * long student table. A plain translucent scrim plus very short transitions
+ * gives the same visual separation and opens instantly. Mirrors the pattern
+ * already used by the course builder (components/admin/builderShared.jsx).
+ * ------------------------------------------------------------------------- */
+const MODAL_OVERLAY = 'fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60'
+const OVERLAY_MOTION = {
+    initial: { opacity: 0 },
+    animate: { opacity: 1 },
+    exit: { opacity: 0 },
+    transition: { duration: 0.12 },
+}
+const PANEL_MOTION = {
+    initial: { opacity: 0, scale: 0.97, y: 8 },
+    animate: { opacity: 1, scale: 1, y: 0 },
+    exit: { opacity: 0, scale: 0.97, y: 8 },
+    transition: { duration: 0.14, ease: 'easeOut' },
+}
+
+/** Overlay that closes on backdrop click and on Escape. */
+const ModalOverlay = ({ onClose, children }) => {
+    useEffect(() => {
+        const onKey = (e) => e.key === 'Escape' && onClose?.()
+        window.addEventListener('keydown', onKey)
+        return () => window.removeEventListener('keydown', onKey)
+    }, [onClose])
+
+    return (
+        <motion.div
+            {...OVERLAY_MOTION}
+            className={MODAL_OVERLAY}
+            onMouseDown={(e) => { if (e.target === e.currentTarget) onClose?.() }}
+        >
+            {children}
+        </motion.div>
+    )
+}
+
+/**
+ * Icon button with an instant CSS tooltip.
+ *
+ * The native `title` attribute only appears after a ~1s browser delay, which
+ * makes icon-only toolbars feel unlabelled; this shows the label on hover and
+ * on keyboard focus straight away.
+ */
+const IconAction = ({ label, onClick, danger = false, children }) => (
+    <div className="relative group">
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={label}
+            className={`p-2 rounded-lg transition-colors text-surface-400 ${danger
+                ? 'hover:text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-900/20'
+                : 'hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20'}`}
+        >
+            {children}
+        </button>
+        <span
+            role="tooltip"
+            className="pointer-events-none absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 z-20 whitespace-nowrap rounded-md bg-surface-900 dark:bg-surface-700 px-2 py-1 text-[11px] font-medium text-white opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-75"
+        >
+            {label}
+        </span>
+    </div>
+)
+
+/* ---------------------------------------------------------------------------
  * StatCard
  * ------------------------------------------------------------------------- */
 const TrendBadge = ({ change }) => {
@@ -281,11 +351,10 @@ const StudentEditModal = ({ student, onClose }) => {
     }
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60 backdrop-blur-sm">
+        <ModalOverlay onClose={onClose}>
             <motion.form
                 onSubmit={handleSubmit}
-                initial={{ opacity: 0, scale: 0.95, y: 20 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
+                {...PANEL_MOTION}
                 className="bg-white dark:bg-surface-800 rounded-3xl w-full max-w-4xl max-h-[92vh] overflow-hidden shadow-2xl border border-surface-100 dark:border-surface-700 flex flex-col"
             >
                 {/* Header */}
@@ -381,14 +450,14 @@ const StudentEditModal = ({ student, onClose }) => {
                     </button>
                 </div>
             </motion.form>
-        </div>
+        </ModalOverlay>
     )
 }
 
 /* ---------------------------------------------------------------------------
  * StudentDetailModal — read-only full profile
  * ------------------------------------------------------------------------- */
-const StudentDetailModal = ({ student, onClose, onEdit }) => {
+const StudentDetailModal = ({ student, onClose, onEdit, courseProgress = [] }) => {
     if (!student) return null
 
     const sections = [
@@ -443,10 +512,9 @@ const StudentDetailModal = ({ student, onClose, onEdit }) => {
     ]
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60 backdrop-blur-sm">
+        <ModalOverlay onClose={onClose}>
             <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 20 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
+                {...PANEL_MOTION}
                 className="bg-white dark:bg-surface-800 rounded-3xl w-full max-w-4xl max-h-[90vh] overflow-hidden shadow-2xl border border-surface-100 dark:border-surface-700 flex flex-col"
             >
                 <div className="p-5 sm:p-6 border-b dark:border-surface-700 flex items-center justify-between bg-surface-50/50 dark:bg-surface-900/20">
@@ -465,6 +533,24 @@ const StudentDetailModal = ({ student, onClose, onEdit }) => {
                 </div>
 
                 <div className="flex-1 overflow-y-auto p-5 sm:p-8 space-y-8 sm:space-y-10">
+                    {courseProgress.length > 0 && (
+                        <div className="space-y-4">
+                            <h3 className="text-xs font-black uppercase tracking-widest text-primary-600 dark:text-primary-400 flex items-center gap-2">
+                                <BookOpen className="w-4 h-4" />
+                                Course Completion
+                            </h3>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-4">
+                                {courseProgress.map((row) => (
+                                    <div key={row.course_id} className="space-y-1">
+                                        <CourseProgressBar row={row} />
+                                        <p className="text-[11px] text-surface-400">
+                                            {row.total ? `${row.completed} of ${row.total} items completed` : 'No published content yet'}
+                                        </p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-8 sm:gap-10">
                         {sections.map((section, idx) => (
                             <div key={idx} className="space-y-4">
@@ -494,7 +580,7 @@ const StudentDetailModal = ({ student, onClose, onEdit }) => {
                     </button>
                 </div>
             </motion.div>
-        </div>
+        </ModalOverlay>
     )
 }
 
@@ -581,6 +667,7 @@ const CreateStudentModal = ({ courses, onClose }) => {
         mutationFn: (payload) => tenantAdminService.createStudent(payload),
         onSuccess: (data) => {
             queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            queryClient.invalidateQueries({ queryKey: ['tenantRosterProgress'] })
             if (data?.temporary_password) {
                 // Email failed — keep the modal open so the admin can copy the password.
                 setCredentials({ email: form.email.trim(), password: data.temporary_password })
@@ -626,11 +713,10 @@ const CreateStudentModal = ({ courses, onClose }) => {
     }
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60 backdrop-blur-sm">
+        <ModalOverlay onClose={onClose}>
             <motion.form
                 onSubmit={handleSubmit}
-                initial={{ opacity: 0, scale: 0.95, y: 20 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
+                {...PANEL_MOTION}
                 className="bg-white dark:bg-surface-800 rounded-3xl w-full max-w-3xl max-h-[92vh] overflow-hidden shadow-2xl border border-surface-100 dark:border-surface-700 flex flex-col"
             >
                 <div className="p-5 sm:p-6 border-b dark:border-surface-700 flex items-center justify-between bg-surface-50/50 dark:bg-surface-900/20">
@@ -731,7 +817,7 @@ const CreateStudentModal = ({ courses, onClose }) => {
                     )}
                 </div>
             </motion.form>
-        </div>
+        </ModalOverlay>
     )
 }
 
@@ -753,6 +839,7 @@ const AssignCoursesModal = ({ student, courses, onClose }) => {
         mutationFn: () => tenantAdminService.assignCourses(student.id, courseIds, sendEmail),
         onSuccess: (data) => {
             queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            queryClient.invalidateQueries({ queryKey: ['tenantRosterProgress'] })
             const count = data?.assigned?.length || 0
             toast.success(count
                 ? `Enrolled in ${count} course${count === 1 ? '' : 's'}${sendEmail ? ' — student notified' : ''}`
@@ -766,6 +853,7 @@ const AssignCoursesModal = ({ student, courses, onClose }) => {
         mutationFn: (courseId) => tenantAdminService.removeCourse(student.id, courseId),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            queryClient.invalidateQueries({ queryKey: ['tenantRosterProgress'] })
             toast.success('Enrollment removed')
             onClose()
         },
@@ -773,10 +861,9 @@ const AssignCoursesModal = ({ student, courses, onClose }) => {
     })
 
     return (
-        <div className="fixed inset-0 z-[100] flex items-center justify-center p-3 sm:p-4 bg-surface-900/60 backdrop-blur-sm">
+        <ModalOverlay onClose={onClose}>
             <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 20 }}
-                animate={{ opacity: 1, scale: 1, y: 0 }}
+                {...PANEL_MOTION}
                 className="bg-white dark:bg-surface-800 rounded-3xl w-full max-w-xl max-h-[92vh] overflow-hidden shadow-2xl border border-surface-100 dark:border-surface-700 flex flex-col"
             >
                 <div className="p-5 sm:p-6 border-b dark:border-surface-700 flex items-center justify-between bg-surface-50/50 dark:bg-surface-900/20">
@@ -852,6 +939,82 @@ const AssignCoursesModal = ({ student, courses, onClose }) => {
                     </button>
                 </div>
             </motion.div>
+        </ModalOverlay>
+    )
+}
+
+/* ---------------------------------------------------------------------------
+ * Course completion
+ * ------------------------------------------------------------------------- */
+const progressTone = (percent) =>
+    percent >= 100 ? 'bg-emerald-500'
+        : percent >= 60 ? 'bg-primary-500'
+            : percent >= 25 ? 'bg-amber-500'
+                : 'bg-surface-400'
+
+const CourseProgressBar = ({ row }) => (
+    <div className="space-y-1">
+        <div className="flex items-baseline justify-between gap-3">
+            <span className="truncate text-xs font-medium text-surface-700 dark:text-surface-200" title={row.course_name}>
+                {row.course_name}
+            </span>
+            <span className="shrink-0 text-[11px] font-bold tabular-nums text-surface-500">
+                {row.total ? `${row.percent}%` : 'No content'}
+            </span>
+        </div>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface-100 dark:bg-surface-700">
+            <div className={`h-full rounded-full ${progressTone(row.percent)}`} style={{ width: `${row.percent}%` }} />
+        </div>
+    </div>
+)
+
+/**
+ * Completion summary for one student.
+ *
+ * A student can sit in many batches, so only the top few courses get a bar and
+ * the rest collapse into a "+N more" button that opens the full list — the row
+ * height stays constant no matter how many enrollments exist.
+ */
+const COURSE_PREVIEW_COUNT = 2
+
+const CourseCompletionCell = ({ rows, loading, onExpand }) => {
+    if (loading) {
+        return (
+            <div className="space-y-2">
+                {[0, 1].map((i) => (
+                    <div key={i} className="h-1.5 w-32 animate-pulse rounded-full bg-surface-100 dark:bg-surface-700" />
+                ))}
+            </div>
+        )
+    }
+    if (!rows || rows.length === 0) {
+        return <span className="text-xs text-surface-400 italic">Not enrolled</span>
+    }
+
+    const done = rows.filter((r) => r.total > 0 && r.percent >= 100).length
+    const hidden = rows.length - COURSE_PREVIEW_COUNT
+
+    return (
+        <div className="min-w-[11rem] max-w-[16rem] space-y-2">
+            {rows.slice(0, COURSE_PREVIEW_COUNT).map((row) => (
+                <CourseProgressBar key={row.course_id} row={row} />
+            ))}
+            <div className="flex items-center gap-2 text-[11px] text-surface-500">
+                {hidden > 0 && (
+                    <button
+                        type="button"
+                        onClick={onExpand}
+                        className="font-semibold text-primary-600 hover:underline"
+                    >
+                        +{hidden} more
+                    </button>
+                )}
+                {done > 0 && (
+                    <span className="inline-flex items-center gap-1 font-semibold text-emerald-600">
+                        <CheckCircle2 className="w-3 h-3" /> {done}/{rows.length} complete
+                    </span>
+                )}
+            </div>
         </div>
     )
 }
@@ -861,21 +1024,11 @@ const AssignCoursesModal = ({ student, courses, onClose }) => {
  * ------------------------------------------------------------------------- */
 const RowActions = ({ student, onView, onEdit, onReset, onCourses, onResetPassword }) => (
     <div className="flex items-center gap-1">
-        <button onClick={() => onCourses(student)} className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all" title="Manage courses">
-            <BookOpen className="w-4 h-4" />
-        </button>
-        <button onClick={() => onEdit(student)} className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all" title="Edit record">
-            <Pencil className="w-4 h-4" />
-        </button>
-        <button onClick={() => onResetPassword(student)} className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all" title="Email a new password">
-            <KeyRound className="w-4 h-4" />
-        </button>
-        <button onClick={() => onView(student)} className="p-2 text-surface-400 hover:text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-900/20 rounded-lg transition-all" title="View full profile">
-            <ExternalLink className="w-4 h-4" />
-        </button>
-        <button onClick={() => onReset(student)} className="p-2 text-surface-400 hover:text-rose-500 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg transition-all" title="Reset progress">
-            <RotateCcw className="w-4 h-4" />
-        </button>
+        <IconAction label="Manage courses" onClick={() => onCourses(student)}><BookOpen className="w-4 h-4" /></IconAction>
+        <IconAction label="Edit record" onClick={() => onEdit(student)}><Pencil className="w-4 h-4" /></IconAction>
+        <IconAction label="Email a new password" onClick={() => onResetPassword(student)}><KeyRound className="w-4 h-4" /></IconAction>
+        <IconAction label="View full profile" onClick={() => onView(student)}><ExternalLink className="w-4 h-4" /></IconAction>
+        <IconAction label="Reset progress" danger onClick={() => onReset(student)}><RotateCcw className="w-4 h-4" /></IconAction>
     </div>
 )
 
@@ -899,6 +1052,29 @@ const StudentManagement = () => {
         queryFn: () => tenantAdminService.getStudents(),
     })
 
+    // Loaded on its own key so the roster paints immediately and completion
+    // bars fill in a moment later instead of blocking the whole table.
+    const { data: progressData, isLoading: progressLoading } = useQuery({
+        queryKey: ['tenantRosterProgress'],
+        queryFn: () => tenantAdminService.getRosterCourseProgress(),
+        staleTime: 60_000,
+    })
+
+    const progressByStudent = useMemo(() => {
+        const map = new Map()
+        for (const row of progressData?.results || []) {
+            map.set(String(row.student_id), row.courses || [])
+        }
+        return map
+    }, [progressData])
+
+    const averagePercent = (student) => {
+        const rows = progressByStudent.get(String(student.id)) || []
+        const graded = rows.filter((r) => r.total > 0)
+        if (!graded.length) return -1
+        return graded.reduce((sum, r) => sum + r.percent, 0) / graded.length
+    }
+
     const { data: examsData } = useQuery({
         queryKey: ['adminExamOptions'],
         queryFn: () => courseService.getAvailableCoursesForEnrollment(),
@@ -909,6 +1085,7 @@ const StudentManagement = () => {
         mutationFn: (id) => tenantAdminService.resetStudentProgress(id),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['tenantStudents'] })
+            queryClient.invalidateQueries({ queryKey: ['tenantRosterProgress'] })
             toast.success('Student progress reset')
         },
         onError: () => toast.error('Failed to reset progress'),
@@ -963,12 +1140,12 @@ const StudentManagement = () => {
 
         const sorted = [...result].sort((a, b) => {
             switch (sortBy) {
-                case 'xp':
-                    return (b.total_xp || 0) - (a.total_xp || 0)
-                case 'accuracy':
-                    return (b.overall_accuracy || 0) - (a.overall_accuracy || 0)
-                case 'level':
-                    return (b.current_level || 0) - (a.current_level || 0)
+                case 'completion_desc':
+                    return averagePercent(b) - averagePercent(a)
+                case 'completion_asc':
+                    return averagePercent(a) - averagePercent(b)
+                case 'courses':
+                    return (b.enrolled_course_ids || []).length - (a.enrolled_course_ids || []).length
                 case 'email':
                     return a.user.email.localeCompare(b.user.email)
                 default:
@@ -976,7 +1153,7 @@ const StudentManagement = () => {
             }
         })
         return sorted
-    }, [studentList, searchTerm, filterRole, filterStatus, filterExam, sortBy])
+    }, [studentList, searchTerm, filterRole, filterStatus, filterExam, sortBy, progressByStudent])
 
     const handleReset = (student) => {
         if (window.confirm(`Reset ALL progress for ${student.user.full_name}? This cannot be undone.`)) {
@@ -993,6 +1170,7 @@ const StudentManagement = () => {
             'Full Name', 'Email', 'Phone', 'Role', 'Status', 'Enrolled Courses', 'Target Year',
             'Grade', 'School', 'Coaching', 'Board', 'Medium', 'City', 'State',
             'Level', 'Total XP', 'Accuracy %', 'Questions Attempted', 'Correct Answers', 'Study Minutes',
+            'Course Completion',
         ]
         const escape = (v) => `"${String(v ?? '').replace(/"/g, '""')}"`
         const rows = filteredStudents.map((s) => [
@@ -1002,6 +1180,8 @@ const StudentManagement = () => {
             s.target_year, s.grade, s.school, s.coaching, s.board, s.medium,
             s.city, s.state, s.current_level, s.total_xp, s.overall_accuracy,
             s.total_questions_attempted, s.total_correct_answers, s.total_study_time_minutes,
+            (progressByStudent.get(String(s.id)) || [])
+                .map((r) => `${r.course_name}: ${r.total ? `${r.percent}%` : 'no content'}`).join('; '),
         ].map(escape).join(','))
         const csv = [headers.map(escape).join(','), ...rows].join('\n')
         const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
@@ -1080,9 +1260,9 @@ const StudentManagement = () => {
                         <select className="input py-2.5" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
                             <option value="name">Name (A-Z)</option>
                             <option value="email">Email (A-Z)</option>
-                            <option value="xp">XP (High-Low)</option>
-                            <option value="accuracy">Accuracy (High-Low)</option>
-                            <option value="level">Level (High-Low)</option>
+                            <option value="completion_desc">Completion (High-Low)</option>
+                            <option value="completion_asc">Completion (Low-High)</option>
+                            <option value="courses">Courses Enrolled</option>
                         </select>
                     </div>
                 </div>
@@ -1105,9 +1285,9 @@ const StudentManagement = () => {
                         <thead className="bg-surface-50 dark:bg-surface-800/50 text-xs font-semibold text-surface-500 uppercase">
                             <tr>
                                 <th className="px-6 py-4">Student</th>
-                                <th className="px-6 py-4">Course</th>
+                                <th className="px-6 py-4">Courses</th>
                                 <th className="px-6 py-4">Status</th>
-                                <th className="px-6 py-4">Performance</th>
+                                <th className="px-6 py-4">Course Completion</th>
                                 <th className="px-6 py-4 text-right">Actions</th>
                             </tr>
                         </thead>
@@ -1154,10 +1334,12 @@ const StudentManagement = () => {
                                             {!student.user.is_suspended ? <><Shield className="w-3.5 h-3.5" /> Active</> : <><ShieldOff className="w-3.5 h-3.5" /> Suspended</>}
                                         </button>
                                     </td>
-                                    <td className="px-6 py-4 text-xs space-y-1 whitespace-nowrap">
-                                        <div className="flex justify-between gap-4"><span className="text-surface-500">Lvl</span><span className="font-semibold text-surface-900 dark:text-white">{student.current_level}</span></div>
-                                        <div className="flex justify-between gap-4"><span className="text-surface-500">XP</span><span className="font-semibold text-surface-900 dark:text-white">{student.total_xp}</span></div>
-                                        <div className="flex justify-between gap-4"><span className="text-surface-500">Acc</span><span className="font-semibold text-surface-900 dark:text-white">{student.overall_accuracy}%</span></div>
+                                    <td className="px-6 py-4">
+                                        <CourseCompletionCell
+                                            rows={progressByStudent.get(String(student.id))}
+                                            loading={progressLoading}
+                                            onExpand={() => setSelectedStudent(student)}
+                                        />
                                     </td>
                                     <td className="px-6 py-4">
                                         <div className="flex justify-end">
@@ -1191,10 +1373,13 @@ const StudentManagement = () => {
                             </div>
                             <span className={`px-2 py-0.5 rounded-full text-[10px] uppercase font-bold shrink-0 ${roleBadgeClass(student.user.role)}`}>{student.user.role}</span>
                         </div>
-                        <div className="grid grid-cols-3 gap-2 text-center text-xs bg-surface-50 dark:bg-surface-800/50 rounded-xl p-2.5">
-                            <div><div className="font-bold text-surface-900 dark:text-white">{student.current_level}</div><div className="text-surface-400">Level</div></div>
-                            <div><div className="font-bold text-surface-900 dark:text-white">{student.total_xp}</div><div className="text-surface-400">XP</div></div>
-                            <div><div className="font-bold text-surface-900 dark:text-white">{student.overall_accuracy}%</div><div className="text-surface-400">Accuracy</div></div>
+                        <div className="bg-surface-50 dark:bg-surface-800/50 rounded-xl p-3">
+                            <div className="text-[10px] font-bold uppercase tracking-wider text-surface-400 mb-2">Course Completion</div>
+                            <CourseCompletionCell
+                                rows={progressByStudent.get(String(student.id))}
+                                loading={progressLoading}
+                                onExpand={() => setSelectedStudent(student)}
+                            />
                         </div>
                         <div className="flex items-center justify-between">
                             <button
@@ -1220,6 +1405,7 @@ const StudentManagement = () => {
                         student={selectedStudent}
                         onClose={() => setSelectedStudent(null)}
                         onEdit={(s) => { setSelectedStudent(null); setEditingStudent(s) }}
+                        courseProgress={progressByStudent.get(String(selectedStudent.id)) || []}
                     />
                 )}
                 {editingStudent && (

--- a/frontend/exam-frontend/src/services/tenantAdminService.js
+++ b/frontend/exam-frontend/src/services/tenantAdminService.js
@@ -36,6 +36,13 @@ export const tenantAdminService = {
         return response.data
     },
 
+    getRosterCourseProgress: async () => {
+        // Course completion for the whole roster in one bulk call — fetched
+        // separately from getStudents so the table paints before it lands.
+        const response = await api.get('/auth/tenant-students/course-progress/')
+        return response.data
+    },
+
     resetStudentProgress: async (studentId) => {
         const response = await api.post(`/auth/tenant-students/${studentId}/reset_progress/`)
         return response.data


### PR DESCRIPTION
Follow-up fixes to the admin student roster shipped in #184.

## Course completion replaces the XP column

The Performance column reported level, XP and accuracy, which says little about whether a student is actually working through the material they were enrolled in. It now shows completion per course.

Progress is computed in bulk. `certificates.compute_course_progress` costs roughly ten queries per (student, course) pair — fine for a single certificate check, unusable for a roster where students sit in several batches each. The new `certificates/bulk_progress.py` answers the same question for the whole tenant in eight grouped aggregates: four for the per-course denominators, four for the per-(student, course) numerators. Cost no longer grows with roster size, and a test asserts the query count is identical for 2 students and 10.

The item definitions mirror `compute_course_progress` exactly — including counting assignments and coding problems through `topic__subject__course` rather than their own course FK — so the percentage an admin sees matches the one that unlocks the student's certificate.

`GET /api/v1/auth/tenant-students/course-progress/` is fetched on its own react-query key, so the table paints before completion data arrives. Only the top two courses get a bar; the rest collapse behind "+N more" which opens the full list in the detail modal. Row height therefore stays constant however many enrollments a student accumulates. Sort options swap XP/accuracy/level for completion high/low and courses enrolled, and CSV export gains a completion column.

## Modal lag

The four student modals used `backdrop-blur-sm`, which forces the browser to repaint the entire page behind the overlay and made them feel sluggish on top of the long student table. Dropped it in favour of the plain scrim and short transitions the course builder already uses (`components/admin/builderShared.jsx`), extracted into a shared `ModalOverlay` that also closes on backdrop click and on Escape.

## Late tooltips

Row action icons relied on the native `title` attribute, which browsers only reveal after about a second, leaving the icon toolbar effectively unlabelled. They now use an instant CSS tooltip that also appears on keyboard focus.

## Verification

- `manage.py test users.tests_admin_provisioning` — 15/15 pass (3 new: percent maths, tenant isolation, flat query count)
- `manage.py check` clean, no new migrations
- `npm run build` succeeds

No schema changes, so this is deploy-safe without a migration step.